### PR TITLE
fix: persist cover images in PostgreSQL to survive Heroku dyno restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Rambulations writing platform are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2026-02-20
+
+### Fixed
+- **Cover image persistence** — uploaded cover images were lost after Heroku dyno restarts because files were stored on the ephemeral filesystem; images are now persisted in PostgreSQL and served from the database with aggressive caching headers (`Cache-Control: immutable`, `ETag`)
+- New `uploaded_files` table (migration 015) stores image binary data, content type, and metadata
+- New `uploads.repo.ts` repository for database-backed file CRUD
+- Upload controller reads multer temp files into PostgreSQL, then cleans up disk; `GET /uploads/cover/:filename` serves images from DB
+- One-time backfill script (`scripts/backfill-uploads.sh`) to import existing filesystem images into PostgreSQL before next dyno cycle
+
+### Changed
+- Version bump 0.5.4 → 0.5.5
+
+---
+
 ## [0.5.4] - 2026-02-17
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/client",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/config/version.ts
+++ b/client/src/config/version.ts
@@ -1,3 +1,3 @@
 // Version is injected at build time via Vite
 // This file is replaced during build with the actual version from package.json
-export const APP_VERSION = '0.5.4'
+export const APP_VERSION = '0.5.5'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writing-platform",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Personal Writing Platform (Vendor-Neutral, Self-Hosted)",
   "private": true,
   "scripts": {

--- a/scripts/backfill-uploads.sh
+++ b/scripts/backfill-uploads.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# One-time backfill: import existing filesystem images into PostgreSQL.
+# Run on the current dyno BEFORE the next restart wipes ephemeral files.
+#
+# Usage (Heroku):
+#   heroku run "sh scripts/backfill-uploads.sh" -a befly
+#
+# Usage (local):
+#   sh scripts/backfill-uploads.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVER_DIR="$SCRIPT_DIR/../server"
+COVER_DIR="$SERVER_DIR/uploads/cover"
+
+if [ -f "$SCRIPT_DIR/../.env" ]; then
+  export $(cat "$SCRIPT_DIR/../.env" | grep -v '^#' | xargs)
+fi
+
+DATABASE_URL="${DATABASE_URL:-postgres://user:pass@localhost:5432/writing}"
+
+if [ ! -d "$COVER_DIR" ]; then
+  echo "No cover directory found at $COVER_DIR — nothing to backfill."
+  exit 0
+fi
+
+count=0
+for img in "$COVER_DIR"/*.jpg "$COVER_DIR"/*.jpeg "$COVER_DIR"/*.png "$COVER_DIR"/*.gif "$COVER_DIR"/*.webp; do
+  [ -f "$img" ] || continue
+  filename="$(basename "$img")"
+
+  exists=$(psql "$DATABASE_URL" -tAc "SELECT 1 FROM uploaded_files WHERE filename = '$filename' LIMIT 1;" 2>/dev/null || echo "")
+  if [ "$exists" = "1" ]; then
+    echo "Skipping $filename (already in DB)"
+    continue
+  fi
+
+  ext="${filename##*.}"
+  case "$ext" in
+    jpg|jpeg) ctype="image/jpeg" ;;
+    png)      ctype="image/png" ;;
+    gif)      ctype="image/gif" ;;
+    webp)     ctype="image/webp" ;;
+    *)        ctype="application/octet-stream" ;;
+  esac
+
+  size=$(wc -c < "$img" | tr -d ' ')
+
+  echo "Importing $filename ($size bytes, $ctype)..."
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+    INSERT INTO uploaded_files (filename, content_type, data, size_bytes)
+    VALUES ('$filename', '$ctype', lo_get(lo_import('$img')), $size)
+    ON CONFLICT (filename) DO NOTHING;
+  " 2>/dev/null || {
+    # lo_import may not work in all environments; fall back to hex encoding
+    hex=$(xxd -p "$img" | tr -d '\n')
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+      INSERT INTO uploaded_files (filename, content_type, data, size_bytes)
+      VALUES ('$filename', '$ctype', decode('$hex', 'hex'), $size)
+      ON CONFLICT (filename) DO NOTHING;
+    "
+  }
+  count=$((count + 1))
+done
+
+echo "Backfill complete: $count image(s) imported."

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/server",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "nodemon src/index.ts",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,6 +15,8 @@ import commentRoutes from './routes/comment.routes.js'
 import activityRoutes from './routes/activity.routes.js'
 import adminRoutes from './routes/admin.routes.js'
 import typographyRulesRoutes from './routes/typography-rules.routes.js'
+import { uploadsController } from './controllers/uploads.controller.js'
+import { asyncHandler } from './utils/asyncHandler.js'
 import { config } from './config/env.js'
 
 const app = express()
@@ -28,7 +30,6 @@ if (config.nodeEnv === 'production') {
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const staticDir = path.resolve(__dirname, '../public')
-const uploadsDir = path.resolve(__dirname, '../uploads')
 const hasStaticBuild = fs.existsSync(path.join(staticDir, 'index.html'))
 
 
@@ -67,8 +68,8 @@ app.use('/api', (req, res, next) => {
   generalRateLimit(req, res, next)
 })
 
-// Serve uploaded images as public assets
-app.use('/uploads', express.static(uploadsDir))
+// Serve uploaded images from PostgreSQL (filesystem is ephemeral on Heroku)
+app.get('/uploads/cover/:filename', asyncHandler(uploadsController.serve))
 
 // CSRF token generation (must be before CSRF protection)
 // Skip CSRF for auth endpoints - they use their own protection

--- a/server/src/db/migrations/015_uploaded_files.sql
+++ b/server/src/db/migrations/015_uploaded_files.sql
@@ -1,0 +1,15 @@
+-- Migration 015: Persistent uploaded files
+-- Heroku uses an ephemeral filesystem; files saved to disk are lost on dyno restart.
+-- Store uploaded images in PostgreSQL so they survive dyno cycling.
+
+CREATE TABLE IF NOT EXISTS uploaded_files (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  filename VARCHAR(255) NOT NULL UNIQUE,
+  content_type VARCHAR(100) NOT NULL,
+  data BYTEA NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  uploaded_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_uploaded_files_filename ON uploaded_files(filename);

--- a/server/src/repositories/uploads.repo.ts
+++ b/server/src/repositories/uploads.repo.ts
@@ -1,0 +1,47 @@
+import { pool } from '../config/db.js'
+
+export interface UploadedFile {
+  id: string
+  filename: string
+  content_type: string
+  data: Buffer
+  size_bytes: number
+  uploaded_by: string | null
+  created_at: Date
+}
+
+export const uploadsRepo = {
+  async save(filename: string, contentType: string, data: Buffer, uploadedBy: string | null): Promise<string> {
+    const result = await pool.query(
+      `INSERT INTO uploaded_files (filename, content_type, data, size_bytes, uploaded_by)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (filename) DO UPDATE SET data = $3, content_type = $2, size_bytes = $4
+       RETURNING id`,
+      [filename, contentType, data, data.length, uploadedBy]
+    )
+    return result.rows[0].id
+  },
+
+  async findByFilename(filename: string): Promise<UploadedFile | null> {
+    const result = await pool.query(
+      'SELECT id, filename, content_type, data, size_bytes, uploaded_by, created_at FROM uploaded_files WHERE filename = $1',
+      [filename]
+    )
+    return result.rows[0] || null
+  },
+
+  async listMetadata(): Promise<Omit<UploadedFile, 'data'>[]> {
+    const result = await pool.query(
+      'SELECT id, filename, content_type, size_bytes, uploaded_by, created_at FROM uploaded_files ORDER BY created_at DESC'
+    )
+    return result.rows
+  },
+
+  async deleteByFilename(filename: string): Promise<boolean> {
+    const result = await pool.query(
+      'DELETE FROM uploaded_files WHERE filename = $1',
+      [filename]
+    )
+    return (result.rowCount ?? 0) > 0
+  }
+}


### PR DESCRIPTION
Cover images uploaded to /uploads/cover/ were stored on the ephemeral filesystem and lost every time Heroku recycled the dyno (~24h).

Store image data in PostgreSQL (uploaded_files table, BYTEA column) and serve via DB-backed GET /uploads/cover/:filename with immutable caching. Existing /uploads/cover/uuid.jpg URLs continue to work unchanged.

Includes migration 015, uploads repository, backfill script, and version bump 0.5.4 → 0.5.5.