### PR TITLE
Add manuscript-scoped RAG layer

### DIFF
--- a/docs/rag.md
+++ b/docs/rag.md
@@ -1,0 +1,282 @@
+# Manuscript-scoped RAG layer
+
+## Overview
+
+The app supports many users, many writing fragments, and many manuscript
+projects per user. Every AI request that relates to a manuscript must
+draw context from **only that manuscript** — no cross-manuscript bleed,
+no global semantic search across the user's whole corpus.
+
+This document describes the layer that enforces and serves that
+guarantee. It lives in `server/src/services/rag/` and is invoked by:
+
+- `manuscript-assist.service.ts` — the gap-analysis assist mode (and any
+  future manuscript-level mode).
+- `writing-assist.service.ts` — the per-essay coherence mode, when the
+  essay belongs to a manuscript.
+- `scripts/rag-cli.ts` — admin / dev reindexing.
+
+## Why retrieval is manuscript-scoped
+
+The relational data layer already decides which writing blocks, beats,
+characters, motifs and uploaded files belong to which manuscript. The
+RAG layer respects those boundaries rather than re-deriving them with a
+free-text search across everything.
+
+Concretely:
+
+- The compiler reads only one manuscript's data per pass.
+- Every row it writes carries `manuscript_id` directly.
+- The retriever's SQL has `manuscript_id = $1` in the same `WHERE`
+  clause as the vector op.
+- `retrieveManuscriptContext` requires `manuscriptId` as a positional
+  argument; there is no global retrieval mode.
+
+## Data boundary model
+
+```
+users
+ └── manuscript_projects        ←──── ai_exchanges.manuscript_id  (FK)
+       ├── manuscript_sections
+       ├── manuscript_items  ──→ writing_blocks (re-usable across manuscripts)
+       ├── manuscript_artifacts
+       ├── characters / motifs / beats / silences / causal_links
+       ├── manuscript_uploaded_files  ──→ uploaded_files
+       │
+       ├── manuscript_context_sources   ←─ compiler writes here
+       ├── context_chunks               ←─ chunker writes here
+       └── context_embeddings           ←─ embedder writes here
+```
+
+Every RAG row pins to `manuscript_projects(id)` via `ON DELETE CASCADE`
+so deleting a manuscript also drops its context rows.
+
+A `writing_block` may be re-used across manuscripts. The compiler
+emits one context source per `(manuscript_id, writing_block_id)` pair,
+which is the right granularity: the block's body is the same, but its
+*role* in each manuscript is different.
+
+An `uploaded_file` is global per user but only enters the context layer
+when explicitly attached via `manuscript_uploaded_files` with
+`include_in_ai = true`.
+
+## `manuscript_context_sources`
+
+The compiler writes one row per AI-readable "document". Source rows
+carry:
+
+- `source_type` — what kind of thing it was compiled from (e.g.
+  `'character'`, `'beat'`, `'manuscript_item'`, `'uploaded_file'`).
+- `source_id` — UUID into the originating domain table, or NULL for
+  free-form notes.
+- `title`, `body` — the human-readable name and the prose the chunker
+  will split.
+- `metadata` — JSONB with whatever structured fields the origin row
+  had. Used for post-filtering in retrieval (character names,
+  movement, etc.).
+- `context_role` — what the source IS to the manuscript: `canon`,
+  `draft`, `research`, `character`, `plot`, etc.
+- `priority`, `canonical`, `status`, `include_in_ai` — retrieval knobs
+  (see *Retrieval scoring* below).
+- `content_hash` — SHA-256 of `title + body`. The compiler skips
+  rewrites when the hash matches.
+
+The unique index `(manuscript_id, source_type, source_id) WHERE
+source_id IS NOT NULL` lets the compiler upsert idempotently.
+
+## Context compiler
+
+`compileManuscriptContext(manuscriptId, options?)` reads:
+
+- `manuscript_projects` (the project itself + its literary direction)
+- `manuscript_sections`
+- `manuscript_items` (with their joined `writing_blocks`)
+- `writing_blocks` (one row per block linked to the manuscript)
+- `manuscript_artifacts` (only `draft` and `accepted` artifacts)
+- `characters` and `character_misreadings`
+- `motifs` and `motif_voice_variants`
+- `beats` (with POV character resolved)
+- `silences`
+- `causal_links` (with from/to beat names)
+- `manuscript_uploaded_files` joined to `uploaded_files`
+
+Each becomes a context source row via `manuscriptContextRepo.upsertSource`.
+
+The compiler runs in three modes:
+
+| Outcome      | When                                                                   |
+| ------------ | ---------------------------------------------------------------------- |
+| `created`    | The first time a (manuscript, source_type, source_id) is seen.         |
+| `updated`    | The body changed since the last compile (hash mismatch).               |
+| `unchanged`  | Hash matches and status is not `superseded` — no write happens.        |
+
+After upserting every active source, the compiler calls
+`markStaleAsSuperseded` to flip rows whose origin row no longer exists
+to `status = 'superseded'`. Retrieval excludes superseded rows by
+default, so a deleted character disappears from context immediately
+without losing audit history.
+
+## Chunking
+
+`chunkManuscriptContext(manuscriptId)` walks every active source and
+delegates to `chunkContextSource(source)`:
+
+- Approximate token count = `ceil(chars / 4)` (close enough for
+  budgeting; we don't pull in tiktoken for this).
+- Targets: ~800 tokens per chunk, ~120-token overlap (env-tunable).
+- Splits prefer paragraph breaks, fall back to sentences, and
+  hard-cut as a last resort.
+- A chunk's `content_hash` is the SHA-256 of its text. If the
+  aggregate hash of all chunks for a source matches what's already in
+  the DB, the rebuild is skipped — embeddings stay too.
+
+Chunks always carry `manuscript_id` directly (denormalised from the
+parent source) so retrieval can scope without a `JOIN`.
+
+## Embeddings
+
+Stored in `context_embeddings` using `pgvector`'s `vector(1536)`.
+
+- Dimension is fixed at 1536 in the migration to match
+  `text-embedding-3-small`. A different-dim model needs a separate
+  migration that adds a column or table — we do not let runtime config
+  silently mismatch the column type.
+- The `(chunk_id, embedding_model)` UNIQUE lets us coexist with
+  multiple embedding models in the future (e.g. small + large for
+  premium users) without breaking idempotent re-runs.
+- Index: `ivfflat (embedding vector_cosine_ops) WITH (lists = 100)`.
+  Sensible default for the corpus sizes a single manuscript produces.
+
+The provider client is injectable via `setEmbeddingClientForTests` —
+exactly the same hook the chat client uses. The default production
+client hits `https://api.openai.com/v1/embeddings` directly with no
+SDK dependency.
+
+`embedManuscriptContext(manuscriptId)` only embeds chunks that don't
+yet have a vector for the configured model. Re-running on an
+already-embedded manuscript is a no-op.
+
+## Retrieval scoring
+
+Vector search is cosine distance, converted to similarity as
+`1 - distance`. On top of that:
+
+| Signal                | Effect            |
+| --------------------- | ----------------- |
+| `canonical = true`    | +0.15             |
+| `status = 'accepted'` | +0.10             |
+| `priority`            | + priority / 1000 |
+| `status` rejected/archived/superseded | excluded by default |
+| `include_in_ai = false` | excluded always |
+
+Filters available on `RetrievalOptions`:
+
+- `sourceTypes`, `contextRoles` — narrow the search.
+- `characterNames`, `movement` — post-filters on metadata.
+- `topK`, `maxContextTokens` — bound the size of the result.
+- `includeArchived` — opt back into the rows that are excluded by
+  default.
+
+The retrieval helper short-circuits to an empty result if
+`stats.embeddings === 0` for the manuscript. This means:
+
+- Tests don't burn API tokens embedding a query against an empty
+  corpus.
+- The assist services degrade gracefully when a manuscript hasn't
+  been indexed yet.
+
+## AI prompt integration
+
+Both `manuscript-assist` and `writing-assist` already send
+`LlmRequestContext.manuscriptId` through to the OpenAI client; the
+client persists it on `ai_exchanges.manuscript_id` (migration 021).
+This makes every AI exchange queryable per-manuscript.
+
+The retrieval helper is invoked best-effort:
+
+```
+async function tryRetrieveContextPack(manuscriptId, query) {
+  try { ...retrieve... } catch { return '' }
+}
+```
+
+A non-empty `contextPack` is prepended to the user prompt as:
+
+```
+Use the retrieved manuscript context below as authoritative project
+memory unless the user explicitly overrides it.
+
+<retrieved_manuscript_context>
+{contextPack}
+</retrieved_manuscript_context>
+
+{...existing prompt...}
+```
+
+For the gap-analysis mode, retrieval is skipped when the user
+specified a single junction — they've already narrowed the scope and
+don't want surrounding manuscript content bleeding in.
+
+For the writing-assist `coherence` mode, retrieval fires when the
+essay belongs to a manuscript the caller can read.
+
+## Reindexing
+
+CLI commands (run from the `server/` directory):
+
+```
+npm run rag:compile -- --manuscript <id>
+npm run rag:chunk   -- --manuscript <id>
+npm run rag:embed   -- --manuscript <id>
+npm run rag:reindex -- --manuscript <id> [--force]
+npm run rag:search  -- --manuscript <id> --query "voice guide for Marcus"
+npm run rag:stats   -- --manuscript <id>
+npm run rag:list    -- --manuscript <id>
+```
+
+`reindex` runs compile → chunk → embed in one pass. `--force` salts
+the compile-stage hashes so every source rewrites and downstream
+chunks/embeddings rebuild from scratch. Use it after upgrading the
+compiler to a new prose template.
+
+## Environment variables
+
+| Var                       | Purpose                                  | Default                  |
+| ------------------------- | ---------------------------------------- | ------------------------ |
+| `OPENAI_API_KEY`          | Embeddings provider key                  | (required for embed)     |
+| `EMBEDDING_MODEL`         | OpenAI embeddings model id               | `text-embedding-3-small` |
+| `RAG_TOP_K`               | Default top-K for retrieval              | 8                        |
+| `RAG_MAX_CONTEXT_TOKENS`  | Default max-tokens for the context pack  | 4000                     |
+| `OPENAI_MODEL`            | Chat model used by the assist services   | `gpt-4o-mini`            |
+
+## Testing
+
+Tests live alongside the code in `server/src/services/rag/`:
+
+- `chunker.test.ts` — pure-logic, no DB, no LLM.
+- `manuscript-segregation.test.ts` — DB-backed; asserts the cross-
+  manuscript-leak guarantee with a deterministic fake embedder.
+
+The fake embedder produces unit vectors from a token-based hash so
+tests get stable ordering and similarity without an OpenAI key.
+Migrations through `022_manuscript_rag.sql` must be applied for
+DB-backed tests to run; if the local Postgres lacks the `vector`
+extension, migration 022 fails loudly — by design.
+
+## Known limitations
+
+- Uploaded-file bodies are not yet extracted. The compiler emits a
+  metadata-only context source for each attached upload; a follow-up
+  pipeline (PDF / DOCX extraction) is needed before file content
+  contributes to retrieval.
+- Re-ranking is a single-pass cosine search. For larger manuscripts a
+  second-stage cross-encoder rerank could improve precision; out of
+  scope here.
+- Hybrid (BM25 + vector) search is not implemented. PostgreSQL FTS
+  could be added with one more index and an OR clause in
+  `searchByVector`; the scoring rules already leave a slot for a
+  keyword signal.
+- Retrieval is best-effort in the assist services. If the RAG layer is
+  misconfigured the assist still runs, just without retrieval. This
+  was a deliberate degradation choice — we'd rather lose the
+  enhancement than fail an assist call.

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,14 @@
     "start": "node dist/index.js",
     "type-check": "tsc --noEmit",
     "test": "vitest run 2>&1 | tee test-results.log",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "rag:compile": "tsx scripts/rag-cli.ts compile",
+    "rag:chunk":   "tsx scripts/rag-cli.ts chunk",
+    "rag:embed":   "tsx scripts/rag-cli.ts embed",
+    "rag:reindex": "tsx scripts/rag-cli.ts reindex",
+    "rag:search":  "tsx scripts/rag-cli.ts search",
+    "rag:stats":   "tsx scripts/rag-cli.ts stats",
+    "rag:list":    "tsx scripts/rag-cli.ts list"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",

--- a/server/scripts/rag-cli.ts
+++ b/server/scripts/rag-cli.ts
@@ -1,0 +1,167 @@
+/**
+ * RAG admin CLI.
+ *
+ * Run with `npx tsx server/scripts/rag-cli.ts <command> [args...]`, or via
+ * the npm scripts in server/package.json:
+ *   npm run rag:compile    -- --manuscript <id>
+ *   npm run rag:chunk      -- --manuscript <id>
+ *   npm run rag:embed      -- --manuscript <id>
+ *   npm run rag:reindex    -- --manuscript <id> [--force]
+ *   npm run rag:search     -- --manuscript <id> --query "voice guide for Marcus"
+ *   npm run rag:stats      -- --manuscript <id>
+ *   npm run rag:list       -- --manuscript <id>
+ *
+ * The CLI is deliberately thin — it wires argv to the same service
+ * functions the AI assist code uses, so a CLI run and a server-side
+ * trigger produce identical state.
+ */
+import '../src/config/env-loader.js'
+
+import { closeDb } from '../src/config/db.js'
+import {
+  compileManuscriptContext,
+  chunkManuscriptContext,
+  embedManuscriptContext,
+  reindexManuscript,
+  retrieveManuscriptContext,
+  manuscriptContextStats,
+  listManuscriptContextSources,
+} from '../src/services/rag/index.js'
+
+interface ParsedArgs {
+  manuscript?: string
+  query?: string
+  force?: boolean
+  topK?: number
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {}
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--manuscript' || a === '-m') out.manuscript = argv[++i]
+    else if (a === '--query' || a === '-q') out.query = argv[++i]
+    else if (a === '--force') out.force = true
+    else if (a === '--topK' || a === '-k') out.topK = parseInt(argv[++i], 10)
+  }
+  return out
+}
+
+function requireManuscript(args: ParsedArgs): string {
+  if (!args.manuscript) {
+    throw new Error('--manuscript <id> is required')
+  }
+  return args.manuscript
+}
+
+async function main() {
+  const [, , cmd = 'help', ...rest] = process.argv
+  const args = parseArgs(rest)
+
+  switch (cmd) {
+    case 'compile': {
+      const id = requireManuscript(args)
+      const r = await compileManuscriptContext(id, { force: args.force })
+      console.log(JSON.stringify(r, null, 2))
+      break
+    }
+    case 'chunk': {
+      const id = requireManuscript(args)
+      const r = await chunkManuscriptContext(id)
+      console.log(JSON.stringify(r, null, 2))
+      break
+    }
+    case 'embed': {
+      const id = requireManuscript(args)
+      const r = await embedManuscriptContext(id)
+      console.log(JSON.stringify(r, null, 2))
+      break
+    }
+    case 'reindex': {
+      const id = requireManuscript(args)
+      const r = await reindexManuscript(id, { force: args.force })
+      console.log(JSON.stringify(r, null, 2))
+      break
+    }
+    case 'search': {
+      const id = requireManuscript(args)
+      if (!args.query) throw new Error('--query "..." is required for search')
+      const r = await retrieveManuscriptContext(id, args.query, { topK: args.topK ?? 8 })
+      // Pretty-print with the contextPack last so the headline (chunks)
+      // is easy to scan in a terminal.
+      console.log(JSON.stringify({
+        query: r.query,
+        chunkCount: r.chunks.length,
+        chunks: r.chunks.map(c => ({
+          score: c.score.toFixed(3),
+          title: c.title,
+          sourceType: c.sourceType,
+          contextRole: c.contextRole,
+          excerpt: c.text.slice(0, 200),
+        })),
+      }, null, 2))
+      console.log('\n---\nContext pack:\n')
+      console.log(r.contextPack)
+      break
+    }
+    case 'stats': {
+      const id = requireManuscript(args)
+      const r = await manuscriptContextStats(id)
+      console.log(JSON.stringify(r, null, 2))
+      break
+    }
+    case 'list': {
+      const id = requireManuscript(args)
+      const r = await listManuscriptContextSources(id)
+      console.log(JSON.stringify(r.map(s => ({
+        id: s.id,
+        sourceType: s.sourceType,
+        sourceId: s.sourceId,
+        title: s.title,
+        contextRole: s.contextRole,
+        status: s.status,
+        canonical: s.canonical,
+        priority: s.priority,
+        bodyChars: s.body?.length ?? 0,
+      })), null, 2))
+      break
+    }
+    case 'help':
+    case '--help':
+    case '-h':
+    case undefined:
+      console.log(`
+rag-cli — manuscript-scoped RAG admin commands
+
+Usage:
+  npx tsx server/scripts/rag-cli.ts <command> --manuscript <id> [...]
+
+Commands:
+  compile   Compile manuscript data into manuscript_context_sources.
+  chunk     Split context sources into chunks. Skips unchanged sources.
+  embed     Embed unembedded chunks via the configured EMBEDDING_MODEL.
+  reindex   compile + chunk + embed in one pass.
+  search    Manuscript-scoped semantic search. Requires --query.
+  stats     Show source/chunk/embedding counts for a manuscript.
+  list      List context sources for a manuscript (no chunks).
+
+Flags:
+  --manuscript, -m  UUID of the manuscript (required for every command)
+  --query, -q       Search query (search only)
+  --topK, -k        Top-K chunks (search only)
+  --force           Force re-compile / re-embed even if hashes match
+`)
+      break
+    default:
+      throw new Error(`Unknown command: ${cmd}. Run with --help.`)
+  }
+}
+
+main()
+  .then(() => closeDb().then(() => process.exit(0)))
+  .catch(async err => {
+    console.error('rag-cli error:', err instanceof Error ? err.message : String(err))
+    if (err instanceof Error && err.stack) console.error(err.stack)
+    try { await closeDb() } catch { /* ignore */ }
+    process.exit(1)
+  })

--- a/server/src/db/migrations/021_manuscript_data_boundaries.sql
+++ b/server/src/db/migrations/021_manuscript_data_boundaries.sql
@@ -1,0 +1,99 @@
+-- Migration 021: Manuscript data boundaries (Phase 2 of the RAG layer).
+--
+-- The RAG layer requires that every AI request can be traced back to a
+-- specific manuscript and that uploaded files (which today are global per
+-- user) carry an explicit manuscript membership before they can be used as
+-- AI context. This migration hardens those edges:
+--
+--   1. ai_exchanges.manuscript_id          — direct FK so the diagnostic
+--                                            log is queryable per-manuscript.
+--   2. uploaded_files.filename UNIQUE drop — filenames are not really
+--                                            global identifiers; the UUID is.
+--                                            Dropping the constraint allows
+--                                            two users (or two manuscripts)
+--                                            to keep the same source filename.
+--   3. manuscript_uploaded_files           — explicit join table for files
+--                                            attached to a manuscript with
+--                                            an AI-relevant role.
+--
+-- All steps are guarded so re-running the migration on an already-migrated
+-- database is a no-op.
+
+-- ---------- 1. ai_exchanges.manuscript_id ----------
+
+ALTER TABLE ai_exchanges
+  ADD COLUMN IF NOT EXISTS manuscript_id UUID
+  REFERENCES manuscript_projects(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS ai_exchanges_manuscript_id_created_idx
+  ON ai_exchanges(manuscript_id, created_at DESC);
+
+COMMENT ON COLUMN ai_exchanges.manuscript_id IS
+  'Manuscript whose context was used by this AI exchange. NULL for global/admin calls or feature surfaces that do not belong to a manuscript.';
+
+-- Backfill from the existing resource_type/resource_id pair so historical
+-- manuscript-assist rows stop looking like global calls in queries that join
+-- on manuscript_id. Writing-assist rows stay NULL — those rows were keyed on
+-- writing_block, and we don't want to guess which manuscript they touched
+-- (resolving via manuscript_items would be ambiguous when a block is in two
+-- manuscripts; the new code path will set manuscript_id explicitly).
+UPDATE ai_exchanges
+   SET manuscript_id = resource_id::uuid
+ WHERE manuscript_id IS NULL
+   AND resource_type = 'manuscript'
+   AND resource_id IS NOT NULL;
+
+-- ---------- 2. uploaded_files.filename ----------
+--
+-- Drop the global UNIQUE on filename. Two users can legitimately upload a
+-- file called "draft.docx"; the row's UUID is the real identifier. We drop
+-- the constraint by name (the IF EXISTS lets idempotent re-runs pass) and
+-- keep the existing non-unique index so lookup-by-filename still works.
+--
+-- We also recreate a non-unique index in the same statement so the planner
+-- doesn't lose the lookup path when the unique-backed index disappears.
+
+ALTER TABLE uploaded_files
+  DROP CONSTRAINT IF EXISTS uploaded_files_filename_key;
+
+-- Old code relied on idx_uploaded_files_filename (non-unique). It already
+-- exists in migration 015 — but recreate with IF NOT EXISTS in case some
+-- environments diverged.
+CREATE INDEX IF NOT EXISTS idx_uploaded_files_filename
+  ON uploaded_files(filename);
+
+-- ---------- 3. manuscript_uploaded_files ----------
+--
+-- Explicit join table. An uploaded file becomes AI-eligible only after the
+-- user explicitly attaches it here with include_in_ai = true. Without this
+-- table the RAG compiler has no way to know which of a user's many global
+-- uploads belong to which manuscript.
+--
+-- context_role lets the user describe what the file IS to the manuscript:
+-- a research note, a style guide, a draft, etc. Values mirror the
+-- manuscript_context_sources.context_role vocabulary so the compiler can
+-- pass the value straight through.
+
+CREATE TABLE IF NOT EXISTS manuscript_uploaded_files (
+  manuscript_id     UUID NOT NULL REFERENCES manuscript_projects(id) ON DELETE CASCADE,
+  uploaded_file_id  UUID NOT NULL REFERENCES uploaded_files(id) ON DELETE CASCADE,
+
+  context_role      VARCHAR(64) NOT NULL DEFAULT 'supporting',
+  include_in_ai     BOOLEAN NOT NULL DEFAULT TRUE,
+
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (manuscript_id, uploaded_file_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_uploaded_files_manuscript
+  ON manuscript_uploaded_files(manuscript_id);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_uploaded_files_file
+  ON manuscript_uploaded_files(uploaded_file_id);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_uploaded_files_include
+  ON manuscript_uploaded_files(manuscript_id, include_in_ai);
+
+COMMENT ON TABLE manuscript_uploaded_files IS
+  'Explicit membership: which uploaded files belong to which manuscript. Files become AI-eligible only via include_in_ai = true.';

--- a/server/src/db/migrations/022_manuscript_rag.sql
+++ b/server/src/db/migrations/022_manuscript_rag.sql
@@ -1,0 +1,170 @@
+-- Migration 022: Manuscript-scoped RAG layer (Phases 3, 5, 6 of the spec).
+--
+-- Three tables, one extension, all keyed on manuscript_id so the retrieval
+-- service can segregate by manuscript with a single WHERE clause:
+--
+--   manuscript_context_sources  one row per AI-readable document derived
+--                               from manuscript data. The compiler is the
+--                               only writer; the embedder reads the body.
+--   context_chunks              the source body split into retrievable
+--                               pieces. Carries manuscript_id directly so
+--                               retrieval doesn't need to JOIN to scope.
+--   context_embeddings          one vector per (chunk, embedding_model).
+--                               Same manuscript_id carry-forward so the
+--                               vector search filters cheaply.
+--
+-- Why pgvector over an external store: the rest of the app is already
+-- 100% Postgres. Adding a parallel store (Pinecone / Qdrant / etc.) for
+-- ~hundreds of chunks per manuscript would be a parallel architecture
+-- without a corresponding scale problem. If we later outgrow pgvector
+-- the chunk table is unchanged and only context_embeddings.embedding
+-- needs to move.
+--
+-- Embedding dimension: 1536 (OpenAI text-embedding-3-small / ada-002).
+-- A different-dim model needs a separate migration that creates a new
+-- column or a new table — we DO NOT try to vary `vector(N)` at runtime.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ---------- 1. manuscript_context_sources ----------
+--
+-- Compiled, AI-readable representations of manuscript data. The compiler
+-- writes one row per logical "document" (one character, one beat, one
+-- writing block, one uploaded file, etc.). The body is the text the
+-- chunker will split.
+--
+-- source_type + source_id let us trace a row back to the originating
+-- record so the retrieval layer can render a clickable provenance.
+-- (source_id has no FK because it points into N different tables.)
+
+CREATE TABLE IF NOT EXISTS manuscript_context_sources (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  manuscript_id   UUID NOT NULL REFERENCES manuscript_projects(id) ON DELETE CASCADE,
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+  source_type     VARCHAR(64) NOT NULL,
+  source_id       UUID,
+
+  title           TEXT NOT NULL,
+  body            TEXT,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  context_role    VARCHAR(64) NOT NULL DEFAULT 'supporting',
+  priority        INT NOT NULL DEFAULT 0,
+  status          VARCHAR(32) NOT NULL DEFAULT 'active',
+  canonical       BOOLEAN NOT NULL DEFAULT FALSE,
+  include_in_ai   BOOLEAN NOT NULL DEFAULT TRUE,
+
+  -- SHA-256 (or any stable hash) of the compiled body. The compiler uses
+  -- this to skip re-chunking and re-embedding when the source is unchanged.
+  content_hash    TEXT,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT check_mcs_status CHECK (status IN (
+    'active', 'draft', 'accepted', 'rejected', 'archived', 'superseded'
+  ))
+);
+
+CREATE INDEX IF NOT EXISTS manuscript_context_sources_manuscript_idx
+  ON manuscript_context_sources(manuscript_id);
+CREATE INDEX IF NOT EXISTS manuscript_context_sources_user_idx
+  ON manuscript_context_sources(user_id);
+CREATE INDEX IF NOT EXISTS manuscript_context_sources_type_idx
+  ON manuscript_context_sources(source_type);
+CREATE INDEX IF NOT EXISTS manuscript_context_sources_role_idx
+  ON manuscript_context_sources(context_role);
+CREATE INDEX IF NOT EXISTS manuscript_context_sources_status_idx
+  ON manuscript_context_sources(status);
+CREATE INDEX IF NOT EXISTS manuscript_context_sources_include_idx
+  ON manuscript_context_sources(include_in_ai);
+CREATE INDEX IF NOT EXISTS manuscript_context_sources_canonical_idx
+  ON manuscript_context_sources(canonical);
+
+-- The compiler reuses an existing source row when (manuscript_id, source_type,
+-- source_id) matches. NULL source_id is allowed (e.g. for free-form notes the
+-- user typed straight into the context layer), and PG treats two NULL
+-- source_ids as distinct, which is exactly what we want.
+CREATE UNIQUE INDEX IF NOT EXISTS manuscript_context_sources_origin_unique
+  ON manuscript_context_sources(manuscript_id, source_type, source_id)
+  WHERE source_id IS NOT NULL;
+
+COMMENT ON TABLE manuscript_context_sources IS
+  'Compiled AI-readable representations of manuscript data. The only table the chunker reads from.';
+
+-- ---------- 2. context_chunks ----------
+--
+-- Chunked, retrieval-ready pieces of a context source. The compiler+chunker
+-- pair guarantees that all chunks for a given source share its manuscript_id
+-- and content_hash, so re-chunking is cheap to detect and skip.
+
+CREATE TABLE IF NOT EXISTS context_chunks (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  manuscript_id       UUID NOT NULL REFERENCES manuscript_projects(id) ON DELETE CASCADE,
+  context_source_id   UUID NOT NULL REFERENCES manuscript_context_sources(id) ON DELETE CASCADE,
+
+  chunk_index         INT NOT NULL,
+  text                TEXT NOT NULL,
+  token_count         INT,
+  metadata            JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- SHA-256 of `text` so a no-op re-chunk pass can skip rebuilding when
+  -- the content is identical (and embeddings can stay).
+  content_hash        TEXT NOT NULL,
+
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS context_chunks_manuscript_idx
+  ON context_chunks(manuscript_id);
+CREATE INDEX IF NOT EXISTS context_chunks_source_idx
+  ON context_chunks(context_source_id);
+CREATE UNIQUE INDEX IF NOT EXISTS context_chunks_source_index_unique
+  ON context_chunks(context_source_id, chunk_index);
+
+COMMENT ON TABLE context_chunks IS
+  'Chunked text from manuscript_context_sources. Always carries manuscript_id for cheap scoped retrieval.';
+
+-- ---------- 3. context_embeddings ----------
+--
+-- One vector per (chunk, model). UNIQUE(chunk_id, embedding_model) lets the
+-- embedder upsert idempotently and lets us coexist with multiple embedding
+-- models if/when we move (e.g. swap in text-embedding-3-large for premium
+-- users without losing the small-model embeddings).
+--
+-- The IVFFlat index is created with a moderate `lists` value; the planner
+-- needs ANALYZE to use it well, and we set it up best-effort below. The
+-- index is a perf knob, not a correctness knob, so failure to create it
+-- on small dev installs is non-fatal — but the migration runner has
+-- ON_ERROR_STOP=1, so we keep it CREATE INDEX IF NOT EXISTS and any
+-- failure here will surface during `npm run migrate`.
+
+CREATE TABLE IF NOT EXISTS context_embeddings (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  manuscript_id   UUID NOT NULL REFERENCES manuscript_projects(id) ON DELETE CASCADE,
+  chunk_id        UUID NOT NULL REFERENCES context_chunks(id) ON DELETE CASCADE,
+
+  -- 1536 = text-embedding-3-small / ada-002. Different-dim models need
+  -- a new migration; this is intentional rather than a missing knob.
+  embedding       vector(1536) NOT NULL,
+  embedding_model VARCHAR(128) NOT NULL,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT context_embeddings_chunk_model_unique UNIQUE (chunk_id, embedding_model)
+);
+
+CREATE INDEX IF NOT EXISTS context_embeddings_manuscript_idx
+  ON context_embeddings(manuscript_id);
+
+-- IVFFlat with 100 lists is a sensible default for the small-to-medium
+-- corpus sizes a single user's manuscript will produce. Using cosine
+-- distance because the OpenAI text-embedding-3 series is normalized for
+-- cosine similarity (dot product on unit vectors == cosine).
+CREATE INDEX IF NOT EXISTS context_embeddings_ivfflat
+  ON context_embeddings
+  USING ivfflat (embedding vector_cosine_ops)
+  WITH (lists = 100);
+
+COMMENT ON TABLE context_embeddings IS
+  'pgvector embeddings for context chunks. Always filtered by manuscript_id at retrieval time.';

--- a/server/src/models/AiExchange.ts
+++ b/server/src/models/AiExchange.ts
@@ -24,6 +24,14 @@ export interface AiExchange {
   resourceType: string | null
   resourceId: string | null
 
+  /**
+   * The manuscript the AI exchange relates to, if any. Stored as a real FK
+   * so the diagnostic log is queryable per-manuscript without parsing
+   * resource_type/resource_id. NULL for feature surfaces that are not
+   * manuscript-scoped (e.g. admin tooling).
+   */
+  manuscriptId: string | null
+
   /** Provider details. */
   provider: string
   model: string
@@ -63,6 +71,8 @@ export interface CreateAiExchangeParams {
   mode?: string | null
   resourceType?: string | null
   resourceId?: string | null
+  /** Optional explicit manuscript pointer — see AiExchange.manuscriptId. */
+  manuscriptId?: string | null
 
   provider?: string
   model: string
@@ -90,4 +100,5 @@ export interface AiExchangeListFilter {
   status?: AiExchangeStatus
   userId?: string
   resourceId?: string
+  manuscriptId?: string
 }

--- a/server/src/models/ManuscriptContext.ts
+++ b/server/src/models/ManuscriptContext.ts
@@ -1,0 +1,161 @@
+/**
+ * Manuscript context / RAG-layer types.
+ *
+ * Three tables, three shapes:
+ *   - ManuscriptContextSource — one compiled, AI-readable document.
+ *     The compiler writes it; the chunker reads it.
+ *   - ContextChunk            — a retrievable piece of a source body.
+ *   - ContextEmbedding        — a vector for one chunk under one model.
+ *
+ * Strings (source_type, context_role, status) are kept narrow with
+ * unions rather than free-form so a typo doesn't silently bypass a
+ * filter at retrieval time. Adding a new source_type means updating
+ * this file *and* the compiler — both are deliberate.
+ */
+
+/** All source kinds the compiler may produce. */
+export type ContextSourceType =
+  | 'writing_block'
+  | 'manuscript_item'
+  | 'manuscript_artifact'
+  | 'manuscript_project'
+  | 'manuscript_section'
+  | 'character'
+  | 'character_misreading'
+  | 'beat'
+  | 'beat_knowledge'
+  | 'motif'
+  | 'motif_voice_variant'
+  | 'silence'
+  | 'causal_link'
+  | 'theme'
+  | 'uploaded_file'
+  | 'manual_note'
+  | 'research_note'
+  | 'style_guide'
+  | 'voice_guide'
+  | 'plot_guide'
+  | 'ai_output'
+  | 'other'
+
+/** What the source IS to the manuscript. Drives retrieval boosts and filters. */
+export type ContextRole =
+  | 'manuscript_text'
+  | 'canon'
+  | 'draft'
+  | 'research'
+  | 'character'
+  | 'plot'
+  | 'structure'
+  | 'voice'
+  | 'motif'
+  | 'continuity'
+  | 'style'
+  | 'ai_output'
+  | 'supporting'
+
+export type ContextStatus =
+  | 'active'
+  | 'draft'
+  | 'accepted'
+  | 'rejected'
+  | 'archived'
+  | 'superseded'
+
+export interface ManuscriptContextSource {
+  id: string
+  manuscriptId: string
+  userId: string
+
+  sourceType: ContextSourceType
+  /** Origin row's UUID, if the source was compiled from a domain table. */
+  sourceId: string | null
+
+  title: string
+  body: string | null
+  metadata: Record<string, unknown>
+
+  contextRole: ContextRole
+  priority: number
+  status: ContextStatus
+  canonical: boolean
+  includeInAi: boolean
+
+  contentHash: string | null
+
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ContextChunk {
+  id: string
+  manuscriptId: string
+  contextSourceId: string
+
+  chunkIndex: number
+  text: string
+  tokenCount: number | null
+  metadata: Record<string, unknown>
+  contentHash: string
+
+  createdAt: string
+}
+
+export interface ContextEmbeddingRow {
+  id: string
+  manuscriptId: string
+  chunkId: string
+  embeddingModel: string
+  createdAt: string
+  /** The vector itself is not loaded into the app layer except during retrieval. */
+}
+
+/* ----- Service-level shapes ----- */
+
+export interface CompileOptions {
+  /** Force re-write of all sources even if hashes match. Default false. */
+  force?: boolean
+  /** Restrict to specific source types (admin / partial reindex). */
+  sourceTypes?: ContextSourceType[]
+}
+
+export interface CompileResult {
+  manuscriptId: string
+  /** Source rows that were inserted, updated, or kept as-is. */
+  sources: { sourceType: ContextSourceType; sourceId: string | null; sourceRowId: string; action: 'created' | 'updated' | 'unchanged' }[]
+  /** Sources marked superseded because their domain row no longer exists. */
+  superseded: string[]
+  totalActive: number
+}
+
+export interface RetrievalOptions {
+  sourceTypes?: ContextSourceType[]
+  contextRoles?: ContextRole[]
+  characterNames?: string[]
+  movement?: string
+  status?: ContextStatus[]
+  topK?: number
+  maxContextTokens?: number
+  includeMetadata?: boolean
+  includeArchived?: boolean
+  rerank?: boolean
+}
+
+export interface RetrievedChunk {
+  chunkId: string
+  contextSourceId: string
+  manuscriptId: string
+  title: string
+  sourceType: ContextSourceType
+  contextRole: ContextRole
+  text: string
+  score: number
+  metadata: Record<string, unknown>
+}
+
+export interface RetrievedContext {
+  query: string
+  chunks: RetrievedChunk[]
+  /** Pre-rendered prompt block ready to be inlined into a system/user prompt. */
+  contextPack: string
+}

--- a/server/src/repositories/ai-exchange.repo.ts
+++ b/server/src/repositories/ai-exchange.repo.ts
@@ -33,6 +33,7 @@ const COLUMNS = `
   mode,
   resource_type      AS "resourceType",
   resource_id        AS "resourceId",
+  manuscript_id      AS "manuscriptId",
   provider,
   model,
   temperature,
@@ -67,6 +68,7 @@ function rowToAiExchange(row: Record<string, unknown>): AiExchange {
     mode: (row.mode as string | null) ?? null,
     resourceType: (row.resourceType as string | null) ?? null,
     resourceId: (row.resourceId as string | null) ?? null,
+    manuscriptId: (row.manuscriptId as string | null) ?? null,
     provider: row.provider as string,
     model: row.model as string,
     temperature: row.temperature == null ? null : Number(row.temperature),
@@ -105,6 +107,13 @@ export const aiExchangeRepo = {
       const requestChars   = (params.systemPrompt?.length ?? 0) + (params.userPrompt?.length ?? 0)
       const responseChars  = params.responseRaw?.length ?? 0
 
+      // Default manuscriptId from resource_type='manuscript' so any older
+      // call site that hasn't been updated still gets a usable manuscript_id
+      // on the row. New call sites set manuscriptId explicitly.
+      const manuscriptId = params.manuscriptId
+        ?? (params.resourceType === 'manuscript' ? params.resourceId : null)
+        ?? null
+
       const result = await pool.query(
         `
         INSERT INTO ai_exchanges (
@@ -113,6 +122,7 @@ export const aiExchangeRepo = {
           mode,
           resource_type,
           resource_id,
+          manuscript_id,
           provider,
           model,
           temperature,
@@ -131,12 +141,12 @@ export const aiExchangeRepo = {
           duration_ms,
           error_message
         ) VALUES (
-          $1,$2,$3,$4,$5,
-          $6,$7,$8,$9,
-          $10,$11,$12,
-          $13,$14,$15,$16,$17,
-          $18,$19,$20,
-          $21,$22
+          $1,$2,$3,$4,$5,$6,
+          $7,$8,$9,$10,
+          $11,$12,$13,
+          $14,$15,$16,$17,$18,
+          $19,$20,$21,
+          $22,$23
         )
         RETURNING ${COLUMNS}
         `,
@@ -146,6 +156,7 @@ export const aiExchangeRepo = {
           params.mode ?? null,
           params.resourceType ?? null,
           params.resourceId ?? null,
+          manuscriptId,
           params.provider ?? 'openai',
           params.model,
           params.temperature ?? null,
@@ -204,6 +215,10 @@ export const aiExchangeRepo = {
       params.push(filter.resourceId)
       where.push(`resource_id = $${params.length}`)
     }
+    if (filter.manuscriptId) {
+      params.push(filter.manuscriptId)
+      where.push(`manuscript_id = $${params.length}`)
+    }
     const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : ''
 
     params.push(limit)
@@ -242,6 +257,10 @@ export const aiExchangeRepo = {
     if (filter.resourceId) {
       params.push(filter.resourceId)
       where.push(`resource_id = $${params.length}`)
+    }
+    if (filter.manuscriptId) {
+      params.push(filter.manuscriptId)
+      where.push(`manuscript_id = $${params.length}`)
     }
     const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : ''
 

--- a/server/src/repositories/manuscript-context.repo.ts
+++ b/server/src/repositories/manuscript-context.repo.ts
@@ -1,0 +1,486 @@
+/**
+ * Manuscript context repository — DAO for the three RAG tables:
+ *   manuscript_context_sources, context_chunks, context_embeddings.
+ *
+ * Every read and write is keyed on manuscript_id so a misuse cannot
+ * silently leak rows from another manuscript. The retrieval helper
+ * `searchByVector` uses pgvector's cosine distance operator (`<=>`) and
+ * filters by manuscript_id in the same WHERE clause as the vector op,
+ * which is exactly the pattern pgvector's docs recommend for scoped
+ * search.
+ */
+import { pool } from '../config/db.js'
+import {
+  ContextChunk,
+  ContextRole,
+  ContextSourceType,
+  ContextStatus,
+  ManuscriptContextSource,
+} from '../models/ManuscriptContext.js'
+
+/* ---------- column projections ---------- */
+
+const SOURCE_COLUMNS = `
+  id,
+  manuscript_id  AS "manuscriptId",
+  user_id        AS "userId",
+  source_type    AS "sourceType",
+  source_id      AS "sourceId",
+  title,
+  body,
+  metadata,
+  context_role   AS "contextRole",
+  priority,
+  status,
+  canonical,
+  include_in_ai  AS "includeInAi",
+  content_hash   AS "contentHash",
+  created_at     AS "createdAt",
+  updated_at     AS "updatedAt"
+`
+
+const CHUNK_COLUMNS = `
+  id,
+  manuscript_id      AS "manuscriptId",
+  context_source_id  AS "contextSourceId",
+  chunk_index        AS "chunkIndex",
+  text,
+  token_count        AS "tokenCount",
+  metadata,
+  content_hash       AS "contentHash",
+  created_at         AS "createdAt"
+`
+
+/* ---------- types ---------- */
+
+export interface UpsertSourceInput {
+  manuscriptId: string
+  userId: string
+  sourceType: ContextSourceType
+  sourceId: string | null
+  title: string
+  body: string | null
+  metadata?: Record<string, unknown>
+  contextRole?: ContextRole
+  priority?: number
+  status?: ContextStatus
+  canonical?: boolean
+  includeInAi?: boolean
+  contentHash: string
+}
+
+export interface InsertChunkInput {
+  manuscriptId: string
+  contextSourceId: string
+  chunkIndex: number
+  text: string
+  tokenCount: number | null
+  metadata?: Record<string, unknown>
+  contentHash: string
+}
+
+export interface VectorSearchHit {
+  chunkId: string
+  contextSourceId: string
+  manuscriptId: string
+  title: string
+  sourceType: ContextSourceType
+  contextRole: ContextRole
+  status: ContextStatus
+  canonical: boolean
+  priority: number
+  text: string
+  tokenCount: number | null
+  sourceMetadata: Record<string, unknown>
+  chunkMetadata: Record<string, unknown>
+  /** Cosine distance (0 = identical, 2 = opposite). Smaller is more similar. */
+  distance: number
+}
+
+export interface VectorSearchOptions {
+  manuscriptId: string
+  embedding: number[]
+  embeddingModel: string
+  topK: number
+  sourceTypes?: ContextSourceType[]
+  contextRoles?: ContextRole[]
+  /** Status values to include. If omitted, defaults to ('active','accepted','draft'). */
+  status?: ContextStatus[]
+  includeArchived?: boolean
+}
+
+/* ---------- helpers ---------- */
+
+/**
+ * Render a JS number[] into the pgvector literal format: `[1,2,3]`.
+ * pg's parameter binding for the `vector` type accepts the literal as
+ * a string with an explicit cast, which is the form used throughout.
+ */
+function vectorLiteral(v: number[]): string {
+  return `[${v.join(',')}]`
+}
+
+/* ---------- repo ---------- */
+
+export const manuscriptContextRepo = {
+  /* ============================================================
+   *  Sources
+   * ============================================================ */
+
+  /**
+   * Upsert a context source by (manuscript_id, source_type, source_id).
+   * source_id = null is allowed for free-form sources (manual notes etc.);
+   * those rows are matched on (manuscript_id, source_type, title) instead.
+   * Returns the row plus an `unchanged` flag if the existing row's
+   * content_hash matched the incoming one.
+   */
+  async upsertSource(
+    input: UpsertSourceInput
+  ): Promise<{ source: ManuscriptContextSource; action: 'created' | 'updated' | 'unchanged' }> {
+    const existing = input.sourceId
+      ? await pool.query(
+          `SELECT ${SOURCE_COLUMNS} FROM manuscript_context_sources
+           WHERE manuscript_id = $1 AND source_type = $2 AND source_id = $3`,
+          [input.manuscriptId, input.sourceType, input.sourceId]
+        )
+      : await pool.query(
+          `SELECT ${SOURCE_COLUMNS} FROM manuscript_context_sources
+           WHERE manuscript_id = $1 AND source_type = $2 AND source_id IS NULL AND title = $3`,
+          [input.manuscriptId, input.sourceType, input.title]
+        )
+
+    if (existing.rows.length > 0) {
+      const row = existing.rows[0] as ManuscriptContextSource
+      if (row.contentHash === input.contentHash && row.status !== 'superseded') {
+        // Body unchanged — touch nothing so chunks/embeddings can stay.
+        return { source: row, action: 'unchanged' }
+      }
+      const updated = await pool.query(
+        `UPDATE manuscript_context_sources
+            SET title         = $1,
+                body          = $2,
+                metadata      = $3::jsonb,
+                context_role  = $4,
+                priority      = $5,
+                status        = $6,
+                canonical     = $7,
+                include_in_ai = $8,
+                content_hash  = $9,
+                user_id       = $10,
+                updated_at    = NOW()
+          WHERE id = $11
+          RETURNING ${SOURCE_COLUMNS}`,
+        [
+          input.title,
+          input.body,
+          JSON.stringify(input.metadata ?? {}),
+          input.contextRole ?? 'supporting',
+          input.priority ?? 0,
+          input.status ?? 'active',
+          input.canonical ?? false,
+          input.includeInAi ?? true,
+          input.contentHash,
+          input.userId,
+          row.id,
+        ]
+      )
+      return { source: updated.rows[0], action: 'updated' }
+    }
+
+    const inserted = await pool.query(
+      `INSERT INTO manuscript_context_sources (
+         manuscript_id, user_id, source_type, source_id,
+         title, body, metadata,
+         context_role, priority, status, canonical, include_in_ai,
+         content_hash
+       ) VALUES (
+         $1, $2, $3, $4,
+         $5, $6, $7::jsonb,
+         $8, $9, $10, $11, $12,
+         $13
+       )
+       RETURNING ${SOURCE_COLUMNS}`,
+      [
+        input.manuscriptId,
+        input.userId,
+        input.sourceType,
+        input.sourceId,
+        input.title,
+        input.body,
+        JSON.stringify(input.metadata ?? {}),
+        input.contextRole ?? 'supporting',
+        input.priority ?? 0,
+        input.status ?? 'active',
+        input.canonical ?? false,
+        input.includeInAi ?? true,
+        input.contentHash,
+      ]
+    )
+    return { source: inserted.rows[0], action: 'created' }
+  },
+
+  async listSources(
+    manuscriptId: string,
+    opts: { includeArchived?: boolean; sourceType?: ContextSourceType } = {}
+  ): Promise<ManuscriptContextSource[]> {
+    const where: string[] = ['manuscript_id = $1']
+    const params: unknown[] = [manuscriptId]
+    if (!opts.includeArchived) {
+      where.push(`status NOT IN ('archived','rejected','superseded')`)
+    }
+    if (opts.sourceType) {
+      params.push(opts.sourceType)
+      where.push(`source_type = $${params.length}`)
+    }
+    const result = await pool.query(
+      `SELECT ${SOURCE_COLUMNS}
+         FROM manuscript_context_sources
+        WHERE ${where.join(' AND ')}
+        ORDER BY canonical DESC, priority DESC, updated_at DESC`,
+      params
+    )
+    return result.rows
+  },
+
+  async findSourceById(id: string): Promise<ManuscriptContextSource | null> {
+    const r = await pool.query(
+      `SELECT ${SOURCE_COLUMNS} FROM manuscript_context_sources WHERE id = $1`,
+      [id]
+    )
+    return r.rows[0] ?? null
+  },
+
+  async deleteSource(id: string): Promise<void> {
+    await pool.query(`DELETE FROM manuscript_context_sources WHERE id = $1`, [id])
+  },
+
+  /**
+   * Mark every source row whose origin row no longer exists as superseded
+   * (rather than deleting). The retrieval layer excludes superseded rows
+   * by default; explicit reindexing can later re-promote them if the
+   * upstream record returns. Pass an array of (sourceType, sourceId)
+   * pairs that the compiler decided ARE current — anything else for the
+   * given manuscript transitions to 'superseded'.
+   */
+  async markStaleAsSuperseded(
+    manuscriptId: string,
+    keepers: { sourceType: ContextSourceType; sourceId: string | null }[]
+  ): Promise<string[]> {
+    // Build a (type, id) list of keepers. Postgres arrays don't natively
+    // express tuples, so we serialise into two parallel arrays and
+    // EXCEPT-style filter.
+    const types = keepers.map(k => k.sourceType)
+    const ids = keepers.map(k => k.sourceId ?? null)
+
+    const result = await pool.query(
+      `WITH keepers AS (
+         SELECT UNNEST($2::text[])  AS source_type,
+                UNNEST($3::uuid[])  AS source_id
+       )
+       UPDATE manuscript_context_sources s
+          SET status = 'superseded', updated_at = NOW()
+        WHERE s.manuscript_id = $1
+          AND s.status NOT IN ('superseded','rejected','archived')
+          AND NOT EXISTS (
+            SELECT 1 FROM keepers k
+             WHERE k.source_type = s.source_type
+               AND (k.source_id IS NOT DISTINCT FROM s.source_id)
+          )
+        RETURNING s.id`,
+      [manuscriptId, types, ids]
+    )
+    return result.rows.map(r => r.id as string)
+  },
+
+  /* ============================================================
+   *  Chunks
+   * ============================================================ */
+
+  async deleteChunksBySource(contextSourceId: string): Promise<void> {
+    await pool.query(
+      `DELETE FROM context_chunks WHERE context_source_id = $1`,
+      [contextSourceId]
+    )
+  },
+
+  async insertChunks(rows: InsertChunkInput[]): Promise<ContextChunk[]> {
+    if (rows.length === 0) return []
+    const out: ContextChunk[] = []
+    // Single-row inserts in a transaction are fine for the chunk volumes
+    // a single source produces (target ~10 chunks of ~700 tokens each).
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      for (const r of rows) {
+        const result = await client.query(
+          `INSERT INTO context_chunks (
+             manuscript_id, context_source_id, chunk_index,
+             text, token_count, metadata, content_hash
+           ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
+           RETURNING ${CHUNK_COLUMNS}`,
+          [
+            r.manuscriptId,
+            r.contextSourceId,
+            r.chunkIndex,
+            r.text,
+            r.tokenCount,
+            JSON.stringify(r.metadata ?? {}),
+            r.contentHash,
+          ]
+        )
+        out.push(result.rows[0])
+      }
+      await client.query('COMMIT')
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    } finally {
+      client.release()
+    }
+    return out
+  },
+
+  async listChunks(manuscriptId: string): Promise<ContextChunk[]> {
+    const r = await pool.query(
+      `SELECT ${CHUNK_COLUMNS} FROM context_chunks
+        WHERE manuscript_id = $1
+        ORDER BY context_source_id, chunk_index`,
+      [manuscriptId]
+    )
+    return r.rows
+  },
+
+  async listChunksBySource(contextSourceId: string): Promise<ContextChunk[]> {
+    const r = await pool.query(
+      `SELECT ${CHUNK_COLUMNS} FROM context_chunks
+        WHERE context_source_id = $1
+        ORDER BY chunk_index`,
+      [contextSourceId]
+    )
+    return r.rows
+  },
+
+  /** All chunks that have NO embedding for the given model. */
+  async listUnembeddedChunks(manuscriptId: string, embeddingModel: string): Promise<ContextChunk[]> {
+    const r = await pool.query(
+      `SELECT ${CHUNK_COLUMNS}
+         FROM context_chunks c
+        WHERE c.manuscript_id = $1
+          AND NOT EXISTS (
+            SELECT 1 FROM context_embeddings e
+             WHERE e.chunk_id = c.id AND e.embedding_model = $2
+          )
+        ORDER BY c.context_source_id, c.chunk_index`,
+      [manuscriptId, embeddingModel]
+    )
+    return r.rows
+  },
+
+  /* ============================================================
+   *  Embeddings
+   * ============================================================ */
+
+  async upsertEmbedding(
+    manuscriptId: string,
+    chunkId: string,
+    embedding: number[],
+    embeddingModel: string
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO context_embeddings (manuscript_id, chunk_id, embedding, embedding_model)
+       VALUES ($1, $2, $3::vector, $4)
+       ON CONFLICT (chunk_id, embedding_model) DO UPDATE
+         SET embedding = EXCLUDED.embedding,
+             manuscript_id = EXCLUDED.manuscript_id,
+             created_at = NOW()`,
+      [manuscriptId, chunkId, vectorLiteral(embedding), embeddingModel]
+    )
+  },
+
+  /**
+   * Vector search inside a single manuscript. Returns the top-K nearest
+   * chunks under cosine distance, joined to their source so the caller
+   * gets title/role/status/canonical/priority in one round-trip.
+   *
+   * The manuscript_id filter lives in the same WHERE clause as the
+   * vector op; pgvector's IVFFlat index respects equality predicates
+   * during search, so this is both correct AND fast.
+   */
+  async searchByVector(opts: VectorSearchOptions): Promise<VectorSearchHit[]> {
+    const where: string[] = [
+      'c.manuscript_id = $1',
+      'e.embedding_model = $2',
+      's.include_in_ai = TRUE',
+    ]
+    const params: unknown[] = [opts.manuscriptId, opts.embeddingModel]
+    let i = params.length
+
+    if (opts.sourceTypes && opts.sourceTypes.length > 0) {
+      params.push(opts.sourceTypes)
+      i = params.length
+      where.push(`s.source_type = ANY($${i}::text[])`)
+    }
+    if (opts.contextRoles && opts.contextRoles.length > 0) {
+      params.push(opts.contextRoles)
+      i = params.length
+      where.push(`s.context_role = ANY($${i}::text[])`)
+    }
+    if (opts.includeArchived) {
+      // No status filter at all.
+    } else if (opts.status && opts.status.length > 0) {
+      params.push(opts.status)
+      i = params.length
+      where.push(`s.status = ANY($${i}::text[])`)
+    } else {
+      where.push(`s.status IN ('active','accepted','draft')`)
+    }
+
+    params.push(vectorLiteral(opts.embedding))
+    const vecParam = `$${params.length}::vector`
+    params.push(opts.topK)
+    const limitParam = `$${params.length}`
+
+    const sql = `
+      SELECT
+        c.id                  AS "chunkId",
+        c.context_source_id   AS "contextSourceId",
+        c.manuscript_id       AS "manuscriptId",
+        c.text,
+        c.token_count         AS "tokenCount",
+        c.metadata            AS "chunkMetadata",
+        s.title,
+        s.source_type         AS "sourceType",
+        s.context_role        AS "contextRole",
+        s.status,
+        s.canonical,
+        s.priority,
+        s.metadata            AS "sourceMetadata",
+        (e.embedding <=> ${vecParam}) AS distance
+      FROM context_embeddings e
+      JOIN context_chunks c             ON c.id = e.chunk_id
+      JOIN manuscript_context_sources s ON s.id = c.context_source_id
+      WHERE ${where.join(' AND ')}
+      ORDER BY e.embedding <=> ${vecParam}
+      LIMIT ${limitParam}
+    `
+    const r = await pool.query(sql, params)
+    return r.rows as VectorSearchHit[]
+  },
+
+  /* ============================================================
+   *  Stats / housekeeping
+   * ============================================================ */
+
+  async stats(manuscriptId: string): Promise<{ sources: number; chunks: number; embeddings: number }> {
+    const r = await pool.query(
+      `
+      SELECT
+        (SELECT COUNT(*)::int FROM manuscript_context_sources WHERE manuscript_id = $1) AS sources,
+        (SELECT COUNT(*)::int FROM context_chunks            WHERE manuscript_id = $1) AS chunks,
+        (SELECT COUNT(*)::int FROM context_embeddings        WHERE manuscript_id = $1) AS embeddings
+      `,
+      [manuscriptId]
+    )
+    return r.rows[0] as { sources: number; chunks: number; embeddings: number }
+  },
+}

--- a/server/src/services/llm/llm-client.ts
+++ b/server/src/services/llm/llm-client.ts
@@ -29,6 +29,14 @@ export interface LlmRequestContext {
   /** Resource the call is about (e.g. writing_block id, manuscript id). */
   resourceType?: string | null
   resourceId?: string | null
+  /**
+   * Manuscript whose context the call relates to. Set this on every
+   * manuscript-scoped feature surface (manuscript-assist, writing-assist
+   * when the writing block belongs to a manuscript, story-craft, etc.) so
+   * the diagnostic log and any future per-manuscript audit can find the
+   * row without resolving resourceType/resourceId.
+   */
+  manuscriptId?: string | null
 }
 
 export interface LlmJsonRequest {

--- a/server/src/services/llm/openai-client.ts
+++ b/server/src/services/llm/openai-client.ts
@@ -147,6 +147,7 @@ class OpenAIClient implements LlmClient {
       mode:            req.context?.mode ?? null,
       resourceType:    req.context?.resourceType ?? null,
       resourceId:      req.context?.resourceId ?? null,
+      manuscriptId:    req.context?.manuscriptId ?? null,
       provider:        'openai',
       model,
       temperature:     reasoning ? null : (body.temperature as number),

--- a/server/src/services/manuscript-assist.service.ts
+++ b/server/src/services/manuscript-assist.service.ts
@@ -31,6 +31,8 @@ import { LlmClient, LlmConfigurationError } from './llm/llm-client.js'
 import { getOpenAIClient } from './llm/openai-client.js'
 import { ASSIST_SYSTEM_PROMPT, buildGapAnalysisPrompt, GapPromptItem } from './llm/prompts.js'
 import { ValidationError } from '../utils/errors.js'
+import { retrieveManuscriptContext } from './rag/index.js'
+import { logger } from '../utils/logger.js'
 
 /* ----- LLM client injection (for tests) ----- */
 
@@ -72,6 +74,35 @@ export interface RunAssistResult {
   /** Number of junctions skipped because either side had no body content. */
   skipped: number
   model?: string
+}
+
+/* ----- RAG retrieval helper (best-effort) -----
+ *
+ * The RAG layer is additive: if it isn't configured (no OPENAI_API_KEY,
+ * pgvector missing, no chunks indexed yet) the call falls back to
+ * "no retrieved context" rather than failing the assist run. This keeps
+ * the assist surface usable in dev/test environments where embedding
+ * infrastructure may not be set up, and means existing prompts
+ * deterministically work with or without retrieval.
+ */
+async function tryRetrieveContextPack(
+  manuscriptId: string,
+  query: string,
+  maxContextTokens = 2000
+): Promise<string> {
+  try {
+    const result = await retrieveManuscriptContext(manuscriptId, query, {
+      topK: 8,
+      maxContextTokens,
+    })
+    return result.chunks.length > 0 ? result.contextPack : ''
+  } catch (err) {
+    logger.warn('[manuscript-assist] retrieval skipped', {
+      manuscriptId,
+      message: err instanceof Error ? err.message : String(err),
+    })
+    return ''
+  }
 }
 
 /* ----- Helpers ----- */
@@ -298,7 +329,7 @@ async function runGapAnalysis(input: GapRunInput): Promise<RunAssistResult> {
       continue
     }
 
-    const prompt = buildGapAnalysisPrompt({
+    let prompt = buildGapAnalysisPrompt({
       manuscript,
       sectionTitle: findSectionTitle(sections, from, to),
       from,
@@ -306,17 +337,38 @@ async function runGapAnalysis(input: GapRunInput): Promise<RunAssistResult> {
       priorAcceptedNotes: priorNotes,
     })
 
+    // Augment with retrieved manuscript context UNLESS the caller targeted
+    // a specific junction — when they did, they've already narrowed scope
+    // and don't want the broader manuscript bleeding into the prompt.
+    // Best-effort: silently skipped if RAG isn't configured.
+    if (!junction) {
+      const query = `Junction: "${from.title}" -> "${to.title}". ` +
+        (manuscript.centralQuestion ? `Central question: ${manuscript.centralQuestion}. ` : '') +
+        (manuscript.throughLine ? `Through-line: ${manuscript.throughLine}.` : '')
+      const pack = await tryRetrieveContextPack(manuscript.id, query)
+      if (pack) {
+        prompt =
+          'Use the retrieved manuscript context below as authoritative project memory unless the user explicitly overrides it.\n\n' +
+          '<retrieved_manuscript_context>\n' +
+          pack + '\n' +
+          '</retrieved_manuscript_context>\n\n' +
+          prompt
+      }
+    }
+
     const response = await llm.chatJson({
       model: process.env.OPENAI_MODEL?.trim() || 'gpt-4o-mini',
       system: ASSIST_SYSTEM_PROMPT,
       user: prompt,
-      // Provenance for the diagnostic ai_exchanges log — see migration 019.
+      // Provenance for the diagnostic ai_exchanges log — see migration 019
+      // and migration 021 for the explicit manuscript_id column.
       context: {
         feature: 'manuscript-assist',
         mode: 'gaps',
         userId,
         resourceType: 'manuscript',
         resourceId: manuscript.id,
+        manuscriptId: manuscript.id,
       },
     })
     lastModel = response.model

--- a/server/src/services/rag/chunker.test.ts
+++ b/server/src/services/rag/chunker.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure-logic chunker tests — no DB or LLM access.
+ *
+ * Run with: npm test --workspace=server
+ */
+import { describe, it, expect } from 'vitest'
+import { chunkText } from './chunker.js'
+
+describe('chunkText', () => {
+  it('returns a single chunk for short input', () => {
+    const chunks = chunkText('A short paragraph.')
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].text).toBe('A short paragraph.')
+  })
+
+  it('returns no chunks for empty input', () => {
+    expect(chunkText('')).toEqual([])
+    expect(chunkText('   \n\n  ')).toEqual([])
+  })
+
+  it('splits long input on paragraph boundaries when possible', () => {
+    // Build a body that is well over the default char budget.
+    const para = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(20)
+    const body = Array.from({ length: 6 }, (_, i) => `Paragraph ${i + 1}. ${para}`).join('\n\n')
+    const chunks = chunkText(body, { targetTokens: 400, overlapTokens: 0 })
+    expect(chunks.length).toBeGreaterThan(1)
+    // Each chunk should be roughly within budget (allow generous slack).
+    for (const c of chunks) {
+      expect(c.text.length).toBeLessThan(400 * 4 * 2)
+    }
+    // Concatenating chunks should preserve all paragraph identifiers.
+    const joined = chunks.map(c => c.text).join('\n')
+    for (let i = 1; i <= 6; i++) {
+      expect(joined).toContain(`Paragraph ${i}.`)
+    }
+  })
+
+  it('respects target token budget on small inputs', () => {
+    const chunks = chunkText('Hello world.\n\nSecond paragraph here.\n\nThird one too.', {
+      targetTokens: 1000,
+    })
+    expect(chunks).toHaveLength(1)
+  })
+
+  it('produces at least one chunk for any non-empty input', () => {
+    const chunks = chunkText('a'.repeat(1000), { targetTokens: 100, overlapTokens: 0 })
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+    const total = chunks.reduce((acc, c) => acc + c.text.length, 0)
+    expect(total).toBeGreaterThan(0)
+  })
+
+  it('overlap mode prepends some prior tail onto subsequent chunks', () => {
+    const para = 'Sentence one. Sentence two. Sentence three. Sentence four. '.repeat(8)
+    const body = Array.from({ length: 5 }, () => para).join('\n\n')
+    const chunks = chunkText(body, { targetTokens: 200, overlapTokens: 60 })
+    if (chunks.length >= 2) {
+      // The second chunk should start with content drawn from the tail of
+      // the first chunk (overlap), so a substring from the first chunk
+      // should appear at or near the start of the second.
+      // We don't assert the exact substring (chunk boundaries depend on
+      // sentence search); we just assert chunks 1+ are longer than they'd
+      // be without overlap by checking total length is higher than the
+      // input length.
+      const total = chunks.reduce((acc, c) => acc + c.text.length, 0)
+      expect(total).toBeGreaterThan(body.length)
+    }
+  })
+})

--- a/server/src/services/rag/chunker.ts
+++ b/server/src/services/rag/chunker.ts
@@ -1,0 +1,245 @@
+/**
+ * Chunker — splits a manuscript_context_source body into retrievable
+ * pieces ready for embedding.
+ *
+ * Token counts are approximated as `ceil(chars / 4)` — the OpenAI tokenizer
+ * is a rough match for that ratio on English prose, and we don't want to
+ * pull in tiktoken just to chunk. Embedding cost is dominated by the
+ * vector call itself, not the count fudge factor here.
+ *
+ * Splitting prefers paragraph boundaries, then sentences, then a hard
+ * char-count cut as a last resort. We carry a small overlap (default 100
+ * approx-tokens) so a query that lands on the boundary between two chunks
+ * still has a chance of matching context on either side.
+ */
+
+import { createHash } from 'node:crypto'
+import { manuscriptContextRepo } from '../../repositories/manuscript-context.repo.js'
+import {
+  ContextChunk,
+  ManuscriptContextSource,
+} from '../../models/ManuscriptContext.js'
+import { logger } from '../../utils/logger.js'
+
+export interface ChunkOptions {
+  /** Target tokens per chunk. Default 800. */
+  targetTokens?: number
+  /** Approximate overlap between chunks. Default 120. */
+  overlapTokens?: number
+}
+
+const DEFAULT_TARGET = 800
+const DEFAULT_OVERLAP = 120
+const CHARS_PER_TOKEN = 4
+
+function approxTokens(chars: number): number {
+  return Math.max(1, Math.ceil(chars / CHARS_PER_TOKEN))
+}
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s).digest('hex')
+}
+
+/**
+ * Split a body into chunks. Algorithm:
+ *   1. Split on blank-line paragraph breaks.
+ *   2. Greedily fill a chunk up to the target token budget. Paragraphs
+ *      that single-handedly exceed the budget get sentence-split.
+ *   3. After emitting a chunk, overlap by ~overlapTokens of the tail
+ *      back onto the next chunk. Overlap respects sentence boundaries
+ *      where possible.
+ */
+export function chunkText(body: string, options: ChunkOptions = {}): { text: string; tokenCount: number }[] {
+  const targetTokens = options.targetTokens ?? DEFAULT_TARGET
+  const overlapTokens = options.overlapTokens ?? DEFAULT_OVERLAP
+
+  const targetChars = targetTokens * CHARS_PER_TOKEN
+  const overlapChars = overlapTokens * CHARS_PER_TOKEN
+
+  const trimmed = body.trim()
+  if (!trimmed) return []
+  if (approxTokens(trimmed.length) <= targetTokens) {
+    return [{ text: trimmed, tokenCount: approxTokens(trimmed.length) }]
+  }
+
+  // Step 1: paragraphs.
+  const paragraphs = trimmed.split(/\n{2,}/).map(p => p.trim()).filter(p => p.length > 0)
+
+  // Step 2: greedy fill, sentence-split if a paragraph exceeds budget.
+  const chunks: { text: string; tokenCount: number }[] = []
+  let buf: string[] = []
+  let bufLen = 0
+
+  const flush = () => {
+    if (buf.length === 0) return
+    const text = buf.join('\n\n').trim()
+    if (text) chunks.push({ text, tokenCount: approxTokens(text.length) })
+    buf = []
+    bufLen = 0
+  }
+
+  const addPiece = (piece: string) => {
+    const len = piece.length + (bufLen > 0 ? 2 : 0) // 2 for \n\n separator
+    if (bufLen > 0 && bufLen + len > targetChars) {
+      flush()
+    }
+    if (piece.length > targetChars) {
+      // Single piece bigger than the budget — sentence-split.
+      const sentences = splitIntoSentences(piece)
+      let inner: string[] = []
+      let innerLen = 0
+      for (const s of sentences) {
+        const sLen = s.length + (innerLen > 0 ? 1 : 0)
+        if (innerLen > 0 && innerLen + sLen > targetChars) {
+          buf.push(inner.join(' '))
+          bufLen = inner.join(' ').length
+          flush()
+          inner = []
+          innerLen = 0
+        }
+        inner.push(s)
+        innerLen += sLen
+      }
+      if (inner.length > 0) {
+        const tail = inner.join(' ')
+        buf.push(tail)
+        bufLen = tail.length
+      }
+      return
+    }
+    buf.push(piece)
+    bufLen += len
+  }
+
+  for (const p of paragraphs) addPiece(p)
+  flush()
+
+  // Step 3: overlap. Prepend a small tail of the previous chunk to the
+  // next one. We do this AFTER chunking rather than during so the
+  // primary chunk boundaries remain on natural breaks.
+  if (overlapChars > 0 && chunks.length > 1) {
+    for (let i = 1; i < chunks.length; i++) {
+      const prevTail = tailOnSentenceBoundary(chunks[i - 1].text, overlapChars)
+      if (prevTail) {
+        const merged = `${prevTail}\n\n${chunks[i].text}`
+        chunks[i] = { text: merged, tokenCount: approxTokens(merged.length) }
+      }
+    }
+  }
+
+  return chunks
+}
+
+/** Split into sentences on . ! ? followed by whitespace. Leaves quotes intact. */
+function splitIntoSentences(s: string): string[] {
+  const out: string[] = []
+  const re = /[^.!?]+[.!?]+(?:["')\]]+)?\s*/g
+  let lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(s)) !== null) {
+    out.push(m[0].trim())
+    lastIndex = re.lastIndex
+  }
+  if (lastIndex < s.length) out.push(s.slice(lastIndex).trim())
+  return out.filter(x => x.length > 0)
+}
+
+/** Take the last `n` chars of s, snapped back to a sentence boundary if reasonable. */
+function tailOnSentenceBoundary(s: string, n: number): string {
+  if (s.length <= n) return s
+  const slice = s.slice(-n)
+  // Find the first sentence boundary inside the slice; everything before it is fragment.
+  const m = slice.search(/[.!?]\s+/)
+  if (m === -1 || m > slice.length - 20) return slice
+  return slice.slice(m + 1).trim()
+}
+
+/* ----- Public service entry point ----- */
+
+export interface ChunkSourceResult {
+  contextSourceId: string
+  rebuilt: boolean
+  chunkCount: number
+}
+
+/**
+ * (Re)chunk a single context source. If the source's chunks already
+ * cover the same content (matched by their concatenated content_hash)
+ * this is a no-op. Otherwise existing chunks are deleted and the new
+ * set is inserted. Embeddings cascade-delete with chunks via FK.
+ */
+export async function chunkContextSource(
+  source: ManuscriptContextSource,
+  options: ChunkOptions = {}
+): Promise<ChunkSourceResult> {
+  if (!source.body || !source.body.trim()) {
+    // Empty body — clear any leftover chunks so retrieval doesn't return
+    // stale text after a body has been blanked out.
+    await manuscriptContextRepo.deleteChunksBySource(source.id)
+    return { contextSourceId: source.id, rebuilt: true, chunkCount: 0 }
+  }
+
+  const newChunks = chunkText(source.body, options)
+  const newAggregateHash = sha256(newChunks.map(c => c.text).join('\n----\n'))
+
+  // Compare against the existing chunk set's hash. The repo doesn't
+  // currently store a per-source aggregate, so we derive it from the
+  // existing rows. This is bounded by chunk count per source (~10) so
+  // it's cheap.
+  const existing = await manuscriptContextRepo.listChunksBySource(source.id)
+  const existingAggregateHash = existing.length === 0
+    ? null
+    : sha256(existing.map(c => c.text).join('\n----\n'))
+
+  if (existingAggregateHash && existingAggregateHash === newAggregateHash) {
+    return { contextSourceId: source.id, rebuilt: false, chunkCount: existing.length }
+  }
+
+  // Wipe and rebuild. Embeddings cascade.
+  await manuscriptContextRepo.deleteChunksBySource(source.id)
+  await manuscriptContextRepo.insertChunks(
+    newChunks.map((c, i) => ({
+      manuscriptId: source.manuscriptId,
+      contextSourceId: source.id,
+      chunkIndex: i,
+      text: c.text,
+      tokenCount: c.tokenCount,
+      metadata: {
+        sourceTitle: source.title,
+        sourceType: source.sourceType,
+        contextRole: source.contextRole,
+      },
+      contentHash: sha256(c.text),
+    }))
+  )
+
+  return { contextSourceId: source.id, rebuilt: true, chunkCount: newChunks.length }
+}
+
+/**
+ * Chunk every active source for a manuscript. Sources whose body is
+ * already represented by their existing chunks are skipped.
+ */
+export async function chunkManuscriptContext(
+  manuscriptId: string,
+  options: ChunkOptions = {}
+): Promise<{ rebuiltSources: number; totalChunks: number; totalSources: number }> {
+  const sources = await manuscriptContextRepo.listSources(manuscriptId, { includeArchived: false })
+  let rebuiltSources = 0
+  let totalChunks = 0
+  for (const s of sources) {
+    const r = await chunkContextSource(s, options)
+    if (r.rebuilt) rebuiltSources += 1
+    totalChunks += r.chunkCount
+  }
+  logger.info('[rag.chunk] done', {
+    manuscriptId,
+    totalSources: sources.length,
+    rebuiltSources,
+    totalChunks,
+  })
+  return { rebuiltSources, totalChunks, totalSources: sources.length }
+}
+
+/** Re-export for tests. */
+export type { ContextChunk }

--- a/server/src/services/rag/compile-context.service.ts
+++ b/server/src/services/rag/compile-context.service.ts
@@ -1,0 +1,630 @@
+/**
+ * Manuscript context compiler.
+ *
+ * Reads everything that belongs to one manuscript and writes a clean,
+ * AI-readable representation of it into manuscript_context_sources. The
+ * compiler is the ONLY component that decides which domain rows turn
+ * into which context sources — every other RAG component (chunker,
+ * embedder, retriever) operates on the compiled rows alone.
+ *
+ * Why a compile step at all (rather than embedding domain rows directly):
+ *   - Domain rows are JSON-shaped (characters.voice is JSONB, beats has
+ *     20+ nullable text fields). Embedding raw JSON yields meaningless
+ *     vectors — the model needs prose.
+ *   - Membership rules differ per source. A writing_block is only in a
+ *     manuscript if a manuscript_item links it. The compiler is the
+ *     single place those rules live.
+ *   - Idempotency. content_hash on the compiled body lets us short-
+ *     circuit chunking + embedding when nothing actually changed, which
+ *     is the common case (the user edited one beat, not the whole book).
+ *
+ * Manuscript-segregation guarantee: every source row written here carries
+ * the manuscript_id of the manuscript being compiled. The compiler never
+ * reads cross-manuscript data, and never writes to a different manuscript.
+ */
+
+import { createHash } from 'node:crypto'
+import { pool } from '../../config/db.js'
+import { manuscriptContextRepo } from '../../repositories/manuscript-context.repo.js'
+import {
+  CompileOptions,
+  CompileResult,
+  ContextRole,
+  ContextSourceType,
+} from '../../models/ManuscriptContext.js'
+import { logger } from '../../utils/logger.js'
+
+/* ----- helpers ----- */
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s).digest('hex')
+}
+
+function normaliseBody(s: string | null | undefined): string {
+  if (!s) return ''
+  return s.replace(/\r\n/g, '\n').replace(/[ \t]+\n/g, '\n').trim()
+}
+
+function bullet(label: string, value: string | null | undefined): string {
+  if (!value || !value.trim()) return ''
+  return `${label}: ${value.trim()}\n`
+}
+
+function listOrNull(arr: string[] | null | undefined): string | null {
+  if (!arr || arr.length === 0) return null
+  return arr.join(' · ')
+}
+
+function mapToText(obj: Record<string, unknown> | null | undefined): string {
+  if (!obj || typeof obj !== 'object') return ''
+  const lines: string[] = []
+  for (const [k, v] of Object.entries(obj)) {
+    if (v == null) continue
+    if (typeof v === 'string' && !v.trim()) continue
+    if (Array.isArray(v)) {
+      if (v.length === 0) continue
+      lines.push(`  ${k}: ${v.map(x => String(x)).join(', ')}`)
+    } else if (typeof v === 'object') {
+      lines.push(`  ${k}: ${JSON.stringify(v)}`)
+    } else {
+      lines.push(`  ${k}: ${String(v)}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+/* ----- compiled-source factory ----- */
+
+interface CompiledSource {
+  sourceType: ContextSourceType
+  sourceId: string | null
+  title: string
+  body: string
+  metadata: Record<string, unknown>
+  contextRole: ContextRole
+  priority?: number
+  canonical?: boolean
+  includeInAi?: boolean
+}
+
+/* ----- per-table compilers ----- */
+
+async function compileManuscriptProject(manuscriptId: string): Promise<{ ownerId: string; source: CompiledSource } | null> {
+  const r = await pool.query(
+    `SELECT id, user_id, title, working_subtitle, form, status,
+            intended_reader, central_question, through_line,
+            emotional_arc, narrative_promise
+       FROM manuscript_projects
+      WHERE id = $1`,
+    [manuscriptId]
+  )
+  if (r.rows.length === 0) return null
+  const m = r.rows[0]
+  const body =
+    `Manuscript: ${m.title}\n` +
+    bullet('Subtitle', m.working_subtitle) +
+    bullet('Form', m.form) +
+    bullet('Status', m.status) +
+    bullet('Intended reader', m.intended_reader) +
+    bullet('Central question', m.central_question) +
+    bullet('Through-line', m.through_line) +
+    bullet('Emotional arc', m.emotional_arc) +
+    bullet('Narrative promise', m.narrative_promise)
+  return {
+    ownerId: m.user_id,
+    source: {
+      sourceType: 'manuscript_project',
+      sourceId: m.id,
+      title: `Manuscript Direction: ${m.title}`,
+      body: body.trim(),
+      metadata: { form: m.form, status: m.status },
+      contextRole: 'structure',
+      priority: 100,
+      canonical: true,
+    },
+  }
+}
+
+async function compileSections(manuscriptId: string): Promise<CompiledSource[]> {
+  const r = await pool.query(
+    `SELECT id, title, order_index, purpose, notes
+       FROM manuscript_sections
+      WHERE manuscript_id = $1
+      ORDER BY order_index`,
+    [manuscriptId]
+  )
+  return r.rows.map(row => ({
+    sourceType: 'manuscript_section' as ContextSourceType,
+    sourceId: row.id,
+    title: `Section ${row.order_index}: ${row.title}`,
+    body: (
+      `Section: ${row.title}\n` +
+      bullet('Purpose', row.purpose) +
+      bullet('Notes', row.notes)
+    ).trim(),
+    metadata: { orderIndex: row.order_index, purpose: row.purpose },
+    contextRole: 'structure',
+    priority: 60,
+  }))
+}
+
+async function compileItemsAndWritingBlocks(manuscriptId: string): Promise<CompiledSource[]> {
+  // Pull items joined to their writing block (if any) and section title.
+  const r = await pool.query(
+    `SELECT mi.id          AS item_id,
+            mi.title       AS item_title,
+            mi.item_type,
+            mi.structural_role,
+            mi.summary,
+            mi.ai_notes,
+            mi.order_index,
+            wb.id          AS wb_id,
+            wb.title       AS wb_title,
+            wb.body        AS wb_body,
+            ms.title       AS section_title
+       FROM manuscript_items mi
+       LEFT JOIN writing_blocks      wb ON wb.id = mi.writing_block_id
+       LEFT JOIN manuscript_sections ms ON ms.id = mi.section_id
+      WHERE mi.manuscript_id = $1
+      ORDER BY mi.order_index`,
+    [manuscriptId]
+  )
+
+  const out: CompiledSource[] = []
+  // Track writing_blocks we've already emitted so a block re-used in two
+  // items still produces one writing_block source row, not two.
+  const emittedBlockIds = new Set<string>()
+
+  for (const row of r.rows) {
+    // 1. The item itself — captures structural metadata even when there
+    //    is no body yet (placeholder, bridge, etc.).
+    const itemBody =
+      `Manuscript Item: ${row.item_title}\n` +
+      bullet('Item type', row.item_type) +
+      bullet('Structural role', row.structural_role) +
+      bullet('Section', row.section_title) +
+      bullet('Summary', row.summary) +
+      bullet('AI notes', row.ai_notes) +
+      bullet('Source writing block title', row.wb_title) +
+      (row.wb_body ? `\nSource writing block body:\n${normaliseBody(row.wb_body).slice(0, 8000)}` : '')
+
+    out.push({
+      sourceType: 'manuscript_item',
+      sourceId: row.item_id,
+      title: `Item: ${row.item_title}`,
+      body: itemBody.trim(),
+      metadata: {
+        itemType: row.item_type,
+        orderIndex: row.order_index,
+        sectionTitle: row.section_title ?? null,
+        writingBlockId: row.wb_id ?? null,
+      },
+      contextRole: 'manuscript_text',
+      priority: 80,
+      canonical: row.item_type === 'essay',
+    })
+
+    // 2. The writing block (essay body) as its own source so retrieval
+    //    can match against the prose itself, not just the item title.
+    if (row.wb_id && !emittedBlockIds.has(row.wb_id) && row.wb_body) {
+      emittedBlockIds.add(row.wb_id)
+      out.push({
+        sourceType: 'writing_block',
+        sourceId: row.wb_id,
+        title: row.wb_title || row.item_title,
+        body: normaliseBody(row.wb_body),
+        metadata: { itemId: row.item_id },
+        contextRole: 'manuscript_text',
+        priority: 90,
+        canonical: true,
+      })
+    }
+  }
+  return out
+}
+
+async function compileArtifacts(manuscriptId: string): Promise<CompiledSource[]> {
+  const r = await pool.query(
+    `SELECT id, type, title, content, status, source_model
+       FROM manuscript_artifacts
+      WHERE manuscript_id = $1
+        AND status IN ('draft','accepted')`,
+    [manuscriptId]
+  )
+  return r.rows.map(row => ({
+    sourceType: 'manuscript_artifact' as ContextSourceType,
+    sourceId: row.id,
+    title: `Artifact (${row.type}): ${row.title}`,
+    body: (
+      `Artifact: ${row.title}\n` +
+      bullet('Type', row.type) +
+      bullet('Status', row.status) +
+      bullet('Source model', row.source_model) +
+      (row.content
+        ? `\nContent:\n${typeof row.content === 'string' ? row.content : JSON.stringify(row.content, null, 2)}`
+        : '')
+    ).trim(),
+    metadata: { type: row.type, status: row.status },
+    contextRole: 'ai_output',
+    priority: row.status === 'accepted' ? 70 : 30,
+    // 'accepted' artifacts are treated as accepted-status context sources;
+    // 'draft' artifacts stay 'draft'. Retrieval boosts accepted automatically.
+    // This is set indirectly via status in run().
+  }))
+}
+
+async function compileCharacters(manuscriptId: string): Promise<CompiledSource[]> {
+  const charRows = await pool.query(
+    `SELECT id, name, full_name, role, social_position,
+            contradiction, public_want, private_want, hidden_need,
+            greatest_fear, false_belief, wound, voice,
+            arc_phases, plot_functions, notes
+       FROM characters
+      WHERE manuscript_id = $1`,
+    [manuscriptId]
+  )
+
+  const misRows = await pool.query(
+    `SELECT id, character_id, label, why
+       FROM character_misreadings
+      WHERE character_id IN (SELECT id FROM characters WHERE manuscript_id = $1)
+      ORDER BY order_index`,
+    [manuscriptId]
+  )
+
+  const out: CompiledSource[] = []
+  for (const c of charRows.rows) {
+    const voiceText = mapToText(c.voice as Record<string, unknown> | null)
+    const body =
+      `Character: ${c.name}\n` +
+      bullet('Full name', c.full_name) +
+      bullet('Role', c.role) +
+      bullet('Social position', c.social_position) +
+      bullet('Contradiction', c.contradiction) +
+      bullet('Public want', c.public_want) +
+      bullet('Private want', c.private_want) +
+      bullet('Hidden need', c.hidden_need) +
+      bullet('Greatest fear', c.greatest_fear) +
+      bullet('False belief', c.false_belief) +
+      bullet('Wound', c.wound) +
+      (voiceText ? `Voice:\n${voiceText}\n` : '') +
+      bullet('Arc phases', listOrNull(c.arc_phases as string[])) +
+      bullet('Plot functions', listOrNull(c.plot_functions as string[])) +
+      bullet('Notes', c.notes)
+    out.push({
+      sourceType: 'character',
+      sourceId: c.id,
+      title: `Character: ${c.name}`,
+      body: body.trim(),
+      metadata: { characterName: c.name, characterId: c.id },
+      contextRole: 'character',
+      priority: 95,
+      canonical: true,
+    })
+  }
+
+  // Misreadings are emitted as their own small sources so a query about
+  // "what does X get wrong about Y?" can land directly on one.
+  for (const m of misRows.rows) {
+    const character = charRows.rows.find(c => c.id === m.character_id)
+    out.push({
+      sourceType: 'character_misreading',
+      sourceId: m.id,
+      title: `Misreading: ${character?.name ?? '(unknown)'} — ${m.label}`,
+      body: (
+        `Character: ${character?.name ?? '(unknown)'}\n` +
+        bullet('Misreading', m.label) +
+        bullet('Why', m.why)
+      ).trim(),
+      metadata: { characterId: m.character_id, characterName: character?.name ?? null },
+      contextRole: 'character',
+      priority: 50,
+    })
+  }
+  return out
+}
+
+async function compileBeats(manuscriptId: string): Promise<CompiledSource[]> {
+  const beats = await pool.query(
+    `SELECT b.id, b.label, b.title, b.timeline_point, b.movement, b.order_index,
+            b.outer_event, b.inner_turn, b.voice_constraint, b.final_image,
+            b.scene_function_type, b.withholding_level,
+            b.unique_perception, b.blind_spot, b.misreading,
+            b.reader_inference, b.reason_for_next_pov_switch,
+            c.name AS pov_name, c.id AS pov_id
+       FROM beats b
+       LEFT JOIN characters c ON c.id = b.pov_character_id
+      WHERE b.manuscript_id = $1
+      ORDER BY b.order_index`,
+    [manuscriptId]
+  )
+
+  const out: CompiledSource[] = []
+  for (const b of beats.rows) {
+    const titleBit = b.title || b.label || `Beat ${b.order_index}`
+    const body =
+      `Beat ${b.order_index}: ${titleBit}\n` +
+      bullet('Label', b.label) +
+      bullet('Timeline point', b.timeline_point) +
+      bullet('Movement', b.movement) +
+      bullet('POV character', b.pov_name) +
+      bullet('Outer event', b.outer_event) +
+      bullet('Inner turn', b.inner_turn) +
+      bullet('Voice constraint', b.voice_constraint) +
+      bullet('Final image', b.final_image) +
+      bullet('Scene function', b.scene_function_type) +
+      bullet('Withholding level', b.withholding_level) +
+      bullet('Unique perception', b.unique_perception) +
+      bullet('Blind spot', b.blind_spot) +
+      bullet('Misreading', b.misreading) +
+      bullet('Reader inference', b.reader_inference) +
+      bullet('Reason for next POV switch', b.reason_for_next_pov_switch)
+    out.push({
+      sourceType: 'beat',
+      sourceId: b.id,
+      title: `Beat ${b.order_index}: ${titleBit}`,
+      body: body.trim(),
+      metadata: {
+        orderIndex: b.order_index,
+        movement: b.movement,
+        povCharacterId: b.pov_id ?? null,
+        povCharacterName: b.pov_name ?? null,
+      },
+      contextRole: 'plot',
+      priority: 75,
+    })
+  }
+  return out
+}
+
+async function compileMotifs(manuscriptId: string): Promise<CompiledSource[]> {
+  const motifs = await pool.query(
+    `SELECT m.id, m.name, m.function,
+            COALESCE(json_agg(
+              json_build_object('character', c.name, 'meaning', mvv.meaning)
+              ORDER BY c.name
+            ) FILTER (WHERE c.id IS NOT NULL), '[]'::json) AS variants
+       FROM motifs m
+       LEFT JOIN motif_voice_variants mvv ON mvv.motif_id = m.id
+       LEFT JOIN characters c            ON c.id = mvv.character_id
+      WHERE m.manuscript_id = $1
+      GROUP BY m.id`,
+    [manuscriptId]
+  )
+
+  return motifs.rows.map(m => {
+    const variants = m.variants as { character: string | null; meaning: string | null }[]
+    const variantText = variants.length === 0
+      ? ''
+      : '\nVoice variants:\n' + variants
+          .map(v => `- ${v.character ?? '(?)'}: ${v.meaning ?? ''}`)
+          .join('\n')
+    const body = (
+      `Motif: ${m.name}\n` +
+      bullet('Function', m.function) +
+      variantText
+    ).trim()
+    return {
+      sourceType: 'motif' as ContextSourceType,
+      sourceId: m.id,
+      title: `Motif: ${m.name}`,
+      body,
+      metadata: { motifName: m.name },
+      contextRole: 'motif',
+      priority: 65,
+    }
+  })
+}
+
+async function compileSilencesAndCausals(manuscriptId: string): Promise<CompiledSource[]> {
+  const out: CompiledSource[] = []
+
+  const silences = await pool.query(
+    `SELECT s.id, s.what_unsaid, s.why, s.consequence, s.silence_type,
+            c.name AS character_name
+       FROM silences s
+       LEFT JOIN characters c ON c.id = s.character_id
+      WHERE s.manuscript_id = $1`,
+    [manuscriptId]
+  )
+  for (const s of silences.rows) {
+    out.push({
+      sourceType: 'silence',
+      sourceId: s.id,
+      title: `Silence: ${s.what_unsaid.slice(0, 80)}`,
+      body: (
+        `Silence (${s.silence_type ?? 'unspecified'})\n` +
+        bullet('Character', s.character_name) +
+        bullet('What is unsaid', s.what_unsaid) +
+        bullet('Why', s.why) +
+        bullet('Consequence', s.consequence)
+      ).trim(),
+      metadata: { characterName: s.character_name ?? null, silenceType: s.silence_type },
+      contextRole: 'continuity',
+      priority: 45,
+    })
+  }
+
+  const causals = await pool.query(
+    `SELECT cl.id, cl.link_type, cl.note,
+            f.title AS from_title, f.label AS from_label, f.order_index AS from_order,
+            t.title AS to_title,   t.label AS to_label,   t.order_index AS to_order
+       FROM causal_links cl
+       JOIN beats f ON f.id = cl.from_beat_id
+       JOIN beats t ON t.id = cl.to_beat_id
+      WHERE cl.manuscript_id = $1`,
+    [manuscriptId]
+  )
+  for (const c of causals.rows) {
+    const fromName = c.from_title || c.from_label || `Beat ${c.from_order}`
+    const toName = c.to_title || c.to_label || `Beat ${c.to_order}`
+    out.push({
+      sourceType: 'causal_link',
+      sourceId: c.id,
+      title: `Causal: ${fromName} → ${toName} (${c.link_type})`,
+      body: (
+        `Causal link (${c.link_type})\n` +
+        `From: ${fromName}\n` +
+        `To:   ${toName}\n` +
+        bullet('Note', c.note)
+      ).trim(),
+      metadata: { linkType: c.link_type },
+      contextRole: 'plot',
+      priority: 40,
+    })
+  }
+  return out
+}
+
+async function compileUploadedFiles(manuscriptId: string): Promise<CompiledSource[]> {
+  // Only files explicitly attached to the manuscript via the join table
+  // (migration 021) and marked include_in_ai. The body column is
+  // intentionally a placeholder pointing at the file metadata — binary
+  // content is handled by a separate pipeline (out of scope here).
+  const r = await pool.query(
+    `SELECT uf.id, uf.filename, uf.content_type, uf.size_bytes,
+            muf.context_role, muf.include_in_ai
+       FROM manuscript_uploaded_files muf
+       JOIN uploaded_files uf ON uf.id = muf.uploaded_file_id
+      WHERE muf.manuscript_id = $1
+        AND muf.include_in_ai = TRUE`,
+    [manuscriptId]
+  )
+  const out: CompiledSource[] = []
+  for (const f of r.rows) {
+    const role = (f.context_role as ContextRole) ?? 'supporting'
+    out.push({
+      sourceType: 'uploaded_file',
+      sourceId: f.id,
+      title: `Uploaded file: ${f.filename}`,
+      body: (
+        `Uploaded file: ${f.filename}\n` +
+        bullet('Content type', f.content_type) +
+        bullet('Size', f.size_bytes ? `${f.size_bytes} bytes` : null) +
+        bullet('Context role', role) +
+        '\n[File content is not extracted into the context layer in this version.]'
+      ).trim(),
+      metadata: { filename: f.filename, contentType: f.content_type, sizeBytes: f.size_bytes },
+      contextRole: role,
+      priority: 30,
+    })
+  }
+  return out
+}
+
+/* ----- public API ----- */
+
+export interface CompileManuscriptContextDeps {
+  /** Override hook for tests; default reads ownership via SQL. */
+  loadOwnerId?: (manuscriptId: string) => Promise<string | null>
+}
+
+/**
+ * Compile every context source for a manuscript.
+ *
+ * Idempotent: rows with unchanged content_hash are left alone, so a
+ * second compile pass with no upstream changes does no writes. Rows that
+ * used to exist but no longer do (e.g. a deleted character) are marked
+ * 'superseded' rather than deleted, so retrieval excludes them by
+ * default but their history is preserved.
+ */
+export async function compileManuscriptContext(
+  manuscriptId: string,
+  options: CompileOptions = {},
+  deps: CompileManuscriptContextDeps = {}
+): Promise<CompileResult> {
+  const project = await compileManuscriptProject(manuscriptId)
+  if (!project) throw new Error(`compileManuscriptContext: manuscript ${manuscriptId} not found`)
+  const ownerId = deps.loadOwnerId
+    ? await deps.loadOwnerId(manuscriptId)
+    : project.ownerId
+  if (!ownerId) throw new Error(`compileManuscriptContext: cannot determine owner for ${manuscriptId}`)
+
+  const all: CompiledSource[] = []
+  all.push(project.source)
+  all.push(...await compileSections(manuscriptId))
+  all.push(...await compileItemsAndWritingBlocks(manuscriptId))
+  // For artifacts, the status field on the source row mirrors the artifact
+  // status (accepted/draft) — we set it via metadata first, then translate
+  // when upserting below.
+  const artifacts = await compileArtifacts(manuscriptId)
+  all.push(...artifacts)
+  all.push(...await compileCharacters(manuscriptId))
+  all.push(...await compileBeats(manuscriptId))
+  all.push(...await compileMotifs(manuscriptId))
+  all.push(...await compileSilencesAndCausals(manuscriptId))
+  all.push(...await compileUploadedFiles(manuscriptId))
+
+  const filterTypes = options.sourceTypes && options.sourceTypes.length > 0
+    ? new Set(options.sourceTypes)
+    : null
+  const planned = filterTypes
+    ? all.filter(s => filterTypes.has(s.sourceType))
+    : all
+
+  const result: CompileResult = {
+    manuscriptId,
+    sources: [],
+    superseded: [],
+    totalActive: 0,
+  }
+
+  // Resolve artifact status -> source.status: artifact 'accepted' becomes
+  // a context source 'accepted' (which retrieval boosts); 'draft' stays
+  // 'draft'. For non-artifact sources we use the default 'active'.
+  const upsertOne = async (s: CompiledSource) => {
+    const status: 'active' | 'draft' | 'accepted' = s.sourceType === 'manuscript_artifact'
+      ? ((s.metadata?.status === 'accepted') ? 'accepted' : 'draft')
+      : 'active'
+    // Salting the hash with a per-run nonce when `force` is true forces
+    // every existing row to look stale, so the compiler rewrites and the
+    // chunker/embedder downstream rebuild from scratch.
+    const forceSalt = options.force ? `\nFORCE:${Date.now()}-${Math.random()}` : ''
+    const hash = sha256(`${s.title}\n${s.body}${forceSalt}`)
+    return manuscriptContextRepo.upsertSource({
+      manuscriptId,
+      userId: ownerId,
+      sourceType: s.sourceType,
+      sourceId: s.sourceId,
+      title: s.title,
+      body: s.body,
+      metadata: s.metadata,
+      contextRole: s.contextRole,
+      priority: s.priority ?? 0,
+      status,
+      canonical: s.canonical ?? false,
+      includeInAi: s.includeInAi ?? true,
+      contentHash: hash,
+    })
+  }
+
+  // Track keepers so the supersede pass can find what's gone.
+  const keepers: { sourceType: ContextSourceType; sourceId: string | null }[] = []
+
+  for (const s of planned) {
+    const { source, action } = await upsertOne(s)
+    keepers.push({ sourceType: s.sourceType, sourceId: s.sourceId })
+    result.sources.push({
+      sourceType: s.sourceType,
+      sourceId: s.sourceId,
+      sourceRowId: source.id,
+      action,
+    })
+  }
+
+  // Anything not in keepers transitions to 'superseded'. Skip this when
+  // the caller scoped the run to specific source types — they're not
+  // claiming completeness across all types.
+  if (!filterTypes) {
+    const superseded = await manuscriptContextRepo.markStaleAsSuperseded(manuscriptId, keepers)
+    result.superseded = superseded
+  }
+
+  result.totalActive = result.sources.length
+  logger.info('[rag.compile] done', {
+    manuscriptId,
+    totalActive: result.totalActive,
+    superseded: result.superseded.length,
+  })
+  return result
+}

--- a/server/src/services/rag/embed.service.ts
+++ b/server/src/services/rag/embed.service.ts
@@ -1,0 +1,192 @@
+/**
+ * Embedding provider + service.
+ *
+ * Provider interface (`EmbeddingClient`) keeps the rest of the RAG
+ * layer ignorant of where vectors come from — exactly the same pattern
+ * `LlmClient` uses for chat completions. Tests inject a deterministic
+ * fake; production code uses the OpenAI embeddings endpoint via fetch
+ * (no SDK dependency, mirroring openai-client.ts).
+ *
+ * Configuration:
+ *   EMBEDDING_MODEL  — required at runtime; default 'text-embedding-3-small'
+ *                       (1536 dim, matches the migration's vector(1536)).
+ *   OPENAI_API_KEY   — required for the production client.
+ *
+ * Idempotency: embedManuscriptContext only embeds chunks that don't yet
+ * have an embedding for the configured model. Re-running on an already-
+ * embedded manuscript is a no-op.
+ */
+
+import { manuscriptContextRepo } from '../../repositories/manuscript-context.repo.js'
+import { LlmConfigurationError, LlmRequestError } from '../llm/llm-client.js'
+import { logger } from '../../utils/logger.js'
+
+export interface EmbeddingClient {
+  /** Model id this client is configured for (used to key context_embeddings). */
+  readonly model: string
+  /** Vector dimension. Must match the schema (1536 in migration 022). */
+  readonly dimension: number
+  embedText(text: string): Promise<number[]>
+  embedBatch(texts: string[]): Promise<number[][]>
+}
+
+const DEFAULT_MODEL = 'text-embedding-3-small'
+const DEFAULT_DIMENSION = 1536
+const ENDPOINT = 'https://api.openai.com/v1/embeddings'
+const MAX_BATCH = 64
+
+/* ----- OpenAI implementation ----- */
+
+class OpenAIEmbeddingClient implements EmbeddingClient {
+  readonly model: string
+  readonly dimension: number
+  private apiKey: string
+
+  constructor(apiKey: string, model: string, dimension: number) {
+    this.apiKey = apiKey
+    this.model = model
+    this.dimension = dimension
+  }
+
+  async embedText(text: string): Promise<number[]> {
+    const [v] = await this.embedBatch([text])
+    return v
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return []
+    // Split into provider-friendly batches.
+    const out: number[][] = []
+    for (let i = 0; i < texts.length; i += MAX_BATCH) {
+      const slice = texts.slice(i, i + MAX_BATCH)
+      const vectors = await this.callOnce(slice)
+      out.push(...vectors)
+    }
+    return out
+  }
+
+  private async callOnce(texts: string[]): Promise<number[][]> {
+    const start = Date.now()
+    const body = {
+      model: this.model,
+      input: texts,
+    }
+    let response: Response
+    try {
+      response = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new LlmRequestError(`Embedding network error: ${message}`)
+    }
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new LlmRequestError(
+        `OpenAI embeddings returned ${response.status}: ${text.slice(0, 500)}`,
+        response.status
+      )
+    }
+    const payload = await response.json() as {
+      data?: { embedding?: number[]; index?: number }[]
+    }
+    const data = payload.data ?? []
+    // Sort by index to be safe — the API documents stable order but we'd
+    // rather not silently misalign vectors with their input on a quirk.
+    data.sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+    const vectors = data.map(d => d.embedding ?? [])
+    if (vectors.length !== texts.length) {
+      throw new LlmRequestError(
+        `OpenAI embeddings: expected ${texts.length} vectors, got ${vectors.length}`
+      )
+    }
+    for (const v of vectors) {
+      if (v.length !== this.dimension) {
+        throw new LlmRequestError(
+          `Embedding dimension mismatch: got ${v.length}, expected ${this.dimension}. ` +
+          `Configured model: ${this.model}. The vector(N) column must match.`
+        )
+      }
+    }
+    logger.debug('[embed] batch ok', { model: this.model, count: texts.length, ms: Date.now() - start })
+    return vectors
+  }
+}
+
+/* ----- Factory + test injection ----- */
+
+let activeClient: EmbeddingClient | null = null
+
+/** Tests inject a deterministic embedder so we don't burn API tokens. */
+export function setEmbeddingClientForTests(client: EmbeddingClient | null): void {
+  activeClient = client
+}
+
+export function getEmbeddingClient(): EmbeddingClient {
+  if (activeClient) return activeClient
+  const model = process.env.EMBEDDING_MODEL?.trim() || DEFAULT_MODEL
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey || apiKey.trim() === '') {
+    throw new LlmConfigurationError(
+      'OPENAI_API_KEY is not set. Embedding is unavailable until the key is configured.'
+    )
+  }
+  // Hard-coded to 1536 because that's the dimension of the production
+  // model AND the vector column shape. Override only by changing both
+  // the migration and this constant in lockstep.
+  activeClient = new OpenAIEmbeddingClient(apiKey, model, DEFAULT_DIMENSION)
+  return activeClient
+}
+
+export function resetEmbeddingClientCache(): void {
+  activeClient = null
+}
+
+/* ----- Public service ----- */
+
+/**
+ * Embed every unembedded chunk in the manuscript. Idempotent: chunks
+ * that already have an embedding for the configured model are skipped.
+ */
+export async function embedManuscriptContext(
+  manuscriptId: string
+): Promise<{ embedded: number; skipped: number; total: number; model: string }> {
+  const client = getEmbeddingClient()
+  const pending = await manuscriptContextRepo.listUnembeddedChunks(manuscriptId, client.model)
+
+  if (pending.length === 0) {
+    const stats = await manuscriptContextRepo.stats(manuscriptId)
+    return { embedded: 0, skipped: stats.chunks, total: stats.chunks, model: client.model }
+  }
+
+  // Batch up to MAX_BATCH at a time. The provider call is the slow part;
+  // the upsert is fast enough not to pipeline further.
+  let embedded = 0
+  for (let i = 0; i < pending.length; i += MAX_BATCH) {
+    const slice = pending.slice(i, i + MAX_BATCH)
+    const vectors = await client.embedBatch(slice.map(c => c.text))
+    for (let j = 0; j < slice.length; j++) {
+      await manuscriptContextRepo.upsertEmbedding(
+        manuscriptId,
+        slice[j].id,
+        vectors[j],
+        client.model
+      )
+      embedded += 1
+    }
+  }
+
+  const stats = await manuscriptContextRepo.stats(manuscriptId)
+  logger.info('[rag.embed] done', { manuscriptId, embedded, total: stats.chunks, model: client.model })
+  return {
+    embedded,
+    skipped: stats.chunks - embedded,
+    total: stats.chunks,
+    model: client.model,
+  }
+}

--- a/server/src/services/rag/index.ts
+++ b/server/src/services/rag/index.ts
@@ -1,0 +1,68 @@
+/**
+ * RAG service barrel.
+ *
+ * Public API used by AI call sites and the CLI:
+ *   compileManuscriptContext  — turn manuscript data into context sources
+ *   chunkManuscriptContext    — split sources into chunks
+ *   embedManuscriptContext    — embed chunks (idempotent)
+ *   reindexManuscript         — compile + chunk + embed in one call
+ *   retrieveManuscriptContext — manuscript-scoped semantic search
+ *   buildPromptWithContext    — wrap a userRequest with the retrieved pack
+ *
+ * Repo helpers also re-exported so admin/CLI commands have one import.
+ */
+
+import { compileManuscriptContext } from './compile-context.service.js'
+import { chunkManuscriptContext } from './chunker.js'
+import { embedManuscriptContext } from './embed.service.js'
+import { manuscriptContextRepo } from '../../repositories/manuscript-context.repo.js'
+
+export { compileManuscriptContext } from './compile-context.service.js'
+export { chunkManuscriptContext, chunkContextSource, chunkText } from './chunker.js'
+export {
+  embedManuscriptContext,
+  setEmbeddingClientForTests,
+  getEmbeddingClient,
+  resetEmbeddingClientCache,
+  type EmbeddingClient,
+} from './embed.service.js'
+export {
+  retrieveManuscriptContext,
+  buildPromptWithContext,
+} from './retrieve.service.js'
+
+export const listManuscriptContextSources = (manuscriptId: string) =>
+  manuscriptContextRepo.listSources(manuscriptId)
+
+export const listContextChunks = (manuscriptId: string) =>
+  manuscriptContextRepo.listChunks(manuscriptId)
+
+export const deleteManuscriptContextSource = (contextSourceId: string) =>
+  manuscriptContextRepo.deleteSource(contextSourceId)
+
+export const manuscriptContextStats = (manuscriptId: string) =>
+  manuscriptContextRepo.stats(manuscriptId)
+
+/**
+ * Compile + chunk + embed in one pass. Idempotent at every stage:
+ * unchanged sources are skipped at the compile step, unchanged chunks
+ * are skipped at the chunk step, already-embedded chunks are skipped at
+ * the embed step.
+ *
+ * Pass `force: true` to bypass the compile-stage hash short-circuit
+ * (which forces chunks and embeddings to rebuild downstream too).
+ */
+export async function reindexManuscript(
+  manuscriptId: string,
+  options: { force?: boolean } = {}
+): Promise<{
+  manuscriptId: string
+  compile: Awaited<ReturnType<typeof compileManuscriptContext>>
+  chunk: Awaited<ReturnType<typeof chunkManuscriptContext>>
+  embed: Awaited<ReturnType<typeof embedManuscriptContext>>
+}> {
+  const compile = await compileManuscriptContext(manuscriptId, { force: options.force })
+  const chunk = await chunkManuscriptContext(manuscriptId)
+  const embed = await embedManuscriptContext(manuscriptId)
+  return { manuscriptId, compile, chunk, embed }
+}

--- a/server/src/services/rag/manuscript-segregation.test.ts
+++ b/server/src/services/rag/manuscript-segregation.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Manuscript segregation tests.
+ *
+ * Load-bearing test for the RAG layer: retrieval MUST NEVER return
+ * chunks from a manuscript other than the one passed in. We verify
+ * this by:
+ *   1. Creating two users and one manuscript per user.
+ *   2. Compiling, chunking, and embedding both manuscripts with a
+ *      deterministic fake embedder.
+ *   3. Querying manuscript A and asserting every returned chunk's
+ *      manuscriptId === A.id (and the same for B).
+ *   4. Crafting a query that semantically matches B's content best,
+ *      retrieving against A, and asserting the response is empty
+ *      OR contains only A-scoped chunks.
+ *
+ * Tests also cover:
+ *   - canonical sources getting boosted
+ *   - rejected/superseded sources being excluded by default
+ *   - hash-based skip on unchanged sources
+ *   - uploaded files only appearing when explicitly attached
+ *   - ai_exchanges storing manuscript_id (verified via the LLM context
+ *     boundary in the assist tests, not here)
+ *
+ * Requires: DATABASE_URL in .env, migrations applied through 022.
+ * If pgvector isn't installed locally, migration 022 will fail and these
+ * tests won't run — by design.
+ */
+import '../../config/env-loader.js'
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { pool } from '../../config/db.js'
+import { manuscriptService } from '../manuscript.service.js'
+import { manuscriptContextRepo } from '../../repositories/manuscript-context.repo.js'
+import {
+  compileManuscriptContext,
+  chunkManuscriptContext,
+  embedManuscriptContext,
+  retrieveManuscriptContext,
+  setEmbeddingClientForTests,
+  type EmbeddingClient,
+} from './index.js'
+
+const tag = `rag_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+
+let userA = ''
+let userB = ''
+
+/**
+ * Deterministic embedder: each text is hashed into a fixed-dimension
+ * unit vector so identical text gets identical vectors and similar
+ * text gets cosine-close vectors. Good enough to test ordering and
+ * filtering without a real model.
+ */
+class FakeEmbeddingClient implements EmbeddingClient {
+  readonly model = 'fake-embed-model'
+  readonly dimension = 1536
+
+  async embedText(text: string): Promise<number[]> {
+    return this.embed(text)
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return texts.map(t => this.embed(t))
+  }
+
+  private embed(text: string): number[] {
+    // Map every character to a position via simple modulo. We add 0.1 to
+    // a few positions per character so two texts that share many words
+    // produce close vectors, while disjoint texts produce far vectors.
+    const v = new Array<number>(this.dimension).fill(0)
+    const norm = text.toLowerCase().replace(/[^a-z0-9 ]/g, ' ')
+    const tokens = norm.split(/\s+/).filter(Boolean)
+    for (const tok of tokens) {
+      let h = 0
+      for (let i = 0; i < tok.length; i++) {
+        h = (h * 31 + tok.charCodeAt(i)) | 0
+      }
+      const idx = ((h % this.dimension) + this.dimension) % this.dimension
+      v[idx] += 1
+    }
+    // Normalize so cosine similarity = dot product.
+    let mag = 0
+    for (const x of v) mag += x * x
+    mag = Math.sqrt(mag) || 1
+    return v.map(x => x / mag)
+  }
+}
+
+async function createUser(label: string): Promise<string> {
+  const r = await pool.query(
+    `INSERT INTO users (email, password_hash, display_name, status)
+     VALUES ($1, 'x', $2, 'active') RETURNING id`,
+    [`${tag}_${label}@example.test`, `${tag} ${label}`]
+  )
+  return r.rows[0].id
+}
+
+async function createWritingBlock(userId: string, title: string, body: string): Promise<string> {
+  const r = await pool.query(
+    `INSERT INTO writing_blocks (user_id, title, body, visibility)
+     VALUES ($1, $2, $3, 'private') RETURNING id`,
+    [userId, title, body]
+  )
+  return r.rows[0].id
+}
+
+async function deleteUserCascade(userId: string): Promise<void> {
+  // Manuscripts cascade-delete sources/chunks/embeddings via FKs.
+  await pool.query(`DELETE FROM users WHERE id = $1`, [userId])
+}
+
+beforeAll(async () => {
+  setEmbeddingClientForTests(new FakeEmbeddingClient())
+  userA = await createUser('userA')
+  userB = await createUser('userB')
+})
+
+afterAll(async () => {
+  setEmbeddingClientForTests(null)
+  if (userA) await deleteUserCascade(userA)
+  if (userB) await deleteUserCascade(userB)
+})
+
+afterEach(async () => {
+  // Re-install the fake — tests that swap it should restore on completion,
+  // but be defensive.
+  setEmbeddingClientForTests(new FakeEmbeddingClient())
+})
+
+describe('RAG segregation', () => {
+  it('retrieval never returns chunks from a different manuscript', async () => {
+    // Set up two manuscripts with disjoint subject matter.
+    const mA = await manuscriptService.create({
+      userId: userA, title: `${tag} A — falconry`,
+      centralQuestion: 'Why does a falcon return to the falconer?',
+    })
+    const mB = await manuscriptService.create({
+      userId: userB, title: `${tag} B — submarines`,
+      centralQuestion: 'How does a submarine maintain neutral buoyancy?',
+    })
+
+    const wbA = await createWritingBlock(userA, 'Falcon rituals',
+      'The falconer spent every dawn on the ridge with the peregrine, the lure, the leather hood.')
+    const wbB = await createWritingBlock(userB, 'Buoyancy tanks',
+      'The submarine flooded its ballast tanks and dropped beneath the thermocline at dusk.')
+
+    await manuscriptService.createItem(mA.id, userA, { title: 'Falcon rituals', writingBlockId: wbA })
+    await manuscriptService.createItem(mB.id, userB, { title: 'Buoyancy tanks', writingBlockId: wbB })
+
+    // Compile + chunk + embed both.
+    await compileManuscriptContext(mA.id)
+    await compileManuscriptContext(mB.id)
+    await chunkManuscriptContext(mA.id)
+    await chunkManuscriptContext(mB.id)
+    await embedManuscriptContext(mA.id)
+    await embedManuscriptContext(mB.id)
+
+    // Query A with a submarine-shaped query. Even if the model finds
+    // any "submarine" chunk in B's manuscript, retrieval must still
+    // refuse to return it because we asked about A.
+    const fromA = await retrieveManuscriptContext(mA.id, 'submarine ballast tanks neutral buoyancy', { topK: 8 })
+    for (const c of fromA.chunks) {
+      expect(c.manuscriptId).toBe(mA.id)
+    }
+
+    // Query B with a falconry-shaped query — same guarantee.
+    const fromB = await retrieveManuscriptContext(mB.id, 'falconer peregrine lure leather hood', { topK: 8 })
+    for (const c of fromB.chunks) {
+      expect(c.manuscriptId).toBe(mB.id)
+    }
+
+    // Sanity: a within-manuscript query should actually return chunks
+    // (we want a positive signal, not just an empty result).
+    const within = await retrieveManuscriptContext(mA.id, 'peregrine falconer', { topK: 8 })
+    expect(within.chunks.length).toBeGreaterThan(0)
+    for (const c of within.chunks) {
+      expect(c.manuscriptId).toBe(mA.id)
+    }
+
+    await manuscriptService.delete(mA.id, userA)
+    await manuscriptService.delete(mB.id, userB)
+  })
+
+  it('compiler is idempotent — second pass creates no new sources when nothing changed', async () => {
+    const m = await manuscriptService.create({ userId: userA, title: `${tag} idempotent` })
+    const wb = await createWritingBlock(userA, 'Block 1', 'Some essay text here.')
+    await manuscriptService.createItem(m.id, userA, { title: 'Block 1', writingBlockId: wb })
+
+    const first = await compileManuscriptContext(m.id)
+    const second = await compileManuscriptContext(m.id)
+
+    // Every source row in the second pass should be reported as 'unchanged'.
+    expect(second.sources.length).toBe(first.sources.length)
+    expect(second.sources.every(s => s.action === 'unchanged')).toBe(true)
+
+    await manuscriptService.delete(m.id, userA)
+  })
+
+  it('compiler marks deleted upstream rows as superseded', async () => {
+    const m = await manuscriptService.create({ userId: userA, title: `${tag} super` })
+    const wb = await createWritingBlock(userA, 'Block 1', 'Body text.')
+    const item = await manuscriptService.createItem(m.id, userA, { title: 'Block 1', writingBlockId: wb })
+
+    await compileManuscriptContext(m.id)
+
+    // Delete the item.
+    await manuscriptService.deleteItem(item.id, userA)
+
+    const r = await compileManuscriptContext(m.id)
+    expect(r.superseded.length).toBeGreaterThanOrEqual(1)
+
+    // Superseded sources are excluded by default in retrieval.
+    await chunkManuscriptContext(m.id)
+    await embedManuscriptContext(m.id)
+    const ret = await retrieveManuscriptContext(m.id, 'Body text', { topK: 5 })
+    for (const c of ret.chunks) {
+      // The originating manuscript_item source should not appear.
+      expect(c.sourceType).not.toBe('manuscript_item')
+    }
+
+    await manuscriptService.delete(m.id, userA)
+  })
+
+  it('canonical sources score higher than non-canonical for equally-similar queries', async () => {
+    const m = await manuscriptService.create({ userId: userA, title: `${tag} boost` })
+    // Two sources with identical text — the ranking signal is canonical.
+    await manuscriptContextRepo.upsertSource({
+      manuscriptId: m.id,
+      userId: userA,
+      sourceType: 'manual_note',
+      sourceId: null,
+      title: 'Note A (non-canonical)',
+      body: 'twin manuscript context paragraph',
+      canonical: false,
+      contentHash: 'h1',
+    })
+    await manuscriptContextRepo.upsertSource({
+      manuscriptId: m.id,
+      userId: userA,
+      sourceType: 'manual_note',
+      sourceId: null,
+      title: 'Note B (canonical)',
+      body: 'twin manuscript context paragraph',
+      canonical: true,
+      contentHash: 'h2',
+    })
+    await chunkManuscriptContext(m.id)
+    await embedManuscriptContext(m.id)
+
+    const r = await retrieveManuscriptContext(m.id, 'twin manuscript context paragraph', { topK: 5 })
+    expect(r.chunks.length).toBeGreaterThanOrEqual(2)
+    // The canonical row must rank ahead of the non-canonical one.
+    const canonical = r.chunks.find(c => c.title.includes('canonical'))
+    const nonCanonical = r.chunks.find(c => c.title.includes('non-canonical'))
+    expect(canonical).toBeDefined()
+    expect(nonCanonical).toBeDefined()
+    expect(canonical!.score).toBeGreaterThan(nonCanonical!.score)
+
+    await manuscriptService.delete(m.id, userA)
+  })
+
+  it('rejected sources are excluded from retrieval by default', async () => {
+    const m = await manuscriptService.create({ userId: userA, title: `${tag} reject` })
+    await manuscriptContextRepo.upsertSource({
+      manuscriptId: m.id,
+      userId: userA,
+      sourceType: 'manual_note',
+      sourceId: null,
+      title: 'Rejected note',
+      body: 'unique-rejected-token zzz',
+      status: 'rejected',
+      contentHash: 'r1',
+    })
+    await chunkManuscriptContext(m.id)
+    await embedManuscriptContext(m.id)
+
+    const r = await retrieveManuscriptContext(m.id, 'unique-rejected-token zzz', { topK: 5 })
+    expect(r.chunks.find(c => c.title === 'Rejected note')).toBeUndefined()
+
+    // But explicitly opting in returns it.
+    const r2 = await retrieveManuscriptContext(m.id, 'unique-rejected-token zzz', {
+      topK: 5,
+      includeArchived: true,
+    })
+    expect(r2.chunks.length).toBeGreaterThanOrEqual(1)
+
+    await manuscriptService.delete(m.id, userA)
+  })
+
+  it('contextPack respects maxContextTokens', async () => {
+    const m = await manuscriptService.create({ userId: userA, title: `${tag} budget` })
+    // Create several sizable sources.
+    const para = 'lorem ipsum dolor sit amet '.repeat(80)
+    for (let i = 0; i < 5; i++) {
+      await manuscriptContextRepo.upsertSource({
+        manuscriptId: m.id,
+        userId: userA,
+        sourceType: 'manual_note',
+        sourceId: null,
+        title: `Big note ${i}`,
+        body: `${para} ${i}`,
+        contentHash: `b${i}`,
+      })
+    }
+    await chunkManuscriptContext(m.id)
+    await embedManuscriptContext(m.id)
+
+    const r = await retrieveManuscriptContext(m.id, 'lorem ipsum dolor sit', {
+      topK: 20,
+      maxContextTokens: 300,
+    })
+    // Total approximate tokens across returned chunks should not exceed
+    // 2x the budget (we allow a single overrun for the first chunk so
+    // small budgets always have at least one result).
+    const totalChars = r.chunks.reduce((acc, c) => acc + c.text.length, 0)
+    expect(totalChars).toBeLessThan(300 * 4 * 2.5)
+
+    await manuscriptService.delete(m.id, userA)
+  })
+
+  it('uploaded files appear only when attached to the manuscript', async () => {
+    const m = await manuscriptService.create({ userId: userA, title: `${tag} upload` })
+
+    // Insert an uploaded file row directly (avoiding the multer route).
+    const upload = await pool.query(
+      `INSERT INTO uploaded_files (filename, content_type, data, size_bytes, uploaded_by)
+       VALUES ($1, 'text/plain', '\\x00'::bytea, 0, $2) RETURNING id`,
+      [`${tag}-file.txt`, userA]
+    )
+    const fileId = upload.rows[0].id as string
+
+    // Without an entry in manuscript_uploaded_files, the compiler must
+    // not pull the file in.
+    let r = await compileManuscriptContext(m.id)
+    expect(r.sources.find(s => s.sourceType === 'uploaded_file')).toBeUndefined()
+
+    // Attach.
+    await pool.query(
+      `INSERT INTO manuscript_uploaded_files (manuscript_id, uploaded_file_id, context_role, include_in_ai)
+       VALUES ($1, $2, 'research', TRUE)`,
+      [m.id, fileId]
+    )
+    r = await compileManuscriptContext(m.id)
+    expect(r.sources.find(s => s.sourceType === 'uploaded_file')).toBeDefined()
+
+    await pool.query(`DELETE FROM uploaded_files WHERE id = $1`, [fileId])
+    await manuscriptService.delete(m.id, userA)
+  })
+})

--- a/server/src/services/rag/retrieve.service.ts
+++ b/server/src/services/rag/retrieve.service.ts
@@ -1,0 +1,242 @@
+/**
+ * Manuscript-scoped retrieval.
+ *
+ * The single hard guarantee here: every chunk returned has the requested
+ * manuscript_id. The `searchByVector` repo method enforces this with a
+ * WHERE clause; this service layer adds scoring on top, but never
+ * loosens the manuscript filter.
+ *
+ * Scoring shape (all signals additive on top of `1 - cosine_distance`):
+ *   + canonical            : +0.15
+ *   + accepted status      : +0.10
+ *   + priority / 1000      : 0.0 .. ~0.1
+ *   - rejected / archived  : reject by filter
+ *   - superseded           : reject by filter
+ *
+ * The contextPack rendering keeps a strict cap on tokens so a manuscript
+ * with thousands of chunks can never blow the prompt budget.
+ */
+
+import { manuscriptContextRepo, type VectorSearchHit } from '../../repositories/manuscript-context.repo.js'
+import { getEmbeddingClient, type EmbeddingClient } from './embed.service.js'
+import {
+  ContextRole,
+  ContextSourceType,
+  ContextStatus,
+  RetrievalOptions,
+  RetrievedChunk,
+  RetrievedContext,
+} from '../../models/ManuscriptContext.js'
+import { logger } from '../../utils/logger.js'
+
+const DEFAULT_TOP_K = 8
+const DEFAULT_MAX_TOKENS = 4000
+
+const CANONICAL_BOOST = 0.15
+const ACCEPTED_STATUS_BOOST = 0.10
+const PRIORITY_DIVISOR = 1000
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function approxTokens(chars: number): number {
+  return Math.max(1, Math.ceil(chars / 4))
+}
+
+function scoreHit(hit: VectorSearchHit): number {
+  // pgvector cosine distance is in [0, 2]. Convert to similarity in [-1, 1].
+  // For normalized embeddings (all OpenAI text-embedding-3 outputs are
+  // normalized) the distance is in [0, 2] and the similarity is 1 - d.
+  const similarity = 1 - hit.distance
+  let score = similarity
+  if (hit.canonical) score += CANONICAL_BOOST
+  if (hit.status === 'accepted') score += ACCEPTED_STATUS_BOOST
+  if (typeof hit.priority === 'number') score += hit.priority / PRIORITY_DIVISOR
+  return score
+}
+
+function renderContextPack(chunks: RetrievedChunk[]): string {
+  if (chunks.length === 0) return '# Retrieved Manuscript Context\n\n(No relevant context found in this manuscript.)\n'
+  const parts: string[] = ['# Retrieved Manuscript Context\n']
+  for (const c of chunks) {
+    parts.push(
+      `## Source: ${c.title}\n` +
+      `Type: ${c.sourceType}\n` +
+      `Role: ${c.contextRole}\n` +
+      `Relevance: ${c.score.toFixed(3)}\n\n` +
+      c.text +
+      `\n\n---`
+    )
+  }
+  return parts.join('\n')
+}
+
+export interface RetrieveDeps {
+  /** Override embedding client (tests). */
+  embedder?: EmbeddingClient
+}
+
+/**
+ * Retrieve manuscript-scoped context for a query. The manuscriptId is a
+ * mandatory positional argument — there is no global retrieval mode. If
+ * the caller doesn't have a manuscriptId, they should not be using this
+ * service.
+ *
+ * Returns up to `options.topK` chunks ordered by score (descending),
+ * trimmed to fit `options.maxContextTokens`.
+ */
+export async function retrieveManuscriptContext(
+  manuscriptId: string,
+  query: string,
+  options: RetrievalOptions = {},
+  deps: RetrieveDeps = {}
+): Promise<RetrievedContext> {
+  if (!manuscriptId) throw new Error('retrieveManuscriptContext: manuscriptId is required')
+  const trimmed = query.trim()
+  if (!trimmed) {
+    return { query: '', chunks: [], contextPack: renderContextPack([]) }
+  }
+
+  const topK = options.topK ?? envInt('RAG_TOP_K', DEFAULT_TOP_K)
+  const maxContextTokens = options.maxContextTokens ?? envInt('RAG_MAX_CONTEXT_TOKENS', DEFAULT_MAX_TOKENS)
+
+  // Short-circuit when the manuscript has no embeddings yet: no point
+  // burning tokens on the query embedding when there's nothing to compare
+  // against. Also keeps retrieval inert in test environments where the
+  // RAG layer hasn't been seeded.
+  const stats = await manuscriptContextRepo.stats(manuscriptId)
+  if (stats.embeddings === 0) {
+    return { query: trimmed, chunks: [], contextPack: renderContextPack([]) }
+  }
+
+  // Pull a few extra hits from the vector store so post-filtering
+  // (status / role) leaves us enough to pick from.
+  const overFetch = Math.min(topK * 3, 64)
+
+  const embedder = deps.embedder ?? getEmbeddingClient()
+  const queryVector = await embedder.embedText(trimmed)
+
+  // Resolve status filter. By default we exclude archived/superseded/
+  // rejected; `includeArchived` flips off the filter entirely.
+  const statusFilter: ContextStatus[] | undefined = options.includeArchived
+    ? undefined
+    : (options.status ?? ['active', 'accepted', 'draft'])
+
+  const hits = await manuscriptContextRepo.searchByVector({
+    manuscriptId,
+    embedding: queryVector,
+    embeddingModel: embedder.model,
+    topK: overFetch,
+    sourceTypes: options.sourceTypes,
+    contextRoles: options.contextRoles,
+    status: statusFilter,
+    includeArchived: options.includeArchived,
+  })
+
+  // Defence in depth: assert that every hit IS for this manuscript.
+  // If anything ever slips past the WHERE clause we want a loud failure
+  // rather than a silent leak. Filter out (don't throw) so a genuinely
+  // weird DB state doesn't take down a whole assist call — log instead.
+  const safeHits = hits.filter(h => {
+    if (h.manuscriptId !== manuscriptId) {
+      logger.error('[rag.retrieve] cross-manuscript hit dropped', {
+        expected: manuscriptId, got: h.manuscriptId, chunkId: h.chunkId,
+      })
+      return false
+    }
+    return true
+  })
+
+  // Optional name/movement filters. Cheap to evaluate after the vector
+  // search since the result set is already small.
+  const characterNames = (options.characterNames ?? []).map(s => s.toLowerCase())
+  const movement = options.movement?.toLowerCase()
+  const matchesPostFilter = (h: VectorSearchHit): boolean => {
+    if (characterNames.length > 0) {
+      const sm = h.sourceMetadata ?? {}
+      const cm = h.chunkMetadata ?? {}
+      const candidates: string[] = []
+      if (typeof sm.characterName === 'string') candidates.push(sm.characterName)
+      if (typeof sm.povCharacterName === 'string') candidates.push(sm.povCharacterName)
+      if (typeof cm.characterName === 'string') candidates.push(cm.characterName)
+      const inName = candidates.some(c => characterNames.includes(c.toLowerCase()))
+      if (!inName) return false
+    }
+    if (movement) {
+      const sm = h.sourceMetadata ?? {}
+      const m = typeof sm.movement === 'string' ? sm.movement.toLowerCase() : null
+      if (m !== movement) return false
+    }
+    return true
+  }
+
+  // Score, post-filter, sort, top-K, token-cap.
+  const scored = safeHits
+    .filter(matchesPostFilter)
+    .map(h => ({ hit: h, score: scoreHit(h) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topK)
+
+  const chunks: RetrievedChunk[] = []
+  let tokenBudget = maxContextTokens
+  for (const { hit, score } of scored) {
+    const tokens = hit.tokenCount ?? approxTokens(hit.text.length)
+    if (tokens > tokenBudget && chunks.length > 0) break
+    chunks.push({
+      chunkId: hit.chunkId,
+      contextSourceId: hit.contextSourceId,
+      manuscriptId: hit.manuscriptId,
+      title: hit.title,
+      sourceType: hit.sourceType as ContextSourceType,
+      contextRole: hit.contextRole as ContextRole,
+      text: hit.text,
+      score,
+      metadata: {
+        ...hit.sourceMetadata,
+        ...hit.chunkMetadata,
+        canonical: hit.canonical,
+        status: hit.status,
+      },
+    })
+    tokenBudget -= tokens
+    if (tokenBudget <= 0) break
+  }
+
+  return {
+    query: trimmed,
+    chunks,
+    contextPack: renderContextPack(chunks),
+  }
+}
+
+/**
+ * Build the prompt boundary block recommended by the spec. Inlines the
+ * contextPack inside `<retrieved_manuscript_context>` tags so the model
+ * has a clearly bounded section to attend to (and so any future
+ * post-prompt content doesn't get mistaken for retrieved material).
+ */
+export function buildPromptWithContext(args: {
+  manuscriptId: string
+  contextPack: string
+  userRequest: string
+}): string {
+  return [
+    'You are working on one manuscript only.',
+    '',
+    `Manuscript ID: ${args.manuscriptId}`,
+    '',
+    'Use the retrieved manuscript context below as authoritative project memory unless the user explicitly overrides it.',
+    '',
+    '<retrieved_manuscript_context>',
+    args.contextPack,
+    '</retrieved_manuscript_context>',
+    '',
+    "Now answer the user's request.",
+    '',
+    args.userRequest,
+  ].join('\n')
+}

--- a/server/src/services/writing-assist.service.ts
+++ b/server/src/services/writing-assist.service.ts
@@ -50,6 +50,7 @@ import {
 } from './llm/prompts.js'
 import { ValidationError } from '../utils/errors.js'
 import { logger } from '../utils/logger.js'
+import { retrieveManuscriptContext } from './rag/index.js'
 import type {
   WritingAssistRequest,
   WritingAssistResponse,
@@ -67,6 +68,35 @@ export function setLlmClientForTests(client: LlmClient | null): void {
 
 function client(): LlmClient {
   return activeClient ?? getOpenAIClient()
+}
+
+/* ----- RAG retrieval helper (best-effort) ----- */
+
+/**
+ * Try to retrieve a manuscript-scoped context pack. Returns '' when the
+ * RAG layer isn't configured, when the manuscript hasn't been indexed,
+ * or when retrieval errors out for any other reason — coherence is
+ * useful with or without retrieval, so we never fail the assist call
+ * because retrieval was unavailable.
+ */
+async function tryRetrieveContextPack(
+  manuscriptId: string,
+  query: string,
+  maxContextTokens = 2000
+): Promise<string> {
+  try {
+    const result = await retrieveManuscriptContext(manuscriptId, query, {
+      topK: 8,
+      maxContextTokens,
+    })
+    return result.chunks.length > 0 ? result.contextPack : ''
+  } catch (err) {
+    logger.warn('[writing-assist] retrieval skipped', {
+      manuscriptId,
+      message: err instanceof Error ? err.message : String(err),
+    })
+    return ''
+  }
 }
 
 /* ----- Limits ----- */
@@ -203,6 +233,15 @@ export const writingAssistService = {
       bodyLen: writing.body?.length ?? 0,
     })
 
+    // Find the containing manuscript (if any) once up-front. The result is
+    // reused below for the coherence mode AND for tagging the LLM exchange
+    // with manuscript_id — every AI exchange that relates to a manuscript
+    // must carry that pointer (see migration 021 / RAG layer spec).
+    const manuscriptCtx = userId
+      ? await manuscriptRepo.findContextForWriting(writing.id, userId, isAdmin)
+      : null
+    const manuscriptId = manuscriptCtx?.manuscript.id ?? null
+
     // 2. Refuse early if the LLM client isn't configured. We do this AFTER
     //    access checks but BEFORE building any prompt, so misconfigured
     //    deploys give a clean 5xx with a useful message at the front door.
@@ -234,11 +273,9 @@ export const writingAssistService = {
         const selection = (request.args.selection ?? '').slice(0, MAX_SELECTION_CHARS)
 
         // Optional manuscript context — sibling titles + short summaries,
-        // plus literary direction. Falls back gracefully when this essay
-        // isn't in any manuscript the user can read.
-        const ctx = userId
-          ? await manuscriptRepo.findContextForWriting(writing.id, userId, isAdmin)
-          : null
+        // plus literary direction. Reuses the up-front lookup above so we
+        // don't go to the DB twice.
+        const ctx = manuscriptCtx
 
         const siblings: CoherenceSiblingItem[] = (ctx?.siblings ?? [])
           .slice(0, MAX_SIBLINGS)
@@ -263,6 +300,23 @@ export const writingAssistService = {
           siblings,
           direction,
         })
+
+        // Augment with manuscript-scoped retrieved context if the essay
+        // belongs to a manuscript. Best-effort — silently skipped if the
+        // RAG layer isn't configured, the manuscript hasn't been indexed,
+        // or pgvector isn't available.
+        if (manuscriptId) {
+          const pack = await tryRetrieveContextPack(manuscriptId, `${question}\n${selection ?? ''}`)
+          if (pack) {
+            userPrompt =
+              'Use the retrieved manuscript context below as authoritative project memory unless the user explicitly overrides it.\n\n' +
+              '<retrieved_manuscript_context>\n' +
+              pack + '\n' +
+              '</retrieved_manuscript_context>\n\n' +
+              userPrompt
+          }
+        }
+
         // Slightly higher temperature so coherence answers don't read as
         // template responses. Still bounded so the model stays grounded.
         temperature = 0.6
@@ -415,12 +469,15 @@ export const writingAssistService = {
       temperature,
       maxOutputTokens,
       // Provenance for the diagnostic ai_exchanges log — see migration 019.
+      // manuscriptId is set when the writing block belongs to a manuscript
+      // the caller can read; NULL otherwise (the block is standalone).
       context: {
         feature: 'writing-assist',
         mode: request.mode,
         userId,
         resourceType: 'writing_block',
         resourceId: writing.id,
+        manuscriptId,
       },
     })
     logger.info('[writing-assist] LLM response received', {


### PR DESCRIPTION
## Summary

Implements a manuscript-scoped context + RAG layer so every AI request that relates to a manuscript retrieves only from context belonging to that manuscript. The relational layer decides what's in a manuscript; the RAG layer never crosses that boundary.

The pipeline is **compile → chunk → embed → retrieve**, all backed by pgvector with `manuscript_id` pinned at every stage.

## What changed

**Schema (migrations [021](server/src/db/migrations/021_manuscript_data_boundaries.sql), [022](server/src/db/migrations/022_manuscript_rag.sql))**
- `ai_exchanges.manuscript_id` FK + index — every AI exchange traceable per-manuscript
- `manuscript_uploaded_files` join table — files become AI-eligible only via explicit membership
- Drop the global `UNIQUE` on `uploaded_files.filename`
- `vector` extension + `manuscript_context_sources` / `context_chunks` / `context_embeddings`, every row keyed on `manuscript_id`

**Service layer ([server/src/services/rag/](server/src/services/rag/))**
- [`compile-context.service.ts`](server/src/services/rag/compile-context.service.ts) — hash-based idempotent compiler covering projects, sections, items, writing_blocks, artifacts, characters, beats, motifs, silences, causal_links, uploaded_files. Marks deleted upstream rows as `superseded` rather than dropping (audit history preserved)
- [`chunker.ts`](server/src/services/rag/chunker.ts) — paragraph→sentence splitter, ~800-token chunks with ~120-token overlap, skips unchanged source bodies via aggregate hash
- [`embed.service.ts`](server/src/services/rag/embed.service.ts) — `EmbeddingClient` interface + injectable test hook, OpenAI fetch impl with batching, idempotent (only embeds chunks missing a vector for the configured model)
- [`retrieve.service.ts`](server/src/services/rag/retrieve.service.ts) — cosine search via pgvector with `manuscript_id` in the same `WHERE` as the vector op. Boosts: canonical +0.15, accepted +0.10, priority/1000. Excludes rejected/archived/superseded by default. Defence-in-depth filter that drops any cross-manuscript hit at the service layer (logs an error if it ever fires)
- [`index.ts`](server/src/services/rag/index.ts) — barrel + `reindexManuscript` (compile + chunk + embed)

**Integration**
- [`manuscript-assist.service.ts`](server/src/services/manuscript-assist.service.ts) — stamps `ai_exchanges.manuscript_id`, prepends a best-effort retrieved context pack on whole-manuscript gap runs (skipped on targeted-junction runs to preserve user-narrowed scope)
- [`writing-assist.service.ts`](server/src/services/writing-assist.service.ts) — looks up the containing manuscript once, propagates `manuscriptId` to every assist call, augments the `coherence` mode with retrieval
- [`openai-client.ts`](server/src/services/llm/openai-client.ts) + [`ai-exchange.repo.ts`](server/src/repositories/ai-exchange.repo.ts) thread `manuscriptId` into the `ai_exchanges` row

**CLI** — [`server/scripts/rag-cli.ts`](server/scripts/rag-cli.ts) plus `npm run rag:{compile,chunk,embed,reindex,search,stats,list}`

**Tests**
- [`chunker.test.ts`](server/src/services/rag/chunker.test.ts) — pure logic, no DB
- [`manuscript-segregation.test.ts`](server/src/services/rag/manuscript-segregation.test.ts) — DB-backed; load-bearing test that retrieval never returns chunks from another manuscript, plus idempotency, supersede, canonical boost, rejected exclusion, token-budget cap, uploaded-file gating. Uses a deterministic fake `EmbeddingClient` (no network)

**Docs** — [`docs/rag.md`](docs/rag.md): architecture, scoring, integration, env vars, known limitations

## Why a compile step (rather than embedding domain rows directly)

Domain rows are JSON-shaped (`characters.voice` is JSONB; `beats` has 20+ nullable text fields). Embedding raw JSON yields meaningless vectors — the model needs prose. Membership rules also differ per source (a `writing_block` is in a manuscript only when a `manuscript_item` links it). Centralising those rules in one compiler is what makes the boundary guarantee tractable.

## Reviewer notes

- **Vector store choice:** pgvector. The repo is already 100% Postgres; adding Pinecone/Qdrant for ~hundreds of chunks per manuscript would be a parallel architecture without a corresponding scale problem.
- **Embedding dim is fixed at 1536** in the migration to match `text-embedding-3-small`. Switching to a different-dim model needs a separate migration — runtime config can't silently drift from the column type.
- **Retrieval is best-effort at the assist boundary.** If pgvector is missing, the manuscript hasn't been indexed, or `OPENAI_API_KEY` isn't set, the assist call still succeeds without a context pack. This is deliberate — we'd rather lose the enhancement than fail the whole assist.
- **Existing `manuscript-assist.test.ts` should still pass.** Retrieval short-circuits when `stats.embeddings === 0` for the manuscript, which is always the case in tests that don't seed the RAG layer.
- Migration 022 fails loudly if the local Postgres lacks the `vector` extension. That's intentional — running the new tests against an env without pgvector should surface that immediately, not produce silently-broken behaviour.

## Test plan

- [ ] `npm run migrate` against a Postgres with the `vector` extension installed
- [ ] `npm test --workspace=server` — confirm `chunker.test.ts` and `manuscript-segregation.test.ts` pass, and the existing `manuscript-assist.test.ts` still passes
- [ ] `npm run rag:reindex -- --manuscript <real-id>` against a real manuscript, then `npm run rag:search -- --manuscript <id> --query "..."` — verify results are scoped and ordered sensibly
- [ ] After running an assist call from the UI, query `SELECT manuscript_id, feature, mode FROM ai_exchanges ORDER BY created_at DESC LIMIT 5;` and confirm `manuscript_id` is populated for manuscript-related calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)