### PR TITLE
Add admin UI for manuscript-scoped RAG

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -118,4 +118,205 @@ export const adminApi = {
       .post<ApiResponse<EssayImportResult>>('/admin/essays/import', { envelope, options })
       .then(r => r.data)
   },
+
+  /* ----- RAG admin ----- */
+
+  ragListManuscripts(): Promise<RagManuscriptRow[]> {
+    return api.get<ApiResponse<RagManuscriptRow[]>>('/admin/rag/manuscripts').then(r => r.data)
+  },
+
+  ragStats(manuscriptId: string): Promise<RagStats> {
+    return api
+      .get<ApiResponse<RagStats>>(`/admin/rag/manuscripts/${manuscriptId}/stats`)
+      .then(r => r.data)
+  },
+
+  ragListSources(manuscriptId: string, includeArchived = false): Promise<RagContextSource[]> {
+    return api
+      .get<ApiResponse<RagContextSource[]>>(
+        `/admin/rag/manuscripts/${manuscriptId}/sources`,
+        { params: { includeArchived: String(includeArchived) } }
+      )
+      .then(r => r.data)
+  },
+
+  ragDeleteSource(sourceId: string): Promise<{ deleted: string }> {
+    return api
+      .delete<ApiResponse<{ deleted: string }>>(`/admin/rag/sources/${sourceId}`)
+      .then(r => r.data)
+  },
+
+  ragCompile(manuscriptId: string, force = false): Promise<RagCompileResult> {
+    return api
+      .post<ApiResponse<RagCompileResult>>(
+        `/admin/rag/manuscripts/${manuscriptId}/compile`,
+        { force }
+      )
+      .then(r => r.data)
+  },
+
+  ragChunk(manuscriptId: string): Promise<RagChunkResult> {
+    return api
+      .post<ApiResponse<RagChunkResult>>(`/admin/rag/manuscripts/${manuscriptId}/chunk`, {})
+      .then(r => r.data)
+  },
+
+  ragEmbed(manuscriptId: string): Promise<RagEmbedResult> {
+    return api
+      .post<ApiResponse<RagEmbedResult>>(`/admin/rag/manuscripts/${manuscriptId}/embed`, {})
+      .then(r => r.data)
+  },
+
+  ragReindex(manuscriptId: string, force = false): Promise<RagReindexResult> {
+    return api
+      .post<ApiResponse<RagReindexResult>>(
+        `/admin/rag/manuscripts/${manuscriptId}/reindex`,
+        { force }
+      )
+      .then(r => r.data)
+  },
+
+  ragSearch(manuscriptId: string, query: string, options: Partial<{
+    topK: number
+    maxContextTokens: number
+    includeArchived: boolean
+    sourceTypes: string[]
+    contextRoles: string[]
+  }> = {}): Promise<RagSearchResult> {
+    return api
+      .post<ApiResponse<RagSearchResult>>(
+        `/admin/rag/manuscripts/${manuscriptId}/search`,
+        { query, ...options }
+      )
+      .then(r => r.data)
+  },
+
+  ragListUploadedFiles(manuscriptId: string): Promise<RagUploadedFileRow[]> {
+    return api
+      .get<ApiResponse<RagUploadedFileRow[]>>(
+        `/admin/rag/manuscripts/${manuscriptId}/uploaded-files`
+      )
+      .then(r => r.data)
+  },
+
+  ragAttachUploadedFile(manuscriptId: string, fileId: string, opts: { contextRole?: string; includeInAi?: boolean }) {
+    return api
+      .post<ApiResponse<{ manuscriptId: string; uploadedFileId: string; contextRole: string; includeInAi: boolean }>>(
+        `/admin/rag/manuscripts/${manuscriptId}/uploaded-files/${fileId}`,
+        opts
+      )
+      .then(r => r.data)
+  },
+
+  ragDetachUploadedFile(manuscriptId: string, fileId: string) {
+    return api
+      .delete<ApiResponse<{ detached: { manuscriptId: string; uploadedFileId: string } }>>(
+        `/admin/rag/manuscripts/${manuscriptId}/uploaded-files/${fileId}`
+      )
+      .then(r => r.data)
+  },
+}
+
+/* ----- RAG admin types ----- */
+
+export interface RagManuscriptRow {
+  id: string
+  title: string
+  userId: string
+  form: string
+  status: string
+  updatedAt: string
+  ownerDisplayName: string | null
+  ownerEmail: string | null
+  contextSources: number
+  contextChunks: number
+  contextEmbeddings: number
+  aiExchanges: number
+}
+
+export interface RagStats {
+  sources: number
+  chunks: number
+  embeddings: number
+  recentExchanges: Array<{
+    id: string
+    feature: string
+    mode: string | null
+    model: string
+    status: 'ok' | 'error'
+    createdAt: string
+  }>
+}
+
+export interface RagContextSource {
+  id: string
+  manuscriptId: string
+  userId: string
+  sourceType: string
+  sourceId: string | null
+  title: string
+  body: string | null
+  metadata: Record<string, unknown>
+  contextRole: string
+  priority: number
+  status: string
+  canonical: boolean
+  includeInAi: boolean
+  contentHash: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RagCompileResult {
+  manuscriptId: string
+  sources: { sourceType: string; sourceId: string | null; sourceRowId: string; action: 'created' | 'updated' | 'unchanged' }[]
+  superseded: string[]
+  totalActive: number
+}
+
+export interface RagChunkResult {
+  rebuiltSources: number
+  totalChunks: number
+  totalSources: number
+}
+
+export interface RagEmbedResult {
+  embedded: number
+  skipped: number
+  total: number
+  model: string
+}
+
+export interface RagReindexResult {
+  manuscriptId: string
+  compile: RagCompileResult
+  chunk: RagChunkResult
+  embed: RagEmbedResult
+}
+
+export interface RagSearchResult {
+  query: string
+  chunks: Array<{
+    chunkId: string
+    contextSourceId: string
+    manuscriptId: string
+    title: string
+    sourceType: string
+    contextRole: string
+    text: string
+    score: number
+    metadata: Record<string, unknown>
+  }>
+  contextPack: string
+}
+
+export interface RagUploadedFileRow {
+  id: string
+  filename: string
+  contentType: string
+  sizeBytes: number
+  createdAt: string
+  attached: boolean
+  contextRole: string | null
+  includeInAi: boolean | null
 }

--- a/client/src/pages/Admin.vue
+++ b/client/src/pages/Admin.vue
@@ -25,6 +25,12 @@
           >
             AI exchanges
           </router-link>
+          <router-link
+            to="/admin/rag"
+            class="text-sm text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            Manuscript RAG
+          </router-link>
           <button
             type="button"
             @click="showImportExport = true"

--- a/client/src/pages/AdminRag.vue
+++ b/client/src/pages/AdminRag.vue
@@ -1,0 +1,589 @@
+<template>
+  <div class="admin-rag-page">
+    <!-- Header -->
+    <div class="w-full px-4 sm:px-6 md:px-8 py-12 sm:py-16 bg-gradient-to-b from-paper to-gray-50">
+      <div class="max-w-6xl mx-auto">
+        <router-link to="/admin" class="text-xs sm:text-sm text-ink-lighter hover:text-ink mb-2 inline-block">
+          ← Back to Admin
+        </router-link>
+        <p class="text-xs sm:text-sm tracking-widest uppercase font-sans text-ink-lighter mb-4">
+          Administration · Manuscript RAG
+        </p>
+        <h1 class="text-3xl sm:text-4xl md:text-5xl font-light tracking-tight mb-4">
+          Manuscript context &amp; retrieval
+        </h1>
+        <p class="text-base sm:text-lg font-light text-ink-light">
+          Index a manuscript so AI assist can retrieve from its compiled context.
+          Every operation is scoped to one manuscript at a time —
+          retrieval never crosses the boundary.
+        </p>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <div class="w-full px-4 sm:px-6 md:px-8 py-8 sm:py-12 bg-paper">
+      <div class="max-w-6xl mx-auto">
+
+        <!-- Manuscript picker -->
+        <div class="mb-6 bg-white border border-gray-100 rounded-lg p-4 shadow-sm">
+          <div class="flex items-end gap-3 flex-wrap">
+            <div class="flex-1 min-w-[280px]">
+              <label class="block text-xs uppercase tracking-wider text-ink-lighter mb-1">Manuscript</label>
+              <select
+                v-model="selectedId"
+                class="w-full text-sm border border-gray-200 rounded px-2 py-1.5 bg-white focus:outline-none focus:ring-1 focus:ring-blue-400"
+                @change="onManuscriptChange"
+              >
+                <option value="">— Choose a manuscript —</option>
+                <option v-for="m in manuscripts" :key="m.id" :value="m.id">
+                  {{ m.title }} · {{ m.ownerDisplayName || m.ownerEmail || m.userId.slice(0, 8) }}
+                  · sources {{ m.contextSources }} / chunks {{ m.contextChunks }} / vectors {{ m.contextEmbeddings }}
+                </option>
+              </select>
+            </div>
+            <button
+              @click="loadManuscripts"
+              :disabled="manuscriptsLoading"
+              class="px-3 py-1.5 text-sm border border-gray-300 rounded text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              {{ manuscriptsLoading ? 'Refreshing…' : 'Refresh list' }}
+            </button>
+          </div>
+          <p v-if="selectedManuscript" class="text-xs text-ink-lighter mt-2">
+            Manuscript ID: <code class="font-mono">{{ selectedManuscript.id }}</code> ·
+            Form: {{ selectedManuscript.form }} ·
+            Status: {{ selectedManuscript.status }} ·
+            AI exchanges so far: {{ selectedManuscript.aiExchanges }}
+          </p>
+        </div>
+
+        <div v-if="!selectedId" class="bg-white rounded-lg border border-gray-100 p-10 text-center">
+          <p class="text-ink-lighter">Pick a manuscript above to begin.</p>
+        </div>
+
+        <template v-else>
+          <!-- Stats + actions -->
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+            <div class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm text-center">
+              <p class="text-xs uppercase tracking-wider text-ink-lighter">Context sources</p>
+              <p class="text-2xl font-semibold mt-1">{{ stats?.sources ?? '—' }}</p>
+            </div>
+            <div class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm text-center">
+              <p class="text-xs uppercase tracking-wider text-ink-lighter">Chunks</p>
+              <p class="text-2xl font-semibold mt-1">{{ stats?.chunks ?? '—' }}</p>
+            </div>
+            <div class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm text-center">
+              <p class="text-xs uppercase tracking-wider text-ink-lighter">Embeddings</p>
+              <p class="text-2xl font-semibold mt-1">{{ stats?.embeddings ?? '—' }}</p>
+            </div>
+          </div>
+
+          <!-- Pipeline controls -->
+          <div class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm mb-6">
+            <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+              <h2 class="text-lg font-medium">Pipeline</h2>
+              <label class="text-xs flex items-center gap-1 text-ink-light">
+                <input type="checkbox" v-model="forceFlag" />
+                Force (rewrite even if hashes match)
+              </label>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                @click="runStep('compile')"
+                :disabled="busy"
+                class="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+              >Compile</button>
+              <button
+                @click="runStep('chunk')"
+                :disabled="busy"
+                class="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+              >Chunk</button>
+              <button
+                @click="runStep('embed')"
+                :disabled="busy"
+                class="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+              >Embed</button>
+              <button
+                @click="runStep('reindex')"
+                :disabled="busy"
+                class="px-3 py-1.5 text-sm border border-blue-500 text-blue-700 rounded hover:bg-blue-50 disabled:opacity-50"
+              >Reindex (compile + chunk + embed)</button>
+              <span v-if="busy" class="text-sm text-ink-lighter">{{ busyLabel }}…</span>
+            </div>
+            <div v-if="lastOutcome" class="mt-3 text-xs">
+              <p class="text-ink-lighter mb-1">Last result:</p>
+              <pre class="bg-gray-50 border border-gray-100 rounded p-2 overflow-x-auto">{{ lastOutcome }}</pre>
+            </div>
+            <p v-if="errorMessage" class="mt-3 text-sm text-red-600">{{ errorMessage }}</p>
+            <p class="mt-3 text-xs text-ink-lighter">
+              Embed makes outbound calls to OpenAI and may take many seconds for a large manuscript.
+              The page is unresponsive while a step is running.
+            </p>
+          </div>
+
+          <!-- Search -->
+          <div class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm mb-6">
+            <h2 class="text-lg font-medium mb-3">Search</h2>
+            <form @submit.prevent="runSearch" class="flex flex-wrap gap-2 items-end">
+              <div class="flex-1 min-w-[240px]">
+                <label class="block text-xs uppercase tracking-wider text-ink-lighter mb-1">Query</label>
+                <input
+                  v-model="searchQuery"
+                  type="text"
+                  placeholder="e.g. voice guide for Marcus"
+                  class="w-full text-sm border border-gray-200 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                />
+              </div>
+              <div>
+                <label class="block text-xs uppercase tracking-wider text-ink-lighter mb-1">Top K</label>
+                <input
+                  v-model.number="searchTopK"
+                  type="number"
+                  min="1"
+                  max="50"
+                  class="w-20 text-sm border border-gray-200 rounded px-2 py-1.5"
+                />
+              </div>
+              <div>
+                <label class="block text-xs uppercase tracking-wider text-ink-lighter mb-1">Max tokens</label>
+                <input
+                  v-model.number="searchMaxTokens"
+                  type="number"
+                  min="100"
+                  max="20000"
+                  class="w-28 text-sm border border-gray-200 rounded px-2 py-1.5"
+                />
+              </div>
+              <label class="text-xs flex items-center gap-1 text-ink-light">
+                <input type="checkbox" v-model="searchIncludeArchived" />
+                Include archived
+              </label>
+              <button
+                type="submit"
+                :disabled="busy || !searchQuery.trim()"
+                class="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+              >Search</button>
+            </form>
+
+            <div v-if="searchResult" class="mt-4">
+              <p class="text-xs text-ink-lighter mb-2">
+                {{ searchResult.chunks.length }} chunk(s) returned for query
+                <code class="font-mono">"{{ searchResult.query }}"</code>
+              </p>
+              <div v-if="searchResult.chunks.length === 0" class="text-sm text-ink-lighter">
+                No matches. The manuscript may not be indexed yet — run Reindex first.
+              </div>
+              <div v-else class="space-y-2">
+                <div
+                  v-for="c in searchResult.chunks"
+                  :key="c.chunkId"
+                  class="border border-gray-100 rounded p-3 bg-gray-50"
+                >
+                  <div class="flex items-center justify-between gap-2 flex-wrap mb-1">
+                    <p class="text-sm font-medium">{{ c.title }}</p>
+                    <p class="text-xs text-ink-lighter">
+                      {{ c.sourceType }} · {{ c.contextRole }} · score {{ c.score.toFixed(3) }}
+                    </p>
+                  </div>
+                  <p class="text-xs whitespace-pre-wrap text-ink-light">{{ c.text }}</p>
+                </div>
+              </div>
+
+              <details v-if="searchResult.chunks.length > 0" class="mt-3">
+                <summary class="text-xs text-ink-lighter cursor-pointer">Rendered context pack</summary>
+                <pre class="text-xs bg-gray-50 border border-gray-100 rounded p-2 overflow-x-auto mt-1 whitespace-pre-wrap">{{ searchResult.contextPack }}</pre>
+              </details>
+            </div>
+          </div>
+
+          <!-- Context sources -->
+          <div class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm mb-6">
+            <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+              <h2 class="text-lg font-medium">Context sources</h2>
+              <div class="flex items-center gap-3">
+                <label class="text-xs flex items-center gap-1 text-ink-light">
+                  <input type="checkbox" v-model="includeArchived" @change="loadSources" />
+                  Show archived/superseded
+                </label>
+                <button
+                  @click="loadSources"
+                  :disabled="sourcesLoading"
+                  class="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                >{{ sourcesLoading ? 'Loading…' : 'Refresh' }}</button>
+              </div>
+            </div>
+            <div v-if="sources.length === 0" class="text-sm text-ink-lighter">
+              No sources yet. Run Compile or Reindex.
+            </div>
+            <div v-else class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead class="text-xs uppercase tracking-wider text-ink-lighter">
+                  <tr class="border-b border-gray-100">
+                    <th class="text-left py-2 pr-2">Title</th>
+                    <th class="text-left py-2 pr-2">Type</th>
+                    <th class="text-left py-2 pr-2">Role</th>
+                    <th class="text-left py-2 pr-2">Status</th>
+                    <th class="text-left py-2 pr-2">Canon</th>
+                    <th class="text-left py-2 pr-2">Pri</th>
+                    <th class="text-left py-2 pr-2">Updated</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="s in sources" :key="s.id" class="border-b border-gray-50">
+                    <td class="py-2 pr-2">
+                      <div class="font-medium">{{ s.title }}</div>
+                      <details>
+                        <summary class="text-xs text-ink-lighter cursor-pointer">body ({{ (s.body?.length ?? 0).toLocaleString() }} chars)</summary>
+                        <pre class="text-xs whitespace-pre-wrap mt-1">{{ s.body }}</pre>
+                      </details>
+                    </td>
+                    <td class="py-2 pr-2 text-xs"><code class="font-mono">{{ s.sourceType }}</code></td>
+                    <td class="py-2 pr-2 text-xs">{{ s.contextRole }}</td>
+                    <td class="py-2 pr-2 text-xs">{{ s.status }}</td>
+                    <td class="py-2 pr-2 text-xs">{{ s.canonical ? 'yes' : '—' }}</td>
+                    <td class="py-2 pr-2 text-xs">{{ s.priority }}</td>
+                    <td class="py-2 pr-2 text-xs">{{ formatRelativeTime(s.updatedAt) }}</td>
+                    <td class="py-2">
+                      <button
+                        @click="confirmDeleteSource(s)"
+                        class="text-xs text-red-600 hover:text-red-800"
+                        title="Hard-delete this source row (chunks + embeddings cascade)"
+                      >Delete</button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Uploaded files -->
+          <div class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm mb-6">
+            <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+              <h2 class="text-lg font-medium">Uploaded files</h2>
+              <button
+                @click="loadUploadedFiles"
+                :disabled="uploadsLoading"
+                class="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+              >{{ uploadsLoading ? 'Loading…' : 'Refresh' }}</button>
+            </div>
+            <p class="text-xs text-ink-lighter mb-3">
+              Files belong to the manuscript's owner. Attach them here so the compiler can include
+              them in the manuscript's context. File body extraction (PDF, DOCX) is not yet
+              implemented — attached files appear as metadata-only context sources.
+            </p>
+            <div v-if="uploadedFiles.length === 0" class="text-sm text-ink-lighter">
+              The manuscript's owner has no uploaded files.
+            </div>
+            <div v-else class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead class="text-xs uppercase tracking-wider text-ink-lighter">
+                  <tr class="border-b border-gray-100">
+                    <th class="text-left py-2 pr-2">Filename</th>
+                    <th class="text-left py-2 pr-2">Type</th>
+                    <th class="text-left py-2 pr-2">Size</th>
+                    <th class="text-left py-2 pr-2">Attached?</th>
+                    <th class="text-left py-2 pr-2">Role</th>
+                    <th class="text-left py-2 pr-2">Include in AI</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="f in uploadedFiles" :key="f.id" class="border-b border-gray-50">
+                    <td class="py-2 pr-2 font-mono text-xs">{{ f.filename }}</td>
+                    <td class="py-2 pr-2 text-xs">{{ f.contentType }}</td>
+                    <td class="py-2 pr-2 text-xs">{{ formatBytes(f.sizeBytes) }}</td>
+                    <td class="py-2 pr-2 text-xs">{{ f.attached ? 'yes' : 'no' }}</td>
+                    <td class="py-2 pr-2 text-xs">
+                      <select
+                        v-model="rolePerFile[f.id]"
+                        class="text-xs border border-gray-200 rounded px-1 py-0.5 bg-white"
+                        :disabled="!f.attached"
+                      >
+                        <option value="supporting">supporting</option>
+                        <option value="research">research</option>
+                        <option value="canon">canon</option>
+                        <option value="draft">draft</option>
+                        <option value="style">style</option>
+                        <option value="voice">voice</option>
+                        <option value="plot">plot</option>
+                        <option value="character">character</option>
+                        <option value="continuity">continuity</option>
+                      </select>
+                    </td>
+                    <td class="py-2 pr-2 text-xs">
+                      <input
+                        type="checkbox"
+                        v-model="includeAiPerFile[f.id]"
+                        :disabled="!f.attached"
+                      />
+                    </td>
+                    <td class="py-2 text-xs whitespace-nowrap">
+                      <button
+                        v-if="!f.attached"
+                        @click="attachFile(f)"
+                        class="px-2 py-0.5 border border-gray-300 rounded hover:bg-gray-50"
+                      >Attach</button>
+                      <template v-else>
+                        <button
+                          @click="updateAttachment(f)"
+                          class="px-2 py-0.5 border border-gray-300 rounded hover:bg-gray-50 mr-1"
+                        >Save</button>
+                        <button
+                          @click="detachFile(f)"
+                          class="px-2 py-0.5 border border-red-300 text-red-600 rounded hover:bg-red-50"
+                        >Detach</button>
+                      </template>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Recent AI exchanges for this manuscript -->
+          <div v-if="stats?.recentExchanges?.length" class="bg-white border border-gray-100 rounded-lg p-4 shadow-sm">
+            <h2 class="text-lg font-medium mb-3">Recent AI exchanges for this manuscript</h2>
+            <table class="w-full text-sm">
+              <thead class="text-xs uppercase tracking-wider text-ink-lighter">
+                <tr class="border-b border-gray-100">
+                  <th class="text-left py-2 pr-2">When</th>
+                  <th class="text-left py-2 pr-2">Feature</th>
+                  <th class="text-left py-2 pr-2">Mode</th>
+                  <th class="text-left py-2 pr-2">Model</th>
+                  <th class="text-left py-2 pr-2">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="ex in stats.recentExchanges" :key="ex.id" class="border-b border-gray-50">
+                  <td class="py-2 pr-2 text-xs">{{ formatRelativeTime(ex.createdAt) }}</td>
+                  <td class="py-2 pr-2 text-xs">{{ ex.feature }}</td>
+                  <td class="py-2 pr-2 text-xs">{{ ex.mode || '—' }}</td>
+                  <td class="py-2 pr-2 text-xs font-mono">{{ ex.model }}</td>
+                  <td class="py-2 pr-2 text-xs">
+                    <span :class="ex.status === 'ok' ? 'text-green-700' : 'text-red-700'">{{ ex.status }}</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <router-link
+              :to="`/admin/ai-exchanges?manuscriptId=${selectedId}`"
+              class="text-xs text-blue-600 hover:text-blue-800 hover:underline mt-2 inline-block"
+            >View all →</router-link>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import {
+  adminApi,
+  type RagManuscriptRow,
+  type RagStats,
+  type RagContextSource,
+  type RagSearchResult,
+  type RagUploadedFileRow,
+} from '../api/admin'
+
+const manuscripts = ref<RagManuscriptRow[]>([])
+const manuscriptsLoading = ref(false)
+const selectedId = ref('')
+
+const stats = ref<RagStats | null>(null)
+const sources = ref<RagContextSource[]>([])
+const sourcesLoading = ref(false)
+const includeArchived = ref(false)
+
+const uploadedFiles = ref<RagUploadedFileRow[]>([])
+const uploadsLoading = ref(false)
+const rolePerFile = ref<Record<string, string>>({})
+const includeAiPerFile = ref<Record<string, boolean>>({})
+
+const searchQuery = ref('')
+const searchTopK = ref(8)
+const searchMaxTokens = ref(4000)
+const searchIncludeArchived = ref(false)
+const searchResult = ref<RagSearchResult | null>(null)
+
+const forceFlag = ref(false)
+const busy = ref(false)
+const busyLabel = ref('')
+const lastOutcome = ref('')
+const errorMessage = ref('')
+
+const selectedManuscript = computed(() =>
+  manuscripts.value.find(m => m.id === selectedId.value) ?? null
+)
+
+const loadManuscripts = async () => {
+  manuscriptsLoading.value = true
+  try {
+    manuscripts.value = await adminApi.ragListManuscripts()
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    manuscriptsLoading.value = false
+  }
+}
+
+const loadStats = async () => {
+  if (!selectedId.value) return
+  try {
+    stats.value = await adminApi.ragStats(selectedId.value)
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+const loadSources = async () => {
+  if (!selectedId.value) return
+  sourcesLoading.value = true
+  try {
+    sources.value = await adminApi.ragListSources(selectedId.value, includeArchived.value)
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    sourcesLoading.value = false
+  }
+}
+
+const loadUploadedFiles = async () => {
+  if (!selectedId.value) return
+  uploadsLoading.value = true
+  try {
+    const files = await adminApi.ragListUploadedFiles(selectedId.value)
+    uploadedFiles.value = files
+    // Seed per-row state from server values; default to 'supporting' / true.
+    const role: Record<string, string> = {}
+    const incl: Record<string, boolean> = {}
+    for (const f of files) {
+      role[f.id] = f.contextRole ?? 'supporting'
+      incl[f.id] = f.includeInAi ?? true
+    }
+    rolePerFile.value = role
+    includeAiPerFile.value = incl
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    uploadsLoading.value = false
+  }
+}
+
+const onManuscriptChange = async () => {
+  errorMessage.value = ''
+  lastOutcome.value = ''
+  searchResult.value = null
+  if (!selectedId.value) return
+  await Promise.all([loadStats(), loadSources(), loadUploadedFiles()])
+}
+
+const runStep = async (step: 'compile' | 'chunk' | 'embed' | 'reindex') => {
+  if (!selectedId.value || busy.value) return
+  busy.value = true
+  busyLabel.value = step.charAt(0).toUpperCase() + step.slice(1)
+  errorMessage.value = ''
+  lastOutcome.value = ''
+  try {
+    let result: unknown
+    if (step === 'compile') result = await adminApi.ragCompile(selectedId.value, forceFlag.value)
+    else if (step === 'chunk') result = await adminApi.ragChunk(selectedId.value)
+    else if (step === 'embed') result = await adminApi.ragEmbed(selectedId.value)
+    else result = await adminApi.ragReindex(selectedId.value, forceFlag.value)
+    lastOutcome.value = JSON.stringify(result, null, 2)
+    await loadStats()
+    if (step === 'compile' || step === 'reindex') await loadSources()
+    // Refresh manuscript counts in the picker.
+    await loadManuscripts()
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    busy.value = false
+    busyLabel.value = ''
+  }
+}
+
+const runSearch = async () => {
+  if (!selectedId.value || !searchQuery.value.trim()) return
+  busy.value = true
+  busyLabel.value = 'Searching'
+  errorMessage.value = ''
+  try {
+    searchResult.value = await adminApi.ragSearch(selectedId.value, searchQuery.value.trim(), {
+      topK: searchTopK.value,
+      maxContextTokens: searchMaxTokens.value,
+      includeArchived: searchIncludeArchived.value,
+    })
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    busy.value = false
+    busyLabel.value = ''
+  }
+}
+
+const confirmDeleteSource = async (s: RagContextSource) => {
+  if (!confirm(`Hard-delete the context source "${s.title}"?\nChunks + embeddings cascade. The compiler will recreate it on the next reindex if its origin row still exists.`)) return
+  try {
+    await adminApi.ragDeleteSource(s.id)
+    await loadSources()
+    await loadStats()
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+const attachFile = async (f: RagUploadedFileRow) => {
+  if (!selectedId.value) return
+  try {
+    await adminApi.ragAttachUploadedFile(selectedId.value, f.id, {
+      contextRole: rolePerFile.value[f.id] ?? 'supporting',
+      includeInAi: includeAiPerFile.value[f.id] ?? true,
+    })
+    await loadUploadedFiles()
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+const updateAttachment = (f: RagUploadedFileRow) => attachFile(f)
+
+const detachFile = async (f: RagUploadedFileRow) => {
+  if (!selectedId.value) return
+  try {
+    await adminApi.ragDetachUploadedFile(selectedId.value, f.id)
+    await loadUploadedFiles()
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+const formatRelativeTime = (iso: string): string => {
+  const diff = Date.now() - new Date(iso).getTime()
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 7) return `${d}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+const formatBytes = (n: number): string => {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+onMounted(loadManuscripts)
+</script>
+
+<style scoped>
+.admin-rag-page pre {
+  font-size: 11px;
+  line-height: 1.4;
+}
+</style>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -26,6 +26,7 @@ import Admin from '../pages/Admin.vue'
 import AdminRules from '../pages/AdminRules.vue'
 import AdminAiExchanges from '../pages/AdminAiExchanges.vue'
 import AdminEssays from '../pages/AdminEssays.vue'
+import AdminRag from '../pages/AdminRag.vue'
 import BaselineTest from '../pages/BaselineTest.vue'
 
 const router = createRouter({
@@ -171,6 +172,12 @@ const router = createRouter({
       path: '/admin/essays',
       name: 'AdminEssays',
       component: AdminEssays,
+      meta: { requiresAuth: true, requiresAdmin: true }
+    },
+    {
+      path: '/admin/rag',
+      name: 'AdminRag',
+      component: AdminRag,
       meta: { requiresAuth: true, requiresAdmin: true }
     },
     {

--- a/server/src/controllers/rag-admin.controller.ts
+++ b/server/src/controllers/rag-admin.controller.ts
@@ -1,0 +1,283 @@
+/**
+ * RAG admin controller — HTTP surface for the manuscript-scoped RAG
+ * pipeline. Mirrors the operations exposed by the rag-cli, so the admin
+ * UI and CLI are interchangeable.
+ *
+ * All routes assume the caller is an admin (gated at the router level
+ * by `requireAdmin`). The compile/chunk/embed/reindex/search ops
+ * delegate straight to the same service functions the assist code uses
+ * — the controller just validates input and shapes responses.
+ */
+import { Request, Response } from 'express'
+import { pool } from '../config/db.js'
+import { ValidationError, NotFoundError } from '../utils/errors.js'
+import {
+  compileManuscriptContext,
+  chunkManuscriptContext,
+  embedManuscriptContext,
+  reindexManuscript,
+  retrieveManuscriptContext,
+  manuscriptContextStats,
+  listManuscriptContextSources,
+  deleteManuscriptContextSource,
+} from '../services/rag/index.js'
+import { manuscriptContextRepo } from '../repositories/manuscript-context.repo.js'
+import { aiExchangeRepo } from '../repositories/ai-exchange.repo.js'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function requireUuid(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !UUID_RE.test(value)) {
+    throw new ValidationError(`${label} must be a UUID`)
+  }
+  return value
+}
+
+async function assertManuscriptExists(id: string): Promise<{ id: string; userId: string; title: string }> {
+  const r = await pool.query(
+    `SELECT id, user_id AS "userId", title FROM manuscript_projects WHERE id = $1`,
+    [id]
+  )
+  if (r.rows.length === 0) throw new NotFoundError('Manuscript not found')
+  return r.rows[0]
+}
+
+export const ragAdminController = {
+  /**
+   * GET /api/admin/rag/manuscripts
+   *
+   * Lightweight list of every manuscript with a few useful columns for
+   * the picker (title, owner display name, current RAG counts). The
+   * counts are inexpensive — three COUNT(*)s scoped by manuscript_id.
+   */
+  async listManuscripts(_req: Request, res: Response) {
+    const r = await pool.query(
+      `SELECT
+         mp.id,
+         mp.title,
+         mp.user_id        AS "userId",
+         mp.form,
+         mp.status,
+         mp.updated_at     AS "updatedAt",
+         u.display_name    AS "ownerDisplayName",
+         u.email           AS "ownerEmail",
+         (SELECT COUNT(*)::int FROM manuscript_context_sources s WHERE s.manuscript_id = mp.id) AS "contextSources",
+         (SELECT COUNT(*)::int FROM context_chunks            c WHERE c.manuscript_id = mp.id) AS "contextChunks",
+         (SELECT COUNT(*)::int FROM context_embeddings        e WHERE e.manuscript_id = mp.id) AS "contextEmbeddings",
+         (SELECT COUNT(*)::int FROM ai_exchanges              x WHERE x.manuscript_id = mp.id) AS "aiExchanges"
+       FROM manuscript_projects mp
+       LEFT JOIN users u ON u.id = mp.user_id
+       ORDER BY mp.updated_at DESC`
+    )
+    res.json({ data: r.rows })
+  },
+
+  /**
+   * GET /api/admin/rag/manuscripts/:id/stats
+   *
+   * Returns counts plus the most recent AI exchange row for context.
+   */
+  async getStats(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    await assertManuscriptExists(id)
+    const stats = await manuscriptContextStats(id)
+    const recentExchanges = await aiExchangeRepo.list({ manuscriptId: id }, 5, 0)
+    res.json({ data: { ...stats, recentExchanges } })
+  },
+
+  /**
+   * GET /api/admin/rag/manuscripts/:id/sources
+   *
+   * List the compiled context sources. Returns the body too — the admin
+   * surface explicitly wants to inspect what the compiler produced.
+   */
+  async listSources(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    await assertManuscriptExists(id)
+    const includeArchived = req.query.includeArchived === 'true'
+    const sources = await manuscriptContextRepo.listSources(id, { includeArchived })
+    res.json({ data: sources })
+  },
+
+  /**
+   * DELETE /api/admin/rag/sources/:sourceId
+   *
+   * Hard-delete a single context source row. Chunks + embeddings cascade
+   * via FK. Use sparingly — the compiler will recreate the source on the
+   * next reindex if its origin row still exists.
+   */
+  async deleteSource(req: Request, res: Response) {
+    const sourceId = requireUuid(req.params.sourceId, 'sourceId')
+    const existing = await manuscriptContextRepo.findSourceById(sourceId)
+    if (!existing) throw new NotFoundError('Context source not found')
+    await deleteManuscriptContextSource(sourceId)
+    res.json({ data: { deleted: sourceId } })
+  },
+
+  /**
+   * POST /api/admin/rag/manuscripts/:id/compile
+   * POST /api/admin/rag/manuscripts/:id/chunk
+   * POST /api/admin/rag/manuscripts/:id/embed
+   * POST /api/admin/rag/manuscripts/:id/reindex
+   *
+   * Each delegates to the corresponding service function. `force` is
+   * accepted for compile and reindex.
+   *
+   * Embed in particular makes outbound calls to OpenAI — the admin
+   * needs to know that the request can take many seconds. We don't
+   * stream progress back; the client shows a spinner and waits.
+   */
+  async compile(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    await assertManuscriptExists(id)
+    const force = req.body?.force === true
+    const result = await compileManuscriptContext(id, { force })
+    res.json({ data: result })
+  },
+
+  async chunk(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    await assertManuscriptExists(id)
+    const result = await chunkManuscriptContext(id)
+    res.json({ data: result })
+  },
+
+  async embed(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    await assertManuscriptExists(id)
+    const result = await embedManuscriptContext(id)
+    res.json({ data: result })
+  },
+
+  async reindex(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    await assertManuscriptExists(id)
+    const force = req.body?.force === true
+    const result = await reindexManuscript(id, { force })
+    res.json({ data: result })
+  },
+
+  /**
+   * POST /api/admin/rag/manuscripts/:id/search
+   *
+   * Body: { query, topK?, maxContextTokens?, includeArchived?, sourceTypes?, contextRoles? }
+   *
+   * Returns the same shape `retrieveManuscriptContext` returns, including
+   * the rendered contextPack so the admin can preview what an assist
+   * call would inject into a prompt.
+   */
+  async search(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    await assertManuscriptExists(id)
+
+    const body = (req.body && typeof req.body === 'object') ? req.body : {}
+    const query = typeof body.query === 'string' ? body.query.trim() : ''
+    if (!query) throw new ValidationError('query is required')
+
+    const topK = typeof body.topK === 'number' && body.topK > 0 ? Math.min(50, body.topK) : 8
+    const maxContextTokens = typeof body.maxContextTokens === 'number' && body.maxContextTokens > 0
+      ? Math.min(20000, body.maxContextTokens)
+      : 4000
+    const includeArchived = body.includeArchived === true
+
+    const arrOfStrings = (v: unknown): string[] | undefined =>
+      Array.isArray(v) && v.every(x => typeof x === 'string') ? v as string[] : undefined
+
+    const sourceTypes = arrOfStrings(body.sourceTypes)
+    const contextRoles = arrOfStrings(body.contextRoles)
+
+    const result = await retrieveManuscriptContext(id, query, {
+      topK,
+      maxContextTokens,
+      includeArchived,
+      // Cast to the narrower union types the service expects; values that
+      // aren't valid will simply not match anything in the DB.
+      sourceTypes: sourceTypes as unknown as undefined,
+      contextRoles: contextRoles as unknown as undefined,
+    })
+
+    res.json({ data: result })
+  },
+
+  /* ============================================================
+   *  Uploaded-file membership
+   * ============================================================ */
+
+  /**
+   * GET /api/admin/rag/manuscripts/:id/uploaded-files
+   *
+   * Returns the union of:
+   *   - files attached to the manuscript via manuscript_uploaded_files
+   *   - files belonging to the manuscript's owner that are NOT attached
+   *
+   * The admin can flip an attachment on/off from a single list.
+   */
+  async listUploadedFiles(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    const m = await assertManuscriptExists(id)
+
+    const r = await pool.query(
+      `SELECT
+         uf.id,
+         uf.filename,
+         uf.content_type            AS "contentType",
+         uf.size_bytes              AS "sizeBytes",
+         uf.created_at              AS "createdAt",
+         (muf.manuscript_id IS NOT NULL) AS attached,
+         muf.context_role           AS "contextRole",
+         muf.include_in_ai          AS "includeInAi"
+       FROM uploaded_files uf
+       LEFT JOIN manuscript_uploaded_files muf
+              ON muf.uploaded_file_id = uf.id
+             AND muf.manuscript_id = $1
+       WHERE uf.uploaded_by = $2
+       ORDER BY (muf.manuscript_id IS NOT NULL) DESC, uf.created_at DESC`,
+      [id, m.userId]
+    )
+    res.json({ data: r.rows })
+  },
+
+  /**
+   * POST /api/admin/rag/manuscripts/:id/uploaded-files/:fileId
+   *
+   * Attach (or update) an uploaded file's role / include_in_ai flag.
+   * Body: { contextRole?: string; includeInAi?: boolean }
+   */
+  async attachUploadedFile(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    const fileId = requireUuid(req.params.fileId, 'fileId')
+    await assertManuscriptExists(id)
+
+    // Sanity-check the file actually exists.
+    const f = await pool.query(`SELECT id FROM uploaded_files WHERE id = $1`, [fileId])
+    if (f.rows.length === 0) throw new NotFoundError('Uploaded file not found')
+
+    const body = (req.body && typeof req.body === 'object') ? req.body : {}
+    const contextRole = typeof body.contextRole === 'string' ? body.contextRole : 'supporting'
+    const includeInAi = body.includeInAi === false ? false : true
+
+    await pool.query(
+      `INSERT INTO manuscript_uploaded_files (manuscript_id, uploaded_file_id, context_role, include_in_ai)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (manuscript_id, uploaded_file_id)
+       DO UPDATE SET context_role = EXCLUDED.context_role,
+                     include_in_ai = EXCLUDED.include_in_ai`,
+      [id, fileId, contextRole, includeInAi]
+    )
+    res.json({ data: { manuscriptId: id, uploadedFileId: fileId, contextRole, includeInAi } })
+  },
+
+  /**
+   * DELETE /api/admin/rag/manuscripts/:id/uploaded-files/:fileId
+   */
+  async detachUploadedFile(req: Request, res: Response) {
+    const id = requireUuid(req.params.id, 'manuscriptId')
+    const fileId = requireUuid(req.params.fileId, 'fileId')
+    await assertManuscriptExists(id)
+    await pool.query(
+      `DELETE FROM manuscript_uploaded_files WHERE manuscript_id = $1 AND uploaded_file_id = $2`,
+      [id, fileId]
+    )
+    res.json({ data: { detached: { manuscriptId: id, uploadedFileId: fileId } } })
+  },
+}

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -2,6 +2,7 @@ import { Router, json as expressJson } from 'express'
 import { adminController } from '../controllers/admin.controller.js'
 import { typographyController } from '../controllers/typography.controller.js'
 import { uploadsController, uploadSingle } from '../controllers/uploads.controller.js'
+import { ragAdminController } from '../controllers/rag-admin.controller.js'
 import { authMiddleware } from '../middleware/auth.middleware.js'
 import { requireAdmin } from '../middleware/authorize.middleware.js'
 import { asyncHandler } from '../utils/asyncHandler.js'
@@ -58,5 +59,21 @@ router.post(
   expressJson({ limit: '50mb' }),
   asyncHandler(adminController.importEssays)
 )
+
+// Manuscript-scoped RAG admin (compile/chunk/embed/reindex/search/sources/uploads)
+// All ops require admin and operate on a single manuscript_id at a time.
+// See docs/rag.md for the architecture.
+router.get(   '/rag/manuscripts',                                       asyncHandler(ragAdminController.listManuscripts))
+router.get(   '/rag/manuscripts/:id/stats',                             asyncHandler(ragAdminController.getStats))
+router.get(   '/rag/manuscripts/:id/sources',                           asyncHandler(ragAdminController.listSources))
+router.delete('/rag/sources/:sourceId',                                 asyncHandler(ragAdminController.deleteSource))
+router.post(  '/rag/manuscripts/:id/compile',                           asyncHandler(ragAdminController.compile))
+router.post(  '/rag/manuscripts/:id/chunk',                             asyncHandler(ragAdminController.chunk))
+router.post(  '/rag/manuscripts/:id/embed',                             asyncHandler(ragAdminController.embed))
+router.post(  '/rag/manuscripts/:id/reindex',                           asyncHandler(ragAdminController.reindex))
+router.post(  '/rag/manuscripts/:id/search',                            asyncHandler(ragAdminController.search))
+router.get(   '/rag/manuscripts/:id/uploaded-files',                    asyncHandler(ragAdminController.listUploadedFiles))
+router.post(  '/rag/manuscripts/:id/uploaded-files/:fileId',            asyncHandler(ragAdminController.attachUploadedFile))
+router.delete('/rag/manuscripts/:id/uploaded-files/:fileId',            asyncHandler(ragAdminController.detachUploadedFile))
 
 export default router


### PR DESCRIPTION
## Summary

Follow-up to [apps/befly#77](https://github.com/DRCUOA/befly/pull/77). Adds an admin view at `/admin/rag` so the manuscript-RAG pipeline can be driven from the UI rather than only the CLI.

The CLI in `server/scripts/rag-cli.ts` still works — both surfaces delegate to the same `rag` service functions, so they stay in sync.

## What changed

**Backend ([rag-admin.controller.ts](server/src/controllers/rag-admin.controller.ts), [admin.routes.ts](server/src/routes/admin.routes.ts))**
- `GET /api/admin/rag/manuscripts` — list with at-a-glance counts (sources, chunks, embeddings, ai_exchanges)
- `GET /api/admin/rag/manuscripts/:id/stats` — counts plus the 5 most recent AI exchanges for that manuscript
- `GET /api/admin/rag/manuscripts/:id/sources` — list compiled context sources (body included for inspection)
- `DELETE /api/admin/rag/sources/:sourceId` — hard-delete a source row (chunks/embeddings cascade)
- `POST /api/admin/rag/manuscripts/:id/compile|chunk|embed|reindex` — pipeline ops
- `POST /api/admin/rag/manuscripts/:id/search` — same shape as `retrieveManuscriptContext`, including the rendered `contextPack`
- `GET|POST|DELETE /api/admin/rag/manuscripts/:id/uploaded-files[/:fileId]` — list the manuscript-owner's files, attach one with a `context_role` and `include_in_ai` flag, or detach

All routes are gated by the existing `requireAdmin` middleware.

**Frontend ([AdminRag.vue](client/src/pages/AdminRag.vue), [admin.ts](client/src/api/admin.ts), [router/index.ts](client/src/router/index.ts), [Admin.vue](client/src/pages/Admin.vue))**
- Manuscript picker showing live counts in the option label, so the admin sees indexing state at a glance
- Pipeline panel: Compile / Chunk / Embed buttons + a primary Reindex button, plus a `force` checkbox that surfaces the salt-the-hash bypass
- Search panel: query, top-K, max-tokens, includeArchived, with the returned chunks rendered inline plus an expandable `<details>` for the rendered context pack
- Sources table: title + body (collapsible), source_type, role, status, canonical, priority, last-updated, plus a per-row delete button
- Uploaded-files table: shows every file owned by the manuscript's owner with attach/detach controls, role select, and an include-in-ai toggle
- Recent AI exchanges section deep-linking into `/admin/ai-exchanges?manuscriptId=...` for full inspection

## Reviewer notes

- Embed makes outbound OpenAI calls and can take many seconds for a large manuscript. The page UI is locked while a step runs and a `busyLabel` is shown — no streaming progress bar (deliberate; the existing assist UI uses the same pattern).
- "Hard-delete" in the sources table is genuinely hard but reversible by reindexing — the compiler will recreate the source on the next pass if its origin row still exists. The button has a `confirm()` to make sure that's intentional.
- The uploaded-files attach operation re-uses the same `manuscript_uploaded_files` table that the compiler reads from, so attaching a file and re-running reindex is the supported workflow for adding research material.
- Both halves type-check (`npx vue-tsc --noEmit` and `npx tsc -p server --noEmit`).

## Test plan

- [ ] Navigate to `/admin/rag` as an admin user — picker populates with manuscripts and counts
- [ ] Pick a manuscript, click **Reindex**, watch counts move from 0 → N
- [ ] Run a search — the context pack matches what the CLI's `npm run rag:search` returns for the same query
- [ ] Open a file under "Uploaded files" → Attach with role `research` → re-run Reindex → confirm the file appears in the sources table as `source_type = uploaded_file`
- [ ] Detach the file → re-run Reindex → confirm the source row transitions to `superseded`
- [ ] Trigger an AI assist call from the rest of the app, then return to `/admin/rag` for that manuscript → "Recent AI exchanges" shows the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)