### PR TITLE
feat(cni-04): single accent colour — reduce palette, remove visual noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the Rambulations writing platform are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-02-16
+
+### Added
+- **Single accent colour (cni-04)** — reduce colour palette to one accent; remove visual noise; opens Phase 2 (Sensory)
+- CSS custom properties: `--color-accent` (#7C6F64), `--color-accent-hover` (#5C524A), `--color-accent-muted` (#F3EFEB) — warm stone derived from existing paper/ink palette
+- Tailwind design tokens `accent`, `accent-hover`, `accent-muted` referencing CSS variables so downstream atomics inherit the palette automatically
+
+### Changed
+- Write view: consolidated 5 accent hues (amber, green, blue, red, gray) into single accent colour with lightness/weight shifts for interactive states
+- Typography suggestions panel: moved above textarea (between title and body) so writers see suggestions without scrolling past text
+- Typography suggestions detail: expanded max height from `max-h-48` (192px) to `max-h-[50vh]` so users can review all suggestions
+- Typography suggestions summary bar: differentiated "Accept all" (font-medium, accent-hover) from "Dismiss" (ink-lighter) and chevron affordance (ink-lighter) for clear visual hierarchy
+- MetadataPanel: focus rings, checkboxes, and select use `accent`/`accent-hover` instead of `ink`; button hovers use `line` token instead of hardcoded `#E5E5E5`
+- ThemeTag: `bg-blue-100 text-blue-800` → `bg-accent-muted text-accent`
+- CoverImageCropModal: cropper background uses `line` token; error text uses `ink` instead of `red-600`
+- DraggableCoverImage: placeholder background uses `line` token instead of `gray-200`
+- Draft saved indicator: uses accent-muted tint with ink weight shift instead of red/green semantic colours
+- Recovery modal: restore button uses accent; dismiss/discard use neutral line/ink-light; preview area uses accent-muted
+- Error displays (Write, MetadataPanel): use `bg-accent-muted border-line text-ink` instead of red palette
+- Version bump 0.5.2 → 0.5.3 (build number in footer)
+
+### Removed
+- All secondary accent colours from Write view: amber (typography), green (accept/success), blue (restore/tags), red (errors/discard)
+- Hardcoded hex colour values (`#E5E5E5`) from interactive hover states in Write view components
+
+---
+
 ## [0.5.2] - 2026-02-16
 
 ### Added
@@ -249,6 +276,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Database migrations (001-008): users, writing_blocks, themes, appreciations, auth/visibility, roles, reaction types, comments
 - Development setup documentation and quick-start guide
 
+[0.5.3]: https://github.com/DRCUOA/befly/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/DRCUOA/befly/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/DRCUOA/befly/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/DRCUOA/befly/compare/v0.4.3...v0.5.0

--- a/client/index.html
+++ b/client/index.html
@@ -7,6 +7,7 @@
     <title>Rambulations</title>
   </head>
   <body>
+    
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/client",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/components/writing/CoverImageCropModal.vue
+++ b/client/src/components/writing/CoverImageCropModal.vue
@@ -10,7 +10,7 @@
       <div class="flex-1 min-h-0 p-4 overflow-hidden">
         <Cropper
           ref="cropperRef"
-          class="cropper h-[min(60vh,400px)] bg-[#E5E5E5] rounded"
+          class="cropper h-[min(60vh,400px)] bg-line rounded"
           :src="imageSrc"
           :stencil-props="{ aspectRatio: 1 }"
           :canvas="canvasOptions"
@@ -18,7 +18,7 @@
           @error="onError"
         />
       </div>
-      <div v-if="cropError" class="px-6 py-2 text-sm text-red-600">{{ cropError }}</div>
+      <div v-if="cropError" class="px-6 py-2 text-sm text-ink">{{ cropError }}</div>
       <div class="px-6 py-4 border-t border-line flex justify-end gap-3">
         <button
           type="button"

--- a/client/src/components/writing/DraggableCoverImage.vue
+++ b/client/src/components/writing/DraggableCoverImage.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="containerRef"
-    class="relative overflow-hidden bg-gray-200 select-none"
+    class="relative overflow-hidden bg-line select-none"
     :class="[containerClass, editable && 'cursor-grab active:cursor-grabbing']"
     @mousedown="onMouseDown"
   >

--- a/client/src/components/writing/MetadataPanel.vue
+++ b/client/src/components/writing/MetadataPanel.vue
@@ -15,7 +15,7 @@
       <h2 class="text-lg font-sans font-medium text-ink">Metadata</h2>
       <button
         type="button"
-        class="p-2 -m-2 text-ink-lighter hover:text-ink rounded focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2"
+        class="p-2 -m-2 text-ink-lighter hover:text-ink rounded focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
         aria-label="Close metadata panel"
         @click="close"
       >
@@ -50,7 +50,7 @@
           />
           <button
             type="button"
-            class="px-3 py-1.5 text-sm rounded border border-line text-ink hover:bg-[#E5E5E5] font-sans"
+            class="px-3 py-1.5 text-sm rounded border border-line text-ink hover:bg-line font-sans"
             @click="coverFileInputRef?.click()"
           >
             Upload image
@@ -58,7 +58,7 @@
           <button
             v-if="form.coverImageUrl"
             type="button"
-            class="px-3 py-1.5 text-sm rounded border border-line text-ink hover:bg-[#E5E5E5] font-sans"
+            class="px-3 py-1.5 text-sm rounded border border-line text-ink hover:bg-line font-sans"
             @click="$emit('open-crop')"
           >
             Crop
@@ -66,7 +66,7 @@
           <button
             v-if="form.coverImageUrl"
             type="button"
-            class="px-3 py-1.5 text-sm rounded border border-line text-ink-lighter hover:bg-[#E5E5E5] font-sans"
+            class="px-3 py-1.5 text-sm rounded border border-line text-ink-lighter hover:bg-line font-sans"
             @click="form.coverImageUrl = ''"
           >
             Clear
@@ -84,7 +84,7 @@
         </label>
         <select
           v-model="form.visibility"
-          class="mt-1 block w-full rounded-md border-line shadow-sm focus:border-ink focus:ring-ink text-base sm:text-sm bg-paper"
+          class="mt-1 block w-full rounded-md border-line shadow-sm focus:border-accent focus:ring-accent text-base sm:text-sm bg-paper"
           aria-label="Choose who can see this writing block"
         >
           <option value="private">Private (only you can see)</option>
@@ -115,7 +115,7 @@
               v-model="form.themeIds"
               type="checkbox"
               :value="theme.id"
-              class="h-4 w-4 text-ink focus:ring-ink border-line rounded"
+              class="h-4 w-4 text-accent focus:ring-accent border-line rounded"
               :aria-label="`Assign theme: ${theme.name}`"
             />
             <label
@@ -132,8 +132,8 @@
       </div>
 
       <!-- Error -->
-      <div v-if="error" class="bg-red-50 border border-red-200 rounded-md p-3 sm:p-4">
-        <p class="text-red-800 text-xs sm:text-sm">{{ error }}</p>
+      <div v-if="error" class="bg-accent-muted border border-line rounded-md p-3 sm:p-4">
+        <p class="text-ink text-xs sm:text-sm">{{ error }}</p>
       </div>
     </div>
   </div>

--- a/client/src/components/writing/ThemeTag.vue
+++ b/client/src/components/writing/ThemeTag.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+  <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-accent-muted text-accent">
     {{ name }}
   </span>
 </template>

--- a/client/src/config/version.ts
+++ b/client/src/config/version.ts
@@ -1,3 +1,3 @@
 // Version is injected at build time via Vite
 // This file is replaced during build with the actual version from package.json
-export const APP_VERSION = '0.5.2'
+export const APP_VERSION = '0.5.3'

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,6 +11,13 @@
   --color-ink-lighter: #8A8A8A;
   --color-ink-whisper: #B8B8B8;
   --color-line: #E8E6E3;
+
+  /* Single accent colour — P2-uix-04
+     Warm stone derived from the paper/ink palette.
+     Hover/focus states shift lightness; no additional hues. */
+  --color-accent: #7C6F64;
+  --color-accent-hover: #5C524A;
+  --color-accent-muted: #F3EFEB;
 }
 
 * {

--- a/client/src/pages/Write.vue
+++ b/client/src/pages/Write.vue
@@ -13,6 +13,82 @@
           aria-label="Title"
         />
       </div>
+
+      <!-- Non-blocking inline typography suggestions (P1-uix-03: progressive reveal)
+           Positioned between title and body so writers see them without scrolling past text. -->
+      <div v-if="typographySuggestions.length > 0" class="w-full px-4 sm:px-6 md:px-8 lg:px-12 pb-3" role="region" aria-label="Typography suggestions">
+        <div class="border border-line bg-accent-muted rounded-md overflow-hidden">
+          <!-- Summary bar — visually interactive: hover shifts to line, chevron signals expand -->
+          <button
+            type="button"
+            class="w-full flex items-center justify-between px-4 py-2.5 text-sm text-accent-hover hover:bg-line transition-colors"
+            @click="suggestionsPanelExpanded = !suggestionsPanelExpanded"
+            :aria-expanded="suggestionsPanelExpanded"
+            aria-controls="typography-suggestions-panel"
+          >
+            <span class="flex items-center gap-2">
+              <svg class="w-4 h-4 text-accent shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              {{ typographySuggestions.length }} typography suggestion{{ typographySuggestions.length === 1 ? '' : 's' }}
+            </span>
+            <span class="flex items-center gap-3">
+              <span
+                role="button"
+                tabindex="0"
+                class="text-xs font-medium text-accent-hover hover:text-ink underline underline-offset-2"
+                @click.stop="acceptAllTypographySuggestions"
+                @keydown.enter.stop="acceptAllTypographySuggestions"
+              >Accept all</span>
+              <span
+                role="button"
+                tabindex="0"
+                class="text-xs text-ink-lighter hover:text-ink-light underline underline-offset-2"
+                @click.stop="dismissAllTypographySuggestions"
+                @keydown.enter.stop="dismissAllTypographySuggestions"
+              >Dismiss</span>
+              <svg
+                class="w-4 h-4 text-ink-lighter transition-transform duration-200"
+                :class="{ 'rotate-180': suggestionsPanelExpanded }"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </span>
+          </button>
+          <!-- Expanded suggestion list — generous height so users can review all detail -->
+          <div
+            v-if="suggestionsPanelExpanded"
+            id="typography-suggestions-panel"
+            class="border-t border-line px-4 pb-3 pt-2 space-y-2 max-h-[50vh] overflow-y-auto"
+          >
+            <div
+              v-for="(suggestion, idx) in typographySuggestions"
+              :key="`${suggestion.start}-${suggestion.ruleId}`"
+              class="flex items-center justify-between gap-3 px-3 py-2 bg-white/70 rounded text-sm"
+            >
+              <div class="flex-1 min-w-0 truncate">
+                <span class="text-ink-lighter">{{ suggestion.description }}:</span>
+                <span class="ml-1 font-mono text-ink">"{{ suggestion.original }}"</span>
+                <span class="mx-1 text-ink-whisper">→</span>
+                <span class="font-mono font-medium text-accent-hover">"{{ suggestion.replacement }}"</span>
+              </div>
+              <div class="flex gap-2 shrink-0">
+                <button
+                  type="button"
+                  @click="acceptTypographySuggestion(idx)"
+                  class="px-2 py-1 text-xs bg-accent text-paper rounded hover:bg-accent-hover transition-colors"
+                >Accept</button>
+                <button
+                  type="button"
+                  @click="dismissTypographySuggestion(idx)"
+                  class="px-2 py-1 text-xs border border-line rounded text-ink-lighter hover:bg-line transition-colors"
+                >Dismiss</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       
       <div class="flex-1 w-full px-4 sm:px-6 md:px-8 lg:px-12 pb-4">
         <textarea
@@ -27,91 +103,16 @@
         />
       </div>
 
-      <!-- Non-blocking inline typography suggestions (P1-uix-03: progressive reveal) -->
-      <div v-if="typographySuggestions.length > 0" class="w-full px-4 sm:px-6 md:px-8 lg:px-12 pb-2" role="region" aria-label="Typography suggestions">
-        <div class="border border-amber-200 bg-amber-50/80 rounded-md overflow-hidden">
-          <!-- Summary bar -->
-          <button
-            type="button"
-            class="w-full flex items-center justify-between px-4 py-2.5 text-sm text-amber-800 hover:bg-amber-100/50 transition-colors"
-            @click="suggestionsPanelExpanded = !suggestionsPanelExpanded"
-            :aria-expanded="suggestionsPanelExpanded"
-            aria-controls="typography-suggestions-panel"
-          >
-            <span class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-amber-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              {{ typographySuggestions.length }} typography suggestion{{ typographySuggestions.length === 1 ? '' : 's' }}
-            </span>
-            <span class="flex items-center gap-3">
-              <span
-                role="button"
-                tabindex="0"
-                class="text-xs text-amber-700 hover:text-amber-900 underline underline-offset-2"
-                @click.stop="acceptAllTypographySuggestions"
-                @keydown.enter.stop="acceptAllTypographySuggestions"
-              >Accept all</span>
-              <span
-                role="button"
-                tabindex="0"
-                class="text-xs text-amber-600 hover:text-amber-800 underline underline-offset-2"
-                @click.stop="dismissAllTypographySuggestions"
-                @keydown.enter.stop="dismissAllTypographySuggestions"
-              >Dismiss</span>
-              <svg
-                class="w-4 h-4 text-amber-500 transition-transform duration-200"
-                :class="{ 'rotate-180': suggestionsPanelExpanded }"
-                fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-              </svg>
-            </span>
-          </button>
-          <!-- Expanded suggestion list -->
-          <div
-            v-if="suggestionsPanelExpanded"
-            id="typography-suggestions-panel"
-            class="border-t border-amber-200 px-4 pb-3 pt-2 space-y-2 max-h-48 overflow-y-auto"
-          >
-            <div
-              v-for="(suggestion, idx) in typographySuggestions"
-              :key="`${suggestion.start}-${suggestion.ruleId}`"
-              class="flex items-center justify-between gap-3 px-3 py-2 bg-white/70 rounded text-sm"
-            >
-              <div class="flex-1 min-w-0 truncate">
-                <span class="text-gray-500">{{ suggestion.description }}:</span>
-                <span class="ml-1 font-mono text-gray-800">"{{ suggestion.original }}"</span>
-                <span class="mx-1 text-gray-400">→</span>
-                <span class="font-mono text-green-700">"{{ suggestion.replacement }}"</span>
-              </div>
-              <div class="flex gap-2 shrink-0">
-                <button
-                  type="button"
-                  @click="acceptTypographySuggestion(idx)"
-                  class="px-2 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
-                >Accept</button>
-                <button
-                  type="button"
-                  @click="dismissTypographySuggestion(idx)"
-                  class="px-2 py-1 text-xs border border-gray-300 rounded text-gray-600 hover:bg-gray-100 transition-colors"
-                >Dismiss</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <!-- Footer: metadata trigger, publish, cancel (≤5 visible controls per epic DoD) -->
       <div class="w-full border-t border-line bg-paper px-4 sm:px-6 md:px-8 lg:px-12 py-4 sm:py-6 sticky bottom-0 z-10">
-      <div v-if="error" class="mb-4 bg-red-50 border border-red-200 rounded-md p-3 sm:p-4">
-        <p class="text-red-800 text-xs sm:text-sm">{{ error }}</p>
+      <div v-if="error" class="mb-4 bg-accent-muted border border-line rounded-md p-3 sm:p-4">
+        <p class="text-ink text-xs sm:text-sm">{{ error }}</p>
       </div>
       
       <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 items-center sm:items-center">
         <button
           type="button"
-          class="inline-flex items-center gap-2 px-4 py-2 border border-line rounded-md text-ink-lighter hover:text-ink hover:bg-[#E5E5E5] text-sm font-sans"
+          class="inline-flex items-center gap-2 px-4 py-2 border border-line rounded-md text-ink-lighter hover:text-ink hover:bg-line text-sm font-sans"
           aria-label="Open metadata settings (cover, themes, visibility)"
           :aria-expanded="metadataPanelOpen"
           @click="metadataPanelOpen = true"
@@ -130,7 +131,7 @@
         </button>
         <router-link
           to="/home"
-          class="px-6 py-2 border border-line rounded-md text-ink-lighter hover:text-ink hover:bg-[#E5E5E5] text-center text-sm font-sans"
+          class="px-6 py-2 border border-line rounded-md text-ink-lighter hover:text-ink hover:bg-line text-center text-sm font-sans"
         >
           Cancel
         </router-link>
@@ -139,7 +140,7 @@
       <div
         v-if="showDraftIndicator"
         class="mt-4 px-3 py-2 rounded-md text-xs sm:text-sm font-sans"
-        :class="hasUnsavedChanges ? 'bg-red-50 text-red-800' : 'bg-green-50 text-green-800'"
+        :class="hasUnsavedChanges ? 'bg-accent-muted text-ink' : 'bg-accent-muted text-ink-lighter'"
       >
         Draft saved at {{ draftSavedAt ?? '—' }}
       </div>
@@ -174,34 +175,34 @@
     <div v-if="showRecoveryModal && recoveryDraft" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="bg-white rounded-lg shadow-xl p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold mb-2">Recover Unsaved Work?</h3>
-        <p class="text-gray-700 mb-4">
+        <p class="text-ink-light mb-4">
           You have an unsaved draft from {{ formatTime(recoveryDraft.timestamp) }}. Would you like to recover it?
         </p>
-        <div class="mb-4 p-3 bg-gray-50 rounded-md text-sm">
-          <div class="font-medium text-gray-700 mb-1">Draft Preview:</div>
-          <div class="text-gray-600">
+        <div class="mb-4 p-3 bg-accent-muted rounded-md text-sm">
+          <div class="font-medium text-ink-light mb-1">Draft Preview:</div>
+          <div class="text-ink-lighter">
             <strong>Title:</strong> {{ recoveryDraft.title || '(empty)' }}
           </div>
-          <div class="text-gray-600 mt-1">
+          <div class="text-ink-lighter mt-1">
             <strong>Body:</strong> {{ recoveryDraft.body.substring(0, 100) }}{{ recoveryDraft.body.length > 100 ? '...' : '' }}
           </div>
         </div>
-        <div class="flex justify-end gap-3">
+        <div class="flex flex-wrap justify-end gap-3">
           <button
             @click="dismissRecoveryModal"
-            class="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 text-sm"
+            class="px-4 py-2 rounded-md text-ink-lighter hover:text-ink-light text-sm"
           >
             Dismiss
           </button>
           <button
             @click="discardDraft"
-            class="px-4 py-2 border border-red-300 rounded-md text-red-700 hover:bg-red-50 text-sm"
+            class="px-4 py-2 border border-line rounded-md text-ink-light hover:text-ink hover:bg-line text-sm"
           >
             Discard
           </button>
           <button
             @click="restoreDraft"
-            class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm"
+            class="px-4 py-2 bg-accent text-paper rounded-md hover:bg-accent-hover text-sm"
           >
             Restore
           </button>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -17,6 +17,9 @@ export default {
         'ink-lighter': '#8A8A8A',
         'ink-whisper': '#B8B8B8',
         'line': '#E8E6E3',
+        'accent': 'var(--color-accent)',
+        'accent-hover': 'var(--color-accent-hover)',
+        'accent-muted': 'var(--color-accent-muted)',
       },
       spacing: {
         '18': '4.5rem',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writing-platform",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Personal Writing Platform (Vendor-Neutral, Self-Hosted)",
   "private": true,
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "nodemon src/index.ts",


### PR DESCRIPTION
Consolidate 5 accent hues (amber, green, blue, red, hardcoded hex) to one warm-stone accent (#7C6F64) across the Write view. All interactive states derive from lightness/weight shifts — no additional hues.

- Add CSS custom properties (--color-accent, --color-accent-hover, --color-accent-muted) and matching Tailwind tokens via var() refs
- Replace amber/green/blue/red/gray Tailwind classes in Write.vue, MetadataPanel, ThemeTag, CoverImageCropModal, DraggableCoverImage
- Move typography suggestions panel above textarea for visibility
- Expand suggestion detail height (max-h-48 → max-h-[50vh])
- Differentiate summary bar actions by weight/tone, not hue
- WCAG AA verified: 5.96:1 (accent), 7.42:1 (accent-hover) vs paper

Bump 0.5.2 → 0.5.3. All 29 tests pass. Opens Phase 2 (Sensory).