### PR TITLE
fix(client): align Admin "Try again" button handler with DOM click type

### DIFF
--- a/client/src/pages/Admin.vue
+++ b/client/src/pages/Admin.vue
@@ -58,7 +58,7 @@
         <!-- Error State -->
         <div v-else-if="error" class="bg-red-50 border border-red-200 rounded-md p-6 mb-6">
           <p class="text-red-800">{{ error }}</p>
-          <button @click="loadUsers" class="mt-3 text-sm text-red-600 hover:text-red-800 underline">
+          <button @click="() => loadUsers()" class="mt-3 text-sm text-red-600 hover:text-red-800 underline">
             Try again
           </button>
         </div>


### PR DESCRIPTION
Diagnostics:
- vue-tsc failed in client build: TS2345 in Admin.vue:61
- Button used @click="loadUsers"; Vue passes PointerEvent as first argument
- loadUsers is (silent?: boolean) => Promise<void>, so handler type was (silent?: boolean) => Promise<void> vs expected (payload: PointerEvent) => void
- Types of property 'onClick' incompatible: PointerEvent not assignable to boolean

Fix proposed:
- Wrapping as @click="() => loadUsers()" supplies a no-arg handler that matches ButtonHTMLAttributes.onClick and still calls loadUsers() with default silent=false for the error-state retry, so loading/error UI behaves correctly.