### PR TITLE
Fix blank pages in book preview

### DIFF
--- a/client/src/components/manuscripts/BookPreviewModal.vue
+++ b/client/src/components/manuscripts/BookPreviewModal.vue
@@ -590,18 +590,17 @@ async function paginate() {
   const total = el.scrollWidth
   const count = Math.max(1, Math.round(total / contentWidth))
 
-  // Each "page" re-renders the same flow inside an overflow:hidden viewport,
-  // shifted left by i * contentWidth so that the i-th column is in view.
-  // Duplicating the flow is simpler than threading a single positioned flow
-  // through both pages of a spread, and keeps each page independently scrollable
-  // by future selection logic. Column counts are usually < 200 for realistic
-  // manuscripts so the DOM cost is acceptable.
+  // Each page re-renders the full flow at width = count * contentWidth so that
+  // every column is laid out side-by-side and positioned. The surrounding
+  // .bp-page-inner is overflow:hidden and only contentWidth wide, clipping
+  // everything except the column the inner flow's translateX scrolls into view.
+  const flowWidth = count * contentWidth
   const flowHtml = el.innerHTML
   const out: { html: string }[] = []
   for (let i = 0; i < count; i++) {
     out.push({
       html:
-        `<div class="bp-page-flow" style="width:${contentWidth}px;height:${contentHeight}px;column-width:${contentWidth}px;column-gap:0;column-fill:auto;transform:translateX(-${i * contentWidth}px);">` +
+        `<div class="bp-page-flow" style="width:${flowWidth}px;height:${contentHeight}px;column-width:${contentWidth}px;column-gap:0;column-fill:auto;transform:translateX(-${i * contentWidth}px);">` +
         flowHtml +
         `</div>`,
     })


### PR DESCRIPTION
## Summary

Fixes a regression in the just-merged book preview ([#75](https://github.com/DRCUOA/befly/pull/75)) where every page after the first rendered blank.

## Root cause

The per-page flow container was rendered at \`width: contentWidth\` (one column wide) with \`overflow: hidden\`. That meant only column 0 was positioned **inside** the flow box; columns 1, 2, 3… were laid out past the box's right edge and clipped at the **flow** level, before the \`translateX\` trick could shift them into the page viewport. Result: page 0 rendered correctly, every other page came up empty.

## Fix

Render each page's flow at \`width = count * contentWidth\` so every column is positioned inside the flow's bounding box. The surrounding \`.bp-page-inner\` (still \`overflow:hidden\`, sized to one column) clips everything except the column the inner flow's \`translateX\` exposes.

Visually identical when it works; the difference is purely structural.

## Test plan

- [ ] Open a manuscript with multiple chapters, click **Preview book**, **Open book**.
- [ ] Verify the title page renders on the first spread.
- [ ] Double-tap forward through several spreads. Verify pages 2, 3, 4, 5… all render text — no longer blank.
- [ ] Verify chapter title pages still land on their own page.
- [ ] Verify the page numbers in the bottom corner reflect the visible content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)