### PR TITLE
Promote AI model picker in chat drawer

### DIFF
--- a/client/src/components/manuscripts/ChatDrawer.vue
+++ b/client/src/components/manuscripts/ChatDrawer.vue
@@ -42,23 +42,34 @@
             title="Start a new chat"
           >+ New</button>
         </div>
-        <div v-if="activeChat" class="flex items-center gap-2 mt-2">
-          <label class="text-xs text-ink-lighter">Model</label>
+        <!-- Model picker: prominent its own row so the writer can swap
+             models before sending the next turn. Rename/Delete moved
+             below into a quieter "options" row. -->
+        <div v-if="activeChat" class="mt-3">
+          <label class="block text-[11px] uppercase tracking-wider text-ink-lighter mb-1">
+            AI model
+          </label>
           <select
             v-model="modelForActive"
-            class="flex-1 text-xs border border-gray-200 rounded px-2 py-1 bg-white"
+            class="w-full text-sm border border-gray-300 rounded px-2 py-1.5 bg-white focus:outline-none focus:ring-1 focus:ring-blue-400"
             @change="changeModel"
           >
             <option v-for="m in models" :key="m.id" :value="m.id">{{ m.label }}</option>
           </select>
+          <p class="text-[10px] text-ink-lighter mt-1">
+            Applies to your next turn. Earlier turns keep the model they were sent with.
+          </p>
+        </div>
+        <div v-if="activeChat" class="mt-2 flex items-center gap-3 text-[11px]">
           <button
             @click="renameActive"
-            class="text-xs text-ink-lighter hover:text-ink"
+            class="text-ink-lighter hover:text-ink"
             title="Rename chat"
           >Rename</button>
+          <span class="text-ink-lighter">·</span>
           <button
             @click="deleteActive"
-            class="text-xs text-red-600 hover:text-red-800"
+            class="text-red-600 hover:text-red-800"
             title="Delete chat"
           >Delete</button>
         </div>


### PR DESCRIPTION
## Summary

Follow-up UX fix on the manuscript chat drawer: the AI model picker was hidden in a small \`text-xs\` row sharing space with Rename / Delete buttons, which made it visually disappear. This promotes it to its own labelled row.

## What changed

In [ChatDrawer.vue](client/src/components/manuscripts/ChatDrawer.vue):

- The model \`<select>\` is now its own full-width row with a clear "AI MODEL" label, styled at the same size as the chat picker above it.
- A one-line note clarifies that switching the model applies to the **next** turn — earlier turns keep the model they were originally sent with on the message row (so the audit trail stays accurate).
- Rename and Delete dropped to a separate, quieter options row below.

## Reviewer notes

- No backend changes. The model picker still calls \`PUT /api/manuscripts/:id/chats/:chatId\` with \`{ model }\` per the existing contract.
- The allow-list (\`gpt-4o-mini\` default, plus 4o / 5-mini / 5) still comes from \`GET /api/manuscripts/chats/models\`, populated by [services/manuscript-chat-models.ts](server/src/services/manuscript-chat-models.ts).
- \`vue-tsc --noEmit\` passes.

## Test plan

- [ ] Open a manuscript → click **Chat** → confirm the AI model dropdown is clearly visible at the top of the drawer (not buried next to Rename/Delete)
- [ ] Switch the model mid-conversation → send another turn → confirm the new turn uses the new model (verifiable via the per-message \`model\` field in the citation panel, or via \`/admin/ai-exchanges?manuscriptId=...\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)