### PR TITLE
chore: bump to 0.4.1 — bulk import for typography rules (cni-08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Rambulations writing platform are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-02-13
+
+### Added
+- Bulk import endpoint `POST /api/admin/typography-rules/import` — import many rules in one request (cni-08)
+- Admin Rules import now uses bulk endpoint; avoids 429 rate limits when importing 230+ rules
+
+### Changed
+- Version bump 0.4.0 → 0.4.1 (build number in footer)
+
+---
+
 ## [0.4.0] - 2026-02-12
 
 ### Added
@@ -149,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Database migrations (001-008): users, writing_blocks, themes, appreciations, auth/visibility, roles, reaction types, comments
 - Development setup documentation and quick-start guide
 
+[0.4.1]: https://github.com/DRCUOA/befly/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/DRCUOA/befly/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/DRCUOA/befly/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/DRCUOA/befly/compare/v0.3.1...v0.3.2

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/config/version.ts
+++ b/client/src/config/version.ts
@@ -1,3 +1,3 @@
 // Version is injected at build time via Vite
 // This file is replaced during build with the actual version from package.json
-export const APP_VERSION = '0.4.0'
+export const APP_VERSION = '0.4.1'

--- a/documentation/EPICS/editorLayer/Atomics/cni-08-typography-rules-bulk-import.json
+++ b/documentation/EPICS/editorLayer/Atomics/cni-08-typography-rules-bulk-import.json
@@ -1,0 +1,48 @@
+{
+  "meta": {
+    "cohort": "c26",
+    "repo": "befly"
+  },
+  "summary": "Bulk import endpoint for typography rules to avoid rate limits",
+  "problem_statement": "Admin Rules import (cni-07) previously created one rule per POST request. Importing large rule sets (~230+ rules) exceeded the general API rate limit (100 requests per 15 minutes), causing 429 errors. A single bulk import endpoint eliminates this bottleneck.",
+  "in_scope": [
+    "Server: POST /api/admin/typography-rules/import accepting { rules: CreateTypographyRuleRequest[] }",
+    "Response: { created, failed, errors } for partial success reporting",
+    "Repository: createMany() with transaction; per-rule failures (e.g. duplicate rule_id) reported, not rolled back",
+    "Service: bulkImport() with same validation/sanitization as single create; invalid rules skipped with errors",
+    "Client: AdminRules.vue importRules() calls bulk endpoint instead of per-rule POSTs",
+    "Cap: 500 rules per request to bound payload and DB load"
+  ],
+  "out_of_scope": [
+    "Bulk update or bulk delete",
+    "Conflict resolution (upsert on duplicate rule_id)",
+    "Async/background import for very large sets",
+    "Rate limit exemption for admin routes"
+  ],
+  "requirements": [
+    "Single HTTP request imports all rules in one transaction",
+    "Partial success: valid rules created; invalid/duplicate rules reported in errors",
+    "Same validation as single create (ruleId format, pattern regex, description length, etc.)",
+    "Admin-only; requires auth + admin role"
+  ],
+  "acceptance_criteria": [
+    "Admin can paste JSON array of rules and import in one action",
+    "230+ rules import without 429 errors",
+    "Invalid rules (bad ruleId, invalid regex) are skipped; created count reflects successes",
+    "Duplicate rule_ids are reported in errors; other rules still created",
+    "Client shows feedback: \"Imported X rules (Y failed)\""
+  ],
+  "dependencies": [
+    "cni-07 typography rules management (admin CRUD, import UI)"
+  ],
+  "risks": [
+    "Large payloads (500 rules) could stress memory; cap mitigates",
+    "Transaction holds connection during full insert; acceptable for 500 rows"
+  ],
+  "implementation_notes": {
+    "shared": "BulkImportTypographyRequest interface: { rules: CreateTypographyRuleRequest[] }",
+    "server": "Route POST /typography-rules/import must be defined before /:id to avoid 'import' matched as id. typography.repo.createMany() uses pool.connect() for transaction; INSERT per rule with try/catch to allow partial success. typography.service.bulkImport() validates each rule, builds valid array, assigns sortOrder when omitted.",
+    "client": "AdminRules.vue importRules(): single api.post('/admin/typography-rules/import', { rules: toImport }) instead of loop. Response data: { created, failed, errors }. Error message uses first error when all fail.",
+    "testing": "typography-rules-guardrail.test.ts: bulk import success case; partial failure with invalid ruleId reports errors"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writing-platform",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Personal Writing Platform (Vendor-Neutral, Self-Hosted)",
   "private": true,
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "nodemon src/index.ts",

--- a/server/src/controllers/typography.controller.ts
+++ b/server/src/controllers/typography.controller.ts
@@ -56,5 +56,15 @@ export const typographyController = {
     }
     const rules = await typographyService.reorder(id, direction)
     res.json({ data: rules })
+  },
+
+  /** Admin: bulk import rules */
+  async bulkImport(req: Request, res: Response) {
+    const rules = req.body.rules
+    if (!Array.isArray(rules)) {
+      throw new ValidationError('rules array is required')
+    }
+    const result = await typographyService.bulkImport(rules)
+    res.status(201).json({ data: result })
   }
 }

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -13,6 +13,7 @@ router.use(requireAdmin)
 
 // Typography rules (admin CRUD)
 router.get('/typography-rules', asyncHandler(typographyController.getAll))
+router.post('/typography-rules/import', asyncHandler(typographyController.bulkImport))
 router.get('/typography-rules/:id', asyncHandler(typographyController.getById))
 router.post('/typography-rules', asyncHandler(typographyController.create))
 router.put('/typography-rules/:id', asyncHandler(typographyController.update))

--- a/shared/TypographyRule.ts
+++ b/shared/TypographyRule.ts
@@ -38,3 +38,8 @@ export interface UpdateTypographyRuleRequest {
   sortOrder?: number
   enabled?: boolean
 }
+
+/** Request body for bulk import (array of rules) */
+export interface BulkImportTypographyRequest {
+  rules: CreateTypographyRuleRequest[]
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/shared",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared types and contracts for writing platform",
   "main": "index.ts",
   "types": "index.ts",


### PR DESCRIPTION
- Add POST /api/admin/typography-rules/import — single request for many rules
- Admin Rules import now uses bulk endpoint; avoids 429 rate limits
- CHANGELOG: 0.4.1 entry; version/build 0.4.0 → 0.4.1