### PR TITLE
feat(cni-06): typography suggestions on blur/save, bump to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Rambulations writing platform are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-02-12
+
+### Added
+- Typography suggestions (cni-06): suggest-only autocorrection on blur and before save
+- Typography rule engine (`client/src/utils/typography-suggestions.ts`): smart quotes, en/em dashes, ellipsis
+- Markdown-aware rules: skip inline code, code blocks, and URLs to avoid corrupting syntax
+- Suggestion modal on Write page before publish: Accept/Dismiss per suggestion, Accept all, Continue without changes
+- Blur hint: "X typography suggestions — review before publishing" when body textarea blurs
+- Draft atomic cni-07: typography rules management (admin CRUD, dedicated module) — spec only, not implemented
+
+### Changed
+- EPIC_PROGRESS.md: Phase 3 in progress; cni-06 complete; cni-07 drafted
+- Version bump 0.3.2 → 0.3.3 (build number in footer)
+
 ## [0.3.2] - 2026-02-11
 
 ### Added
@@ -112,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Database migrations (001-008): users, writing_blocks, themes, appreciations, auth/visibility, roles, reaction types, comments
 - Development setup documentation and quick-start guide
 
+[0.3.3]: https://github.com/DRCUOA/befly/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/DRCUOA/befly/compare/v0.3.1...v0.3.2
 [0.3.0]: https://github.com/DRCUOA/befly/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/DRCUOA/befly/compare/v0.1.2...v0.2.0

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/client",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/config/version.ts
+++ b/client/src/config/version.ts
@@ -1,3 +1,3 @@
 // Version is injected at build time via Vite
 // This file is replaced during build with the actual version from package.json
-export const APP_VERSION = '0.3.2'
+export const APP_VERSION = '0.3.3'

--- a/client/src/utils/typography-suggestions.ts
+++ b/client/src/utils/typography-suggestions.ts
@@ -1,0 +1,204 @@
+/**
+ * Typography suggestion engine — Option A (suggest only, no programmatic apply)
+ *
+ * Detects typography issues in markdown-aware manner. Does not mutate text;
+ * returns suggestions for user to accept or dismiss.
+ *
+ * Rules: smart quotes, en/em dashes, ellipsis.
+ * Skips: inline code, code blocks, URLs to avoid corrupting markdown.
+ *
+ * Rule format (extensible):
+ *   TypographyRule = { id, description, pattern: RegExp, replace: (match, ...groups) => string | null }
+ *   - id: unique rule identifier
+ *   - description: shown in UI
+ *   - pattern: regex with 'g' flag; matches are skipped if in excluded ranges (code, URLs)
+ *   - replace: return replacement or null to skip. Use groups for capture groups.
+ *
+ * @see documentation/EPICS/editorLayer/Atomics/cni-06-autocorrection-option-a.json
+ */
+
+export interface TypographySuggestion {
+  /** Start index in text */
+  start: number
+  /** End index (exclusive) in text */
+  end: number
+  /** Original text slice */
+  original: string
+  /** Suggested replacement */
+  replacement: string
+  /** Human-readable description */
+  description: string
+  /** Rule identifier for extensibility */
+  ruleId: string
+}
+
+/** Rule definition for extensible plugin-style architecture */
+export interface TypographyRule {
+  id: string
+  description: string
+  /** Regex to find matches. Use capture groups if needed. */
+  pattern: RegExp
+  /** Return replacement for a match, or null to skip */
+  replace: (match: string, ...groups: string[]) => string | null
+}
+
+/**
+ * Ranges that should not be modified (code, URLs).
+ * Returns array of [start, end] pairs (exclusive end).
+ */
+function getExcludedRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = []
+  let i = 0
+
+  while (i < text.length) {
+    // Inline code: `...`
+    if (text[i] === '`') {
+      const start = i
+      i++
+      // Triple backtick = code block
+      if (text.slice(i, i + 2) === '``') {
+        i += 2
+        while (i < text.length) {
+          const idx = text.indexOf('```', i)
+          if (idx === -1) {
+            ranges.push([start, text.length])
+            i = text.length
+            break
+          }
+          ranges.push([start, idx + 3])
+          i = idx + 3
+          break
+        }
+      } else {
+        const end = text.indexOf('`', i)
+        if (end === -1) break
+        ranges.push([start, end + 1])
+        i = end + 1
+      }
+      continue
+    }
+
+    // URL in [text](url) — exclude the (url) part
+    if (text[i] === ']' && text[i + 1] === '(') {
+      const urlStart = i + 1
+      const urlEnd = text.indexOf(')', urlStart)
+      if (urlEnd !== -1) {
+        ranges.push([urlStart, urlEnd + 1])
+        i = urlEnd + 1
+        continue
+      }
+    }
+
+    i++
+  }
+
+  return ranges
+}
+
+/** True if [index, end) overlaps any excluded range (don't corrupt code/URLs) */
+function overlapsExcludedRange(index: number, end: number, excluded: Array<[number, number]>): boolean {
+  return excluded.some(([s, e]) => index < e && end > s)
+}
+
+/** Default typography rules: smart quotes, en/em dashes, ellipsis. Order matters (em before en). */
+const ACTIVE_RULES: TypographyRule[] = [
+  {
+    id: 'ellipsis',
+    description: 'Use ellipsis character',
+    pattern: /\.{3}/g,
+    replace: () => '…'
+  },
+  {
+    id: 'em_dash',
+    description: 'Use em dash',
+    pattern: /---/g,
+    replace: () => '—'
+  },
+  {
+    id: 'en_dash',
+    description: 'Use en dash',
+    pattern: /--/g,
+    replace: () => '–'
+  },
+  {
+    id: 'smart_quotes_double',
+    description: 'Use smart double quotes',
+    pattern: /"(.*?)"/g,
+    replace: (_, content) => `"${content}"`
+  },
+  {
+    id: 'smart_quotes_single',
+    description: 'Use smart single quotes',
+    pattern: /'(.*?)'/g,
+    replace: (_, content) => `'${content}'`
+  }
+]
+
+/**
+ * Scan text for typography suggestions. Markdown-aware (skips code, URLs).
+ */
+export function scanTypography(text: string, rules: TypographyRule[] = ACTIVE_RULES): TypographySuggestion[] {
+  const suggestions: TypographySuggestion[] = []
+  const excluded = getExcludedRanges(text)
+
+  for (const rule of rules) {
+    const regex = new RegExp(rule.pattern.source, rule.pattern.flags)
+    let match: RegExpExecArray | null
+
+    while ((match = regex.exec(text)) !== null) {
+      const start = match.index
+      const end = start + match[0].length
+      const original = match[0]
+
+      if (overlapsExcludedRange(start, end, excluded)) continue
+
+      const replacement = rule.replace(original, ...match.slice(1))
+      if (replacement === null || replacement === original) continue
+
+      suggestions.push({
+        start,
+        end,
+        original,
+        replacement,
+        description: rule.description,
+        ruleId: rule.id
+      })
+    }
+  }
+
+  // Deduplicate overlapping suggestions (e.g. same span suggested by multiple rules)
+  return deduplicateSuggestions(suggestions)
+}
+
+function deduplicateSuggestions(suggestions: TypographySuggestion[]): TypographySuggestion[] {
+  const result: TypographySuggestion[] = []
+  for (const s of suggestions) {
+    const overlaps = result.some(
+      r => (s.start >= r.start && s.start < r.end) || (s.end > r.start && s.end <= r.end) || (s.start <= r.start && s.end >= r.end)
+    )
+    if (!overlaps) result.push(s)
+  }
+  return result.sort((a, b) => a.start - b.start)
+}
+
+/**
+ * Apply a single suggestion to text. Returns new string.
+ * Does not mutate; for use when user accepts a suggestion.
+ */
+export function applySuggestion(text: string, suggestion: TypographySuggestion): string {
+  return text.slice(0, suggestion.start) + suggestion.replacement + text.slice(suggestion.end)
+}
+
+/**
+ * Apply multiple suggestions. Applies in reverse order by start index
+ * so indices remain valid. Returns new string.
+ */
+export function applySuggestions(text: string, suggestions: TypographySuggestion[]): string {
+  const sorted = [...suggestions].sort((a, b) => b.start - a.start)
+  let result = text
+  for (const s of sorted) {
+    result = applySuggestion(result, s)
+  }
+  return result
+}
+

--- a/documentation/EPICS/editorLayer/Atomics/cni-07-typography-rules-management.json
+++ b/documentation/EPICS/editorLayer/Atomics/cni-07-typography-rules-management.json
@@ -1,0 +1,52 @@
+{
+  "meta": {
+    "cohort": "c26",
+    "repo": "befly"
+  },
+  "summary": "Typography rules management — dedicated module with admin CRUD",
+  "problem_statement": "Typography suggestion rules (cni-06) are currently hardcoded in the client. To make the correction system more useful and adaptable, admins need the ability to create, edit, reorder, enable/disable, and delete rules without code changes. A dedicated module with full-stack CRUD enables site-specific customization and experimentation.",
+  "in_scope": [
+    "Dedicated typography-rules module: shared types, client engine, server persistence",
+    "Database table and migration for typography rules (id, order, enabled, pattern, replacement, description, etc.)",
+    "Server API: GET /api/admin/typography-rules, POST/PUT/DELETE for full CRUD",
+    "Public API: GET /api/typography-rules (or /api/public/typography-rules) — returns enabled rules for Write page (no auth required)",
+    "Admin UI: new view /admin/rules (or section in Admin) with list, create, edit, delete, reorder",
+    "Client: Write page fetches rules from API instead of hardcoded; fallback to bundled defaults if API fails",
+    "Rule validation: pattern must be valid regex; replacement supported; serializable format for server storage"
+  ],
+  "out_of_scope": [
+    "Per-user rule preferences (all rules are site-wide)",
+    "Rule testing/preview UI in admin (future enhancement)",
+    "Import/export rule sets",
+    "Version history or audit log for rule changes"
+  ],
+  "requirements": [
+    "Rules persisted in database; editable by admins only",
+    "Order field for rule execution order (em dash before en dash, etc.)",
+    "Enabled flag to toggle rules without deleting",
+    "Pattern stored as string; replacement as string or template (e.g. $1 for capture group)",
+    "Write page uses API rules; graceful fallback to default rules on fetch failure"
+  ],
+  "acceptance_criteria": [
+    "Admin can create a new typography rule (pattern, replacement, description, order)",
+    "Admin can edit existing rules",
+    "Admin can delete rules",
+    "Admin can reorder rules (drag-and-drop or up/down buttons)",
+    "Admin can enable/disable rules without deleting",
+    "Write page typography suggestions use rules from API when available",
+    "Write page falls back to bundled default rules if API fails or returns empty"
+  ],
+  "dependencies": [
+    "cni-06 autocorrection option A implemented"
+  ],
+  "risks": [
+    "Stored regex patterns can be invalid or cause ReDoS — validate/server-side sanitize",
+    "Malicious replacement templates could inject script — sanitize replacement format"
+  ],
+  "implementation_notes": {
+    "shared": "TypographyRule type/interface; rule schema for API request/response",
+    "server": "Migration for typography_rules table (id, sort_order, enabled, rule_id, description, pattern, replacement, created_at, updated_at). Controller, service, repository. Admin routes under /api/admin/typography-rules. Public read-only route /api/typography-rules for Write page.",
+    "client": "Composable useTypographyRules() fetches from /api/typography-rules. Admin page AdminRules.vue or AdminRules section: list with edit/delete/reorder; create/edit form for pattern, replacement, description. Write.vue passes fetched rules to scanTypography(). Default rules in typography-suggestions.ts as fallback.",
+    "rule_format": "Replacement can use $1, $2 for capture groups. Pattern must include 'g' flag for global. Validate pattern compiles before save."
+  }
+}

--- a/documentation/EPICS/editorLayer/EPIC_PROGRESS.md
+++ b/documentation/EPICS/editorLayer/EPIC_PROGRESS.md
@@ -1,6 +1,6 @@
 # Editor Layer Epic — Progress and Next Steps
 
-**Last updated:** February 11, 2026
+**Last updated:** February 12, 2026
 
 ## Status Overview
 
@@ -9,7 +9,7 @@
 | CNI 01–03 (investigate) | Complete | Audit, strategy, baseline done |
 | Phase 1: Critical Safety | **Complete** | cni-04 done; cni-05 accepted as-is (no confirmation dialogs) |
 | Phase 2: Validation | **Complete** | Undo/redo tests done; see findings below |
-| Phase 3: Auto-correction | Not started | Option A: suggest only, no programmatic apply |
+| Phase 3: Auto-correction | **In progress** | cni-06 implemented; cni-07 drafted |
 
 ---
 
@@ -75,11 +75,31 @@
 | Apply corrections | **Suggest only** — show inline hints or modal; user chooses to accept |
 | Undo wrapper | Not needed |
 
-**Potential deliverables:**
-- Typography suggestions (smart quotes, dashes, ellipsis) on blur or before save
-- Inline hints or tooltip: "Consider: `"hello"` → `"hello"`"
-- User clicks to apply (single change) or accepts all
-- No programmatic text mutation — user action triggers the change, so undo works
+---
+
+### cni-06: Autocorrection Option A — **Complete**
+
+| Criterion | Status |
+|----------|--------|
+| Typography suggestions appear on blur or before save | Yes |
+| User can accept or dismiss each suggestion | Yes |
+| No programmatic text mutation without user action | Yes |
+| Undo/redo behavior unchanged | Yes |
+| Initial rules: smart quotes, en/em dashes, ellipsis | Yes |
+
+**Implementation:**
+- [`client/src/utils/typography-suggestions.ts`](../../../client/src/utils/typography-suggestions.ts) — rule engine, markdown-aware scan, apply helpers
+- [`client/src/pages/Write.vue`](../../../client/src/pages/Write.vue) — suggestion modal before save, blur hint, user-initiated apply
+
+**Delivered:** Modal before publish; Accept/Dismiss per suggestion or Accept all/Dismiss all; blur indicator for suggestion count.
+
+---
+
+### cni-07: Typography Rules Management — **Drafted**
+
+Atomic spec drafted: [cni-07-typography-rules-management.json](./Atomics/cni-07-typography-rules-management.json)
+
+Scope: dedicated module, admin CRUD UI, server persistence, public read API. Not yet implemented.
 
 ---
 
@@ -92,7 +112,5 @@
 
 ## Recommended Next Steps
 
-1. **Implement cni-06** — [cni-06-autocorrection-option-a.json](./Atomics/cni-06-autocorrection-option-a.json) scopes suggest-on-blur/save, no programmatic apply, user-initiated accept.
-2. **Prototype suggestion UI** — Decide: inline underline, tooltip, or modal before save. Minimal implementation to validate UX.
-3. **Define initial suggestion rules** — Start with typography (smart quotes, dashes, ellipsis); document rule format for extensibility.
-4. **Implement when ready** — Phase 1 and 2 complete; no blocking items.
+1. **Implement cni-07** — [cni-07-typography-rules-management.json](./Atomics/cni-07-typography-rules-management.json) scopes admin CRUD for typography rules, dedicated module, server persistence.
+2. **Optional: EDITOR_PERFORMANCE_BASELINE.md** — Add note that critical autosave/draft items are addressed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writing-platform",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Personal Writing Platform (Vendor-Neutral, Self-Hosted)",
   "private": true,
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "nodemon src/index.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/shared",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Shared types and contracts for writing platform",
   "main": "index.ts",
   "types": "index.ts",


### PR DESCRIPTION
- Implement suggest-only typography corrections (Option A)
- Add typography rule engine: smart quotes, en/em dashes, ellipsis
- Markdown-aware rules (skip code blocks, inline code, URLs)
- Suggestion modal before publish: Accept/Dismiss, Accept all
- Blur hint for suggestion count on body textarea
- EPIC_PROGRESS: Phase 3 in progress, cni-06 complete, cni-07 drafted
- Add cni-07 atomic spec for typography rules management (admin CRUD)
- Version 0.3.2 → 0.3.3; CHANGELOG entry