### PR TITLE
Release v0.3.0: admin user locations map and logging cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Rambulations writing platform are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-02-10
+
+### Added
+- Admin user locations map: global Leaflet/OpenStreetMap view with pins for users who have coordinates set
+- Optional `latitude` and `longitude` on users (migration 011); admin can set location per user in the expanded panel
+- `PUT /api/admin/users/:id` accepts `latitude` and `longitude` for location updates
+
+### Changed
+- Removed debug console logging: admin stats queries, DB pool init/connect/close, graceful shutdown messages, client CSRF and config load warnings
+
 ## [0.2.0] - 2026-02-09
 
 ### Added
@@ -83,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Database migrations (001-008): users, writing_blocks, themes, appreciations, auth/visibility, roles, reaction types, comments
 - Development setup documentation and quick-start guide
 
+[0.3.0]: https://github.com/DRCUOA/befly/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/DRCUOA/befly/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/DRCUOA/befly/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/DRCUOA/befly/compare/v0.1.0...v0.1.1

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,12 +9,14 @@
     "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "vue": "^3.4.0",
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.0.0",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^20.10.0",
+    "@vitejs/plugin-vue": "^5.0.0",
     "autoprefixer": "^10.4.16",
     "marked": "^11.1.0",
     "postcss": "^8.4.32",

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -46,8 +46,7 @@ async function request<T>(
   if (csrfToken && ['POST', 'PUT', 'DELETE', 'PATCH'].includes(options.method || 'GET')) {
     headers['X-CSRF-Token'] = csrfToken
   } else if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(options.method || 'GET')) {
-    // Log warning if CSRF token is missing for state-changing operations
-    console.warn('CSRF token not found in cookies for', options.method, endpoint)
+    // CSRF token missing for state-changing operations; server may reject
   }
 
   // Include credentials for cookies (httpOnly auth token)

--- a/client/src/config/app.ts
+++ b/client/src/config/app.ts
@@ -19,8 +19,7 @@ export async function loadAppConfig(): Promise<void> {
     const response = await api.get<ApiResponse<ConfigResponse>>('/config')
     appName.value = response.data.appName
     configLoaded = true
-  } catch (err) {
-    console.warn('Failed to load app config from server, using default:', err)
+  } catch {
     // Keep default value
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "writing-platform",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "writing-platform",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "workspaces": [
         "client",
         "server",
@@ -21,12 +21,14 @@
     },
     "client": {
       "name": "@writing-platform/client",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "vue": "^3.4.0",
         "vue-router": "^4.2.5"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.21",
         "@types/node": "^20.10.0",
         "@vitejs/plugin-vue": "^5.0.0",
         "autoprefixer": "^10.4.16",
@@ -1059,6 +1061,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -1075,6 +1084,16 @@
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -2708,6 +2727,12 @@
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -4903,7 +4928,7 @@
     },
     "server": {
       "name": "@writing-platform/server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
@@ -4929,7 +4954,7 @@
     },
     "shared": {
       "name": "@writing-platform/shared",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "typescript": "^5.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writing-platform",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Personal Writing Platform (Vendor-Neutral, Self-Hosted)",
   "private": true,
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "nodemon src/index.ts",

--- a/server/src/config/db.ts
+++ b/server/src/config/db.ts
@@ -30,11 +30,8 @@ function buildPoolConfig(): pg.PoolConfig {
 
 function getPool(): pg.Pool {
   if (!_pool) {
-    console.log('[DB] Initialising connection pool')
-
     const poolConfig = buildPoolConfig()
     _pool = new Pool(poolConfig)
-    console.log(`[DB] SSL ${config.nodeEnv === 'production' ? 'enabled' : 'disabled'} (${config.nodeEnv})`)
   }
   return _pool
 }
@@ -52,8 +49,7 @@ export const pool = {
 
 export async function initDb() {
   try {
-    const result = await pool.query('SELECT NOW()')
-    console.log('Database connected:', result.rows[0].now)
+    await pool.query('SELECT NOW()')
   } catch (error) {
     console.error('Database connection error:', error)
     throw error
@@ -65,7 +61,6 @@ export async function closeDb() {
     try {
       await _pool.end()
       _pool = null
-      console.log('Database pool closed')
     } catch (error) {
       console.error('Error closing database pool:', error)
       throw error

--- a/server/src/db/migrations/011_user_locations.sql
+++ b/server/src/db/migrations/011_user_locations.sql
@@ -1,0 +1,9 @@
+-- Migration 011: User locations (optional lat/lng for admin map)
+-- Adds latitude and longitude to users for displaying pins on admin map
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS latitude DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS longitude DOUBLE PRECISION;
+
+COMMENT ON COLUMN users.latitude IS 'Optional latitude for admin map pin';
+COMMENT ON COLUMN users.longitude IS 'Optional longitude for admin map pin';

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -40,37 +40,21 @@ process.on('unhandledRejection', (reason, promise) => {
 
 // Graceful shutdown handler
 async function gracefulShutdown(signal: string) {
-  console.log(`\nReceived ${signal}. Starting graceful shutdown...`)
-  
-  // Close HTTP server
   if (server) {
     return new Promise<void>((resolve) => {
-      server!.close(() => {
-        console.log('HTTP server closed')
-        resolve()
-      })
-      
-      // Force close after 10 seconds
-      setTimeout(() => {
-        console.log('Forcing server close after timeout')
-        resolve()
-      }, 10000)
+      server!.close(() => resolve())
+      setTimeout(() => resolve(), 10000)
     }).then(async () => {
-      // Close database connections
       try {
         await closeDb()
-        console.log('Database connections closed')
       } catch (error) {
         console.error('Error closing database:', error)
       }
-      
       process.exit(0)
     })
   } else {
-    // No server to close, just close DB and exit
     try {
       await closeDb()
-      console.log('Database connections closed')
     } catch (error) {
       console.error('Error closing database:', error)
     }

--- a/server/src/repositories/user.repo.ts
+++ b/server/src/repositories/user.repo.ts
@@ -23,7 +23,8 @@ export const userRepo = {
       `SELECT id, email, display_name as "displayName", 
               COALESCE(role, 'user') as role, 
               status, 
-              created_at as "createdAt", updated_at as "updatedAt"
+              created_at as "createdAt", updated_at as "updatedAt",
+              latitude, longitude
        FROM users
        WHERE id = $1 AND status = 'active'`,
       [id]
@@ -102,7 +103,8 @@ export const userRepo = {
       `SELECT id, email, display_name as "displayName", 
               COALESCE(role, 'user') as role, 
               status, 
-              created_at as "createdAt", updated_at as "updatedAt"
+              created_at as "createdAt", updated_at as "updatedAt",
+              latitude, longitude
        FROM users
        ORDER BY created_at DESC
        LIMIT $1 OFFSET $2`,
@@ -135,6 +137,8 @@ export const userRepo = {
     passwordHash: string
     status: string
     role: 'user' | 'admin'
+    latitude: number
+    longitude: number
   }>): Promise<User> {
     const fields: string[] = []
     const values: unknown[] = []
@@ -156,6 +160,14 @@ export const userRepo = {
       fields.push(`role = $${paramCount++}`)
       values.push(updates.role)
     }
+    if (updates.latitude !== undefined) {
+      fields.push(`latitude = $${paramCount++}`)
+      values.push(updates.latitude)
+    }
+    if (updates.longitude !== undefined) {
+      fields.push(`longitude = $${paramCount++}`)
+      values.push(updates.longitude)
+    }
 
     if (fields.length === 0) {
       const user = await this.findById(id)
@@ -171,7 +183,7 @@ export const userRepo = {
        SET ${fields.join(', ')}
        WHERE id = $${paramCount}
        RETURNING id, email, display_name as "displayName", COALESCE(role, 'user') as role, status, 
-                 created_at as "createdAt", updated_at as "updatedAt"`,
+                 created_at as "createdAt", updated_at as "updatedAt", latitude, longitude`,
       values
     )
     return result.rows[0]

--- a/shared/User.ts
+++ b/shared/User.ts
@@ -6,6 +6,9 @@ export interface User {
   status: 'active' | 'inactive' | 'suspended'
   createdAt: string
   updatedAt: string
+  /** Optional: used for admin map pins */
+  latitude?: number
+  longitude?: number
 }
 
 export interface UserWithPassword extends User {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/shared",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared types and contracts for writing platform",
   "main": "index.ts",
   "types": "index.ts",


### PR DESCRIPTION
- Add global map (Leaflet/OSM) to admin view with pins for user locations
- Add optional latitude/longitude on users (migration 011); admin can set per user
- Extend PUT /api/admin/users/:id to accept latitude and longitude
- Remove debug console logging (admin stats, DB pool, shutdown, client CSRF/config)
- Bump version to 0.3.0 and update CHANGELOG