### PR TITLE
Fix: server crash from @shared/* runtime import (ManuscriptChat)

### DIFF
--- a/server/src/controllers/manuscript-chat.controller.ts
+++ b/server/src/controllers/manuscript-chat.controller.ts
@@ -16,7 +16,10 @@
 import { Request, Response } from 'express'
 import { manuscriptChatService } from '../services/manuscript-chat.service.js'
 import { ValidationError } from '../utils/errors.js'
-import { MANUSCRIPT_CHAT_MODELS, DEFAULT_MANUSCRIPT_CHAT_MODEL } from '../models/ManuscriptChat.js'
+import {
+  MANUSCRIPT_CHAT_MODELS,
+  DEFAULT_MANUSCRIPT_CHAT_MODEL,
+} from '../services/manuscript-chat-models.js'
 
 function requireUserId(req: Request): string {
   const userId = (req as Request & { userId?: string }).userId

--- a/server/src/models/ManuscriptChat.ts
+++ b/server/src/models/ManuscriptChat.ts
@@ -1,2 +1,6 @@
 // Re-export shared types for consistency with the rest of the server models.
-export * from '@shared/ManuscriptChat'
+//
+// Uses `export type *` (not `export *`) so tsc erases the runtime import.
+// `@shared/*` is a compile-time path alias only; production Node has no
+// resolver for it. shared/ManuscriptChat.ts is types-only by design.
+export type * from '@shared/ManuscriptChat'

--- a/server/src/services/manuscript-chat-models.ts
+++ b/server/src/services/manuscript-chat-models.ts
@@ -1,0 +1,29 @@
+/**
+ * Manuscript chat — runtime constants.
+ *
+ * Lives server-side rather than in shared/ so the production runtime
+ * can resolve them. (See the warning at the top of shared/ManuscriptChat.ts:
+ * the shared workspace is shipped as raw TS in the Heroku image and any
+ * runtime import path-aliased to it would fail at runtime.)
+ *
+ * The client never imports this file — it fetches the same list via the
+ * GET /api/manuscripts/chats/models endpoint, which surfaces these exact
+ * values.
+ */
+
+/**
+ * Curated allow-list of chat models. Free-text would let a typo nuke a
+ * conversation; the dropdown locks the writer to known-good options.
+ * The default is the same as the rest of the app's assist surfaces.
+ */
+export const MANUSCRIPT_CHAT_MODELS = [
+  { id: 'gpt-4o-mini', label: 'gpt-4o-mini (fast, low cost — default)' },
+  { id: 'gpt-4o',      label: 'gpt-4o (mid quality)' },
+  { id: 'gpt-5-mini',  label: 'gpt-5-mini (newer reasoning, balanced)' },
+  { id: 'gpt-5',       label: 'gpt-5 (newer reasoning, highest quality)' },
+] as const
+
+export const DEFAULT_MANUSCRIPT_CHAT_MODEL: string = 'gpt-4o-mini'
+
+export const ALLOWED_MANUSCRIPT_CHAT_MODEL_IDS: readonly string[] =
+  MANUSCRIPT_CHAT_MODELS.map(m => m.id)

--- a/server/src/services/manuscript-chat.service.ts
+++ b/server/src/services/manuscript-chat.service.ts
@@ -21,15 +21,17 @@
  */
 import { manuscriptService } from './manuscript.service.js'
 import { manuscriptChatRepo } from '../repositories/manuscript-chat.repo.js'
-import {
+import type {
   ManuscriptChat,
   ManuscriptChatMessage,
   ManuscriptChatWithMessages,
   ChatChunkCitation,
-  MANUSCRIPT_CHAT_MODELS,
-  DEFAULT_MANUSCRIPT_CHAT_MODEL,
   ManuscriptChatModelId,
 } from '../models/ManuscriptChat.js'
+import {
+  DEFAULT_MANUSCRIPT_CHAT_MODEL,
+  ALLOWED_MANUSCRIPT_CHAT_MODEL_IDS,
+} from './manuscript-chat-models.js'
 import {
   LlmClient,
   LlmChatMessage,
@@ -60,13 +62,11 @@ const MAX_TITLE_CHARS = 80
 const RAG_TOP_K = 8
 const RAG_MAX_CONTEXT_TOKENS = 3500
 
-const ALLOWED_MODELS: readonly string[] = MANUSCRIPT_CHAT_MODELS.map(m => m.id)
-
 function validateModel(model: string | undefined): string {
   if (!model || !model.trim()) return DEFAULT_MANUSCRIPT_CHAT_MODEL
-  if (!ALLOWED_MODELS.includes(model)) {
+  if (!ALLOWED_MANUSCRIPT_CHAT_MODEL_IDS.includes(model)) {
     throw new ValidationError(
-      `Unsupported chat model "${model}". Allowed: ${ALLOWED_MODELS.join(', ')}`
+      `Unsupported chat model "${model}". Allowed: ${ALLOWED_MANUSCRIPT_CHAT_MODEL_IDS.join(', ')}`
     )
   }
   return model

--- a/shared/ManuscriptChat.ts
+++ b/shared/ManuscriptChat.ts
@@ -1,8 +1,21 @@
 /**
- * Manuscript-scoped chat — shared contract between server and client.
+ * Manuscript-scoped chat — shared TYPES between server and client.
+ *
+ * IMPORTANT: this file is types-only.
+ *
+ * The server imports `@shared/...` via a tsconfig path alias that is
+ * resolved at compile time but NOT preserved at runtime. The Heroku
+ * image copies shared/ as raw TypeScript (no compile step on the
+ * shared workspace), so any RUNTIME export here would emit an import
+ * the production Node process can't resolve. (Mirror of the warning
+ * comment in server/src/models/StoryCraft.ts.)
+ *
+ * Concrete runtime constants — model allow-list, defaults — live
+ * server-side in services/manuscript-chat-models.ts and are surfaced
+ * to the client via the GET /chats/models endpoint.
  *
  * One conversation = one row in manuscript_chats, pinned to a manuscript.
- * Each turn = one row in manuscript_chat_messages. The assistant turns
+ * Each turn = one row in manuscript_chat_messages. Assistant turns
  * carry provenance (which retrieved chunks the model saw, which
  * ai_exchanges row captured the wire-level request) so the UI can render
  * "answer grounded in: ..." links.
@@ -55,17 +68,8 @@ export interface ChatChunkCitation {
 }
 
 /**
- * Curated allow-list of chat models. Free-text would let a typo nuke a
- * conversation; the dropdown locks the writer to known-good options.
- * The default is the same as the rest of the app's assist surfaces.
+ * Discriminated string for the chat model id. Concrete list of allowed
+ * ids lives server-side; this type keeps the wire contract tight without
+ * forcing the client to import a runtime const.
  */
-export const MANUSCRIPT_CHAT_MODELS = [
-  { id: 'gpt-4o-mini', label: 'gpt-4o-mini (fast, low cost — default)' },
-  { id: 'gpt-4o',      label: 'gpt-4o (mid quality)' },
-  { id: 'gpt-5-mini',  label: 'gpt-5-mini (newer reasoning, balanced)' },
-  { id: 'gpt-5',       label: 'gpt-5 (newer reasoning, highest quality)' },
-] as const
-
-export type ManuscriptChatModelId = typeof MANUSCRIPT_CHAT_MODELS[number]['id']
-
-export const DEFAULT_MANUSCRIPT_CHAT_MODEL: ManuscriptChatModelId = 'gpt-4o-mini'
+export type ManuscriptChatModelId = string


### PR DESCRIPTION
## Summary

**Hotfix for production crash** introduced by [#79](https://github.com/DRCUOA/befly/pull/79):

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@shared/ManuscriptChat'
  imported from /app/server/dist/models/ManuscriptChat.js
\`\`\`

## Root cause

\`@shared/*\` is a **tsconfig path alias**, resolved at compile time only. The Heroku image copies \`shared/\` as raw TypeScript (no build step on the shared workspace), and Node has no resolver for the alias at runtime.

Existing files that use this pattern (e.g. \`models/Manuscript.ts\` with \`export * from '@shared/Manuscript'\`) work *only* because the shared file has zero runtime exports — tsc elides the runtime import in that case. \`shared/StoryCraft.ts\` actually has a comment warning about this:

> the \`type\` modifier, tsc preserves \`export * from '@shared/StoryCraft'\` in
> the emit … so we use \`export type *\` instead

\`shared/ManuscriptChat.ts\` shipped with \`MANUSCRIPT_CHAT_MODELS\` and \`DEFAULT_MANUSCRIPT_CHAT_MODEL\` as runtime const exports, which forced tsc to emit a real \`import from '@shared/ManuscriptChat'\` in the compiled output. Production Node couldn't resolve it → boot crash.

## Fix

- [shared/ManuscriptChat.ts](shared/ManuscriptChat.ts) is now types-only (matches \`shared/StoryCraft.ts\`'s safer pattern), with a top-of-file comment warning future contributors not to add runtime exports.
- The runtime constants moved to a new server-only file [server/src/services/manuscript-chat-models.ts](server/src/services/manuscript-chat-models.ts).
- [server/src/models/ManuscriptChat.ts](server/src/models/ManuscriptChat.ts) now uses \`export type *\` (instead of \`export *\`) so tsc emits no runtime import even if \`shared/\` ever grows runtime exports again.
- The chat service and controller import constants from the new server-only file; types still come from \`models/ManuscriptChat\`.
- The client never imported the constants — it already fetches the list via \`GET /api/manuscripts/chats/models\` — so no client changes.

## Verification

Compiled \`server\` to a temp dir and inspected the output:

- \`dist/server/src/models/ManuscriptChat.js\` is now \`export {};\` — no runtime import
- \`dist/server/src/controllers/manuscript-chat.controller.js\` imports the constants from the relative path \`'../services/manuscript-chat-models.js'\` ✓
- \`grep -rln "@shared/ManuscriptChat" dist/server/src/\` matches only \`.d.ts\` files (consumed by tsc, never loaded at runtime) ✓

\`tsc --noEmit\` passes for both server and client.

## Test plan

- [ ] Deploy to Heroku — server boots without the \`ERR_MODULE_NOT_FOUND\`
- [ ] Open a manuscript → click **Chat** → confirm the chat drawer loads (proves the controller and service are reachable)
- [ ] \`GET /api/manuscripts/chats/models\` returns the four-entry allow-list

🤖 Generated with [Claude Code](https://claude.com/claude-code)