### PR TITLE
fix(read): avoid repeating excerpt lines in article body

### DIFF
--- a/client/src/pages/Read.vue
+++ b/client/src/pages/Read.vue
@@ -65,8 +65,11 @@
         </div>
       </div>
 
-      <!-- Essay Content -->
-      <div class="w-full px-4 sm:px-6 md:px-8 py-8 sm:py-12 md:py-16 bg-paper">
+      <!-- Essay Content (continues after the excerpt; no duplicate of the opening lines) -->
+      <div
+        v-if="paragraphs.length > 0"
+        class="w-full px-4 sm:px-6 md:px-8 py-8 sm:py-12 md:py-16 bg-paper"
+      >
         <div class="max-w-3xl mx-auto essay-content text-base sm:text-lg md:text-xl leading-relaxed">
           <div
             v-for="(paragraph, index) in paragraphs"
@@ -126,7 +129,11 @@ import type { WritingBlock } from '../domain/WritingBlock'
 import type { Theme } from '../domain/Theme'
 import type { Appreciation } from '../domain/Appreciation'
 import type { ApiResponse } from '@shared/ApiResponses'
-import { markdownToText } from '../utils/markdown'
+import {
+  markdownToText,
+  bodyMarkdownAfterExcerptPrefix,
+  READING_EXCERPT_PLAIN_LENGTH
+} from '../utils/markdown'
 
 const route = useRoute()
 const { isAuthenticated } = useAuth()
@@ -139,12 +146,11 @@ const appreciations = ref<Appreciation[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 
-// Split content into paragraphs for progressive reveal
+// Split content into paragraphs for progressive reveal (body only — excerpt covers the opening)
 const paragraphs = computed(() => {
   if (!writing.value) return []
-  const text = writing.value.body
-  // Split by double newlines (paragraph breaks)
-  return text.split(/\n\n+/).filter(p => p.trim().length > 0)
+  const afterExcerpt = bodyMarkdownAfterExcerptPrefix(writing.value.body)
+  return afterExcerpt.split(/\n\n+/).filter(p => p.trim().length > 0)
 })
 
 const wordCount = computed(() => {
@@ -161,7 +167,8 @@ const readTime = computed(() => {
 const excerpt = computed(() => {
   if (!writing.value) return ''
   const text = markdownToText(writing.value.body)
-  return text.substring(0, 200) + '...'
+  if (text.length <= READING_EXCERPT_PLAIN_LENGTH) return text
+  return text.substring(0, READING_EXCERPT_PLAIN_LENGTH) + '...'
 })
 
 const formattedDate = computed(() => {

--- a/client/src/utils/markdown.spec.ts
+++ b/client/src/utils/markdown.spec.ts
@@ -2,7 +2,13 @@
  * Tests for markdown utilities, including word count (P3-uix-07 / cni-07)
  */
 import { describe, it, expect } from 'vitest'
-import { stripMarkdownForWordCount, countWordsInMarkdown } from './markdown'
+import {
+  stripMarkdownForWordCount,
+  countWordsInMarkdown,
+  markdownToText,
+  bodyMarkdownAfterExcerptPrefix,
+  READING_EXCERPT_PLAIN_LENGTH
+} from './markdown'
 
 describe('stripMarkdownForWordCount', () => {
   it('strips headers and keeps content', () => {
@@ -66,5 +72,28 @@ describe('countWordsInMarkdown', () => {
   it('handles mixed markdown', () => {
     const md = '# Title\n\nSome **bold** and *italic* with [a link](x.com).'
     expect(countWordsInMarkdown(md)).toBe(8) // Title Some bold and italic with a link
+  })
+})
+
+describe('bodyMarkdownAfterExcerptPrefix', () => {
+  it('returns empty when plain text fits in excerpt length', () => {
+    const md = 'Short piece.'
+    expect(bodyMarkdownAfterExcerptPrefix(md, READING_EXCERPT_PLAIN_LENGTH)).toBe('')
+  })
+
+  it('continues body after excerpt without repeating opening lines', () => {
+    const opening = 'A family.\n\nA group.\n\nA circle of friends.\n\n'
+    const rest = 'A rabbit warren.\n\nA nest.\n\nA hive.'
+    const md = opening + rest
+    const excerptPlain = markdownToText(md).substring(0, READING_EXCERPT_PLAIN_LENGTH)
+    const bodyPlain = markdownToText(bodyMarkdownAfterExcerptPrefix(md) ?? '')
+    expect(markdownToText(md)).toBe(excerptPlain + bodyPlain)
+  })
+
+  it('handles markdown syntax before the split', () => {
+    const md = '**Hello** ' + 'word '.repeat(120)
+    const full = markdownToText(md)
+    const after = bodyMarkdownAfterExcerptPrefix(md)
+    expect(full.substring(READING_EXCERPT_PLAIN_LENGTH).trimStart()).toBe(markdownToText(after).trimStart())
   })
 })

--- a/client/src/utils/markdown.ts
+++ b/client/src/utils/markdown.ts
@@ -25,6 +25,39 @@ export function markdownToText(markdown: string): string {
     .trim()
 }
 
+/** Plain-text length used for the reading-page excerpt (Read.vue); body starts after this prefix. */
+export const READING_EXCERPT_PLAIN_LENGTH = 200
+
+/**
+ * Returns the markdown that follows the first `excerptPlainLength` characters of plain text
+ * (same rules as {@link markdownToText}), so the essay body does not repeat the italic excerpt.
+ */
+export function bodyMarkdownAfterExcerptPrefix(
+  markdown: string,
+  excerptPlainLength: number = READING_EXCERPT_PLAIN_LENGTH
+): string {
+  if (!markdown.trim()) return ''
+  const fullPlain = markdownToText(markdown)
+  if (fullPlain.length <= excerptPlainLength) return ''
+  const target = fullPlain.substring(0, excerptPlainLength)
+
+  for (let i = 0; i <= markdown.length; i++) {
+    const p = markdownToText(markdown.slice(0, i))
+    if (p === target) {
+      return markdown.slice(i).trimStart()
+    }
+  }
+
+  for (let i = 0; i <= markdown.length; i++) {
+    const p = markdownToText(markdown.slice(0, i))
+    if (p.length >= excerptPlainLength && p.substring(0, excerptPlainLength) === target) {
+      return markdown.slice(i).trimStart()
+    }
+  }
+
+  return ''
+}
+
 /**
  * Strip Markdown syntax to get plain text for word counting.
  * Excludes headings, links, images, code fences, and other syntax tokens


### PR DESCRIPTION
Continues the essay body after the italic excerpt using `bodyMarkdownAfterExcerptPrefix()`, so opening lines are not duplicated. Short pieces show full text in the excerpt only; tests added.

Made with [Cursor](https://cursor.com)