### PR TITLE
Fix: chat H12 timeout — async LLM call + client polling

### DIFF
--- a/client/src/components/manuscripts/ChatDrawer.vue
+++ b/client/src/components/manuscripts/ChatDrawer.vue
@@ -97,12 +97,22 @@
             <div class="flex items-start gap-2">
               <span
                 class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded mt-0.5"
-                :class="msg.role === 'user' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-ink-light'"
+                :class="msg.role === 'user' ? 'bg-blue-50 text-blue-700' : (msg.status === 'error' ? 'bg-red-50 text-red-700' : 'bg-gray-100 text-ink-light')"
               >{{ msg.role }}</span>
               <div class="flex-1 min-w-0">
+                <!-- Pending assistant placeholder while the background
+                     LLM call is still running. -->
+                <div v-if="msg.role === 'assistant' && msg.status === 'pending'" class="text-sm italic text-ink-lighter">
+                  <span class="inline-flex items-center gap-1">
+                    <span class="dot-pulse">Thinking</span>
+                    <span class="dot-pulse-anim">…</span>
+                  </span>
+                  <span class="ml-1 text-[10px]">({{ msg.model || 'default model' }})</span>
+                </div>
                 <div
+                  v-else
                   class="text-sm whitespace-pre-wrap break-words"
-                  :class="msg.role === 'user' ? 'text-ink' : 'text-ink-light'"
+                  :class="msg.role === 'user' ? 'text-ink' : (msg.status === 'error' ? 'text-red-700' : 'text-ink-light')"
                 >{{ msg.content }}</div>
                 <div v-if="msg.retrievedChunkIds.length > 0" class="mt-1">
                   <details class="text-[11px] text-ink-lighter">
@@ -121,13 +131,12 @@
                     </ul>
                   </details>
                 </div>
-                <p v-if="msg.role === 'assistant' && msg.model" class="text-[10px] text-ink-lighter mt-0.5">
+                <p v-if="msg.role === 'assistant' && msg.status === 'complete' && msg.model" class="text-[10px] text-ink-lighter mt-0.5">
                   {{ msg.model }}<span v-if="msg.completionTokens"> · {{ msg.completionTokens }} tokens out</span>
                 </p>
               </div>
             </div>
           </div>
-          <div v-if="busy" class="text-xs text-ink-lighter italic">Thinking…</div>
           <p v-if="errorMessage" class="text-xs text-red-600 mt-2">{{ errorMessage }}</p>
         </template>
       </div>
@@ -138,21 +147,26 @@
           <textarea
             v-model="draft"
             rows="2"
-            :disabled="!activeChat || busy"
-            placeholder="Ask anything about this manuscript…"
+            :disabled="composerDisabled"
+            :placeholder="hasPending ? 'Waiting for the model to reply…' : 'Ask anything about this manuscript…'"
             class="flex-1 text-sm border border-gray-200 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400 resize-none disabled:bg-gray-50"
             @keydown.enter.exact.prevent="onSubmit"
           ></textarea>
           <button
             type="submit"
-            :disabled="!activeChat || busy || !draft.trim()"
+            :disabled="composerDisabled || !draft.trim()"
             class="px-3 py-1.5 text-sm border border-blue-500 text-blue-700 rounded hover:bg-blue-50 disabled:opacity-50"
           >
             {{ busy ? 'Sending…' : 'Send' }}
           </button>
         </form>
         <p class="text-[10px] text-ink-lighter mt-1">
-          Enter to send · Shift+Enter for newline · Replies use indexed manuscript context. Reindex from /admin/rag if results look stale.
+          <template v-if="hasPending">
+            Reasoning models can take 30–60s. The reply will land here automatically — feel free to leave the drawer open.
+          </template>
+          <template v-else>
+            Enter to send · Shift+Enter for newline · Replies use indexed manuscript context. Reindex from /admin/rag if results look stale.
+          </template>
         </p>
       </footer>
     </aside>
@@ -160,7 +174,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import { manuscriptChatApi } from '../../api/manuscriptChat'
 import type {
   ManuscriptChat,
@@ -199,6 +213,60 @@ const messagesEl = ref<HTMLElement | null>(null)
 const activeChat = computed(() =>
   chats.value.find(c => c.id === selectedChatId.value) ?? null
 )
+
+/**
+ * True while any message in the active chat is in 'pending' status —
+ * meaning the server's background worker hasn't finished the LLM call
+ * yet. We poll while this is true and disable the composer so the
+ * writer can't fire a second turn before the first lands.
+ */
+const hasPending = computed(() => messages.value.some(m => m.status === 'pending'))
+
+const composerDisabled = computed(() => !activeChat.value || busy.value || hasPending.value)
+
+// Polling state. Cleared on chat change, drawer close, and unmount so a
+// stale interval can't keep firing against the wrong chat.
+let pollTimer: ReturnType<typeof setInterval> | null = null
+const POLL_INTERVAL_MS = 2000
+const POLL_MAX_MS = 5 * 60 * 1000  // give up after 5 minutes
+let pollStartedAt = 0
+
+const stopPolling = () => {
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+const startPollingIfNeeded = () => {
+  if (pollTimer) return
+  if (!hasPending.value) return
+  pollStartedAt = Date.now()
+  pollTimer = setInterval(async () => {
+    if (!selectedChatId.value || !props.open) {
+      stopPolling()
+      return
+    }
+    if (Date.now() - pollStartedAt > POLL_MAX_MS) {
+      stopPolling()
+      errorMessage.value = 'The model is taking longer than expected. Refresh the chat to check again.'
+      return
+    }
+    try {
+      const r = await manuscriptChatApi.get(props.manuscriptId, selectedChatId.value)
+      messages.value = r.messages
+      if (!hasPending.value) {
+        stopPolling()
+        await scrollToBottom()
+      }
+    } catch (e) {
+      // Network blip — keep polling. If the user closes the drawer or
+      // navigates away, the watch on `props.open` clears the timer.
+      // eslint-disable-next-line no-console
+      console.warn('[chat] poll error', e)
+    }
+  }, POLL_INTERVAL_MS)
+}
 
 const scrollToBottom = async () => {
   await nextTick()
@@ -255,6 +323,9 @@ const loadMessages = async (chatId: string) => {
     messages.value = r.messages
     modelForActive.value = r.chat.model
     await scrollToBottom()
+    // If we landed on a chat whose latest assistant turn is still
+    // pending (e.g. the writer reloaded mid-call), resume polling.
+    if (hasPending.value) startPollingIfNeeded()
   } catch (e) {
     errorMessage.value = e instanceof Error ? e.message : String(e)
   } finally {
@@ -325,16 +396,20 @@ const changeModel = async () => {
 }
 
 const onSubmit = async () => {
-  if (!activeChat.value || busy.value || !draft.value.trim()) return
+  if (composerDisabled.value || !draft.value.trim()) return
+  if (!activeChat.value) return
   const content = draft.value.trim()
   busy.value = true
   errorMessage.value = ''
-  // Optimistic echo of the user message so the UI feels responsive.
+  // Optimistic echo of the user message so the UI feels responsive
+  // while the POST round-trip is in flight (~100ms now that the LLM
+  // call no longer blocks the request).
   const optimistic: ManuscriptChatMessage = {
     id: `optimistic-${Date.now()}`,
     chatId: activeChat.value.id,
     role: 'user',
     content,
+    status: 'complete',
     retrievedChunkIds: [],
     aiExchangeId: null,
     model: null,
@@ -347,17 +422,19 @@ const onSubmit = async () => {
   await scrollToBottom()
   try {
     const result = await manuscriptChatApi.sendMessage(props.manuscriptId, activeChat.value.id, content)
-    // Replace the optimistic message with the persisted one and append
-    // the assistant turn.
+    // The server returned the persisted user message + a 'pending'
+    // assistant placeholder. The actual assistant content arrives via
+    // polling once the background LLM call finishes.
     messages.value = [
       ...messages.value.filter(m => m.id !== optimistic.id),
       result.userMessage,
       result.assistantMessage,
     ]
-    citationsByMessageId.value = {
-      ...citationsByMessageId.value,
-      [result.assistantMessage.id]: result.citations,
-    }
+    // Citations are no longer returned synchronously — they land on
+    // the placeholder row via retrieved_chunk_ids when the background
+    // worker finalises it. The "Grounded in N sources" UI reads the
+    // chunk count off the message; the per-citation excerpts will
+    // populate when we add a chunks-by-id endpoint.
     // Bump the chat to the top of the list (its updatedAt just changed).
     const idx = chats.value.findIndex(c => c.id === result.chat.id)
     if (idx >= 0) {
@@ -365,6 +442,7 @@ const onSubmit = async () => {
       chats.value = [{ ...chat, updatedAt: result.chat.updatedAt }, ...chats.value]
     }
     await scrollToBottom()
+    startPollingIfNeeded()
   } catch (e) {
     errorMessage.value = e instanceof Error ? e.message : String(e)
     // Roll back the optimistic echo on failure so the writer can retry.
@@ -381,14 +459,28 @@ watch(() => props.open, async (open) => {
     await loadModels()
     await loadChats()
     await scrollToBottom()
+  } else {
+    // Stop polling when the drawer closes — we'll resume on reopen if
+    // there's still a pending message.
+    stopPolling()
   }
 })
 
 watch(() => props.manuscriptId, () => {
   // Manuscript changed — drop chat state and reload.
+  stopPolling()
   selectedChatId.value = ''
   messages.value = []
   if (props.open) loadChats()
+})
+
+watch(selectedChatId, () => {
+  // Switching chats invalidates the polling target.
+  stopPolling()
+})
+
+onBeforeUnmount(() => {
+  stopPolling()
 })
 </script>
 
@@ -399,5 +491,14 @@ aside {
 @keyframes slide-in {
   from { transform: translateX(8%); opacity: 0; }
   to   { transform: translateX(0);   opacity: 1; }
+}
+
+.dot-pulse-anim {
+  display: inline-block;
+  animation: dot-pulse 1.2s ease-in-out infinite;
+}
+@keyframes dot-pulse {
+  0%, 80%, 100% { opacity: 0.3; }
+  40%           { opacity: 1; }
 }
 </style>

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -208,15 +208,31 @@ service in
 UI in
 [ChatDrawer.vue](../client/src/components/manuscripts/ChatDrawer.vue).
 
-Per-turn flow:
+Per-turn flow (the HTTP handler returns within ~100ms; the LLM call runs
+in the background):
 
-1. Persist the user's message to `manuscript_chat_messages` immediately
-   (so the conversation state survives an LLM failure).
-2. Retrieve a fresh manuscript-scoped context pack for the new question.
-3. Send `system + retrieved_pack + last 6 turns + new question` via
-   `LlmClient.chatText` (non-JSON mode — returns markdown).
-4. Persist the assistant reply with `retrieved_chunk_ids` for provenance
-   and `ai_exchange_id` for the diagnostic audit trail.
+1. Persist the user's message to `manuscript_chat_messages` (status
+   `complete`).
+2. Persist a placeholder assistant message with status `pending` and
+   empty content (migration 024). Its id is captured so the background
+   worker can finalise it.
+3. Return the response immediately — both rows are included so the
+   client can render the placeholder with a spinner.
+4. **Background worker** (no awaiting in the request handler):
+   - Retrieve a fresh manuscript-scoped context pack for the new question.
+   - Send `system + retrieved_pack + last 6 turns + new question` via
+     `LlmClient.chatText` (non-JSON mode — returns markdown).
+   - UPDATE the placeholder with the final content, `retrieved_chunk_ids`
+     for provenance, `ai_exchange_id` for the diagnostic audit trail,
+     and status `complete`. Failures flip the status to `error` and the
+     content becomes a user-facing error message.
+5. The client polls `GET /api/manuscripts/:id/chats/:chatId` every 2s
+   until the placeholder is no longer pending (timeout 5 min).
+
+This shape exists because Heroku's web dyno has a hard 30s router
+timeout (H12). Reasoning models (gpt-5, gpt-5-mini) routinely take 40+
+seconds; the previous synchronous design dropped those connections
+even though the work itself completed correctly.
 
 Chats are private to their author even when the manuscript is shared.
 The per-conversation model is chosen from a curated allow-list

--- a/server/src/db/migrations/024_chat_messages_status.sql
+++ b/server/src/db/migrations/024_chat_messages_status.sql
@@ -1,0 +1,36 @@
+-- Migration 024: Async chat — pending assistant messages
+--
+-- Heroku's web dyno has a hard 30s router timeout (H12). The chat service
+-- was awaiting the LLM call inside the POST /messages handler, which
+-- routinely exceeded 30s — especially on reasoning models (gpt-5,
+-- gpt-5-mini). Production logs showed the work completing at ~42s while
+-- the user got a 503 because Heroku had already closed the connection.
+--
+-- Fix: the POST handler now persists a placeholder assistant message
+-- with status='pending' and returns immediately. A background promise
+-- runs retrieval + LLM and UPDATEs the placeholder when the work
+-- finishes. The client polls /chats/:id until status flips to
+-- 'complete' or 'error'.
+--
+-- Existing rows default to 'complete' so the read path is unchanged for
+-- chats that already exist.
+
+ALTER TABLE manuscript_chat_messages
+  ADD COLUMN IF NOT EXISTS status VARCHAR(16) NOT NULL DEFAULT 'complete';
+
+-- Drop the old single-value check (if present) and recreate so the column
+-- is constrained to the three known states.
+ALTER TABLE manuscript_chat_messages
+  DROP CONSTRAINT IF EXISTS check_chat_message_status;
+ALTER TABLE manuscript_chat_messages
+  ADD CONSTRAINT check_chat_message_status
+  CHECK (status IN ('pending', 'complete', 'error'));
+
+-- Partial index for the polling path. Most messages are 'complete'; we
+-- only ever query 'pending' rows briefly while a turn is in flight.
+CREATE INDEX IF NOT EXISTS idx_chat_messages_pending
+  ON manuscript_chat_messages(chat_id, status)
+  WHERE status = 'pending';
+
+COMMENT ON COLUMN manuscript_chat_messages.status IS
+  'Lifecycle of an assistant turn. user rows are always complete; assistant rows transition pending -> complete (or pending -> error).';

--- a/server/src/repositories/manuscript-chat.repo.ts
+++ b/server/src/repositories/manuscript-chat.repo.ts
@@ -31,6 +31,7 @@ const MESSAGE_COLUMNS = `
   chat_id              AS "chatId",
   role,
   content,
+  status,
   retrieved_chunk_ids  AS "retrievedChunkIds",
   ai_exchange_id       AS "aiExchangeId",
   model,
@@ -151,10 +152,10 @@ export const manuscriptChatRepo = {
   }): Promise<ManuscriptChatMessage> {
     const r = await pool.query(
       `INSERT INTO manuscript_chat_messages (
-         chat_id, role, content,
+         chat_id, role, content, status,
          retrieved_chunk_ids, ai_exchange_id, model,
          prompt_tokens, completion_tokens
-       ) VALUES ($1, $2, $3, $4::uuid[], $5, $6, $7, $8)
+       ) VALUES ($1, $2, $3, 'complete', $4::uuid[], $5, $6, $7, $8)
        RETURNING ${MESSAGE_COLUMNS}`,
       [
         input.chatId,
@@ -168,6 +169,74 @@ export const manuscriptChatRepo = {
       ]
     )
     await this.touch(input.chatId)
+    return r.rows[0]
+  },
+
+  /**
+   * Insert a placeholder assistant message in the 'pending' state. The
+   * background LLM worker later calls finalizeAssistantMessage() or
+   * errorAssistantMessage() to flip it to a terminal state. Empty content
+   * + pending status is what the polling client uses as the spinner cue.
+   */
+  async appendPendingAssistant(chatId: string, model: string): Promise<ManuscriptChatMessage> {
+    const r = await pool.query(
+      `INSERT INTO manuscript_chat_messages (
+         chat_id, role, content, status, model
+       ) VALUES ($1, 'assistant', '', 'pending', $2)
+       RETURNING ${MESSAGE_COLUMNS}`,
+      [chatId, model]
+    )
+    await this.touch(chatId)
+    return r.rows[0]
+  },
+
+  async finalizeAssistantMessage(input: {
+    id: string
+    content: string
+    retrievedChunkIds: string[]
+    aiExchangeId: string | null
+    model: string
+    promptTokens: number | null
+    completionTokens: number | null
+  }): Promise<ManuscriptChatMessage> {
+    const r = await pool.query(
+      `UPDATE manuscript_chat_messages
+          SET content             = $2,
+              status              = 'complete',
+              retrieved_chunk_ids = $3::uuid[],
+              ai_exchange_id      = $4,
+              model               = $5,
+              prompt_tokens       = $6,
+              completion_tokens   = $7
+        WHERE id = $1
+        RETURNING ${MESSAGE_COLUMNS}`,
+      [
+        input.id,
+        input.content,
+        input.retrievedChunkIds,
+        input.aiExchangeId,
+        input.model,
+        input.promptTokens,
+        input.completionTokens,
+      ]
+    )
+    if (r.rows.length > 0) {
+      await this.touch(r.rows[0].chatId)
+    }
+    return r.rows[0]
+  },
+
+  async errorAssistantMessage(id: string, errorContent: string): Promise<ManuscriptChatMessage | null> {
+    const r = await pool.query(
+      `UPDATE manuscript_chat_messages
+          SET content = $2,
+              status  = 'error'
+        WHERE id = $1
+        RETURNING ${MESSAGE_COLUMNS}`,
+      [id, errorContent]
+    )
+    if (r.rows.length === 0) return null
+    await this.touch(r.rows[0].chatId)
     return r.rows[0]
   },
 }

--- a/server/src/services/manuscript-chat.service.ts
+++ b/server/src/services/manuscript-chat.service.ts
@@ -220,13 +220,19 @@ export const manuscriptChatService = {
   },
 
   /**
-   * Send one user message and synchronously generate the assistant
-   * reply. Both messages are persisted (the user message first, before
-   * the LLM call, so the conversation state survives a model failure).
+   * Persist one user message + a 'pending' assistant placeholder, then
+   * RETURN IMMEDIATELY. The retrieval + LLM call runs as a background
+   * promise that finalises the placeholder when it completes.
    *
-   * If the model call throws, the user's message stays in the log and
-   * the error bubbles up — the UI shows the error inline; the writer
-   * can retry by sending again.
+   * Why this shape: Heroku's web dyno has a hard 30s router timeout.
+   * Reasoning models (gpt-5, gpt-5-mini) routinely take 40+ seconds.
+   * Awaiting the LLM call inside the request handler used to produce
+   * H12 timeouts even though the work itself completed correctly.
+   *
+   * The client polls GET /chats/:id until the placeholder transitions
+   * to 'complete' or 'error'. Citations for an answer are no longer
+   * returned synchronously — the client reads them out of the
+   * placeholder's retrieved_chunk_ids on the next poll cycle.
    */
   async sendMessage(
     chatId: string,
@@ -243,17 +249,16 @@ export const manuscriptChatService = {
     const chat = await manuscriptChatRepo.findById(chatId, userId)
     const manuscript = await manuscriptService.get(chat.manuscriptId, userId, isAdmin)
 
-    // Persist the user turn FIRST so it's durable even if the LLM call
-    // later fails. The drawer relies on this — a network blip mid-call
-    // shouldn't lose what the writer typed.
+    // 1. Persist the user turn so it's durable.
     const userMessage = await manuscriptChatRepo.appendMessage({
       chatId,
       role: 'user',
       content: trimmed,
     })
 
-    // Refuse the call cleanly if the LLM client isn't configured. We do
-    // this AFTER persisting the user turn so the writer's text is saved.
+    // 2. Refuse the call cleanly if the LLM client isn't configured.
+    //    Surfaced now (before the placeholder) so the writer sees a
+    //    real error instead of a placeholder that times out.
     let llm: LlmClient
     try {
       llm = client()
@@ -262,56 +267,94 @@ export const manuscriptChatService = {
       throw err
     }
 
-    // Pull a fresh context pack for the latest question. (We do not
-    // try to merge with prior turns' retrievals — every turn gets its
-    // own retrieval, scoped by the new query.)
-    const retrieved = await tryRetrieve(chat.manuscriptId, trimmed)
+    // 3. Insert the assistant placeholder with status='pending' and
+    //    capture its id so the background worker can finalise it.
+    const pendingAssistant = await manuscriptChatRepo.appendPendingAssistant(chatId, chat.model)
 
-    // Last N prior messages (excluding the one we just inserted, since
-    // it would duplicate the new user turn).
-    const allMessages = await manuscriptChatRepo.listMessages(chatId)
+    // 4. Kick off the long-running work. We DO NOT await this — the
+    //    HTTP handler returns within ~100ms regardless of how long
+    //    the LLM call takes. The promise updates the placeholder when
+    //    it finishes; any failure is recorded as an 'error' state on
+    //    the same row.
+    void runTurnInBackground({
+      chatId,
+      manuscriptId: chat.manuscriptId,
+      manuscriptTitle: manuscript.title,
+      userId,
+      userQuery: trimmed,
+      pendingAssistantId: pendingAssistant.id,
+      model: chat.model,
+      llm,
+    })
+
+    const refreshedChat = await manuscriptChatRepo.findById(chatId, userId)
+    return {
+      chat: refreshedChat,
+      userMessage,
+      assistantMessage: pendingAssistant,
+      // Citations land on the placeholder row when the background
+      // worker finalises it — the client reads them from the polled
+      // message rather than from this synchronous response.
+      citations: [],
+    }
+  },
+}
+
+/* ----- Background worker -----
+ *
+ * Runs outside any HTTP request lifecycle. It must not throw — every
+ * failure path is captured as an 'error' state on the placeholder so
+ * the client can render a clean message instead of polling forever.
+ */
+interface BackgroundTurnInput {
+  chatId: string
+  manuscriptId: string
+  manuscriptTitle: string
+  userId: string
+  userQuery: string
+  pendingAssistantId: string
+  model: string
+  llm: LlmClient
+}
+
+async function runTurnInBackground(input: BackgroundTurnInput): Promise<void> {
+  const start = Date.now()
+  try {
+    const retrieved = await tryRetrieve(input.manuscriptId, input.userQuery)
+
+    // Pull the trimmed history window — excluding the placeholder we
+    // just inserted (which is empty) and the just-persisted user
+    // message (which is appended explicitly below).
+    const allMessages = await manuscriptChatRepo.listMessages(input.chatId)
     const priorWindow = allMessages
-      .filter(m => m.id !== userMessage.id)
+      .filter(m => m.id !== input.pendingAssistantId && m.status === 'complete')
       .slice(-HISTORY_TURN_WINDOW)
 
     const messages = buildMessages({
-      manuscriptTitle: manuscript.title,
-      manuscriptId: chat.manuscriptId,
+      manuscriptTitle: input.manuscriptTitle,
+      manuscriptId: input.manuscriptId,
       contextPack: retrieved.contextPack,
       history: priorWindow,
-      userMessage: trimmed,
+      userMessage: input.userQuery,
     })
 
-    const start = Date.now()
-    const response = await llm.chatText({
-      model: chat.model,
+    const response = await input.llm.chatText({
+      model: input.model,
       messages,
-      // Slightly higher than the JSON modes — chat answers are ok being
-      // a touch more varied. Bounded so the model still grounds.
       temperature: 0.5,
       maxOutputTokens: 1500,
       context: {
         feature: 'manuscript-chat',
         mode: 'turn',
-        userId,
+        userId: input.userId,
         resourceType: 'manuscript_chat',
-        resourceId: chatId,
-        manuscriptId: chat.manuscriptId,
+        resourceId: input.chatId,
+        manuscriptId: input.manuscriptId,
       },
     })
-    logger.info('[manuscript-chat] turn completed', {
-      chatId,
-      manuscriptId: chat.manuscriptId,
-      model: response.model,
-      ms: Date.now() - start,
-      retrievedChunks: retrieved.chunkIds.length,
-      promptTokens: response.usage?.promptTokens,
-      completionTokens: response.usage?.completionTokens,
-    })
 
-    const assistantMessage = await manuscriptChatRepo.appendMessage({
-      chatId,
-      role: 'assistant',
+    await manuscriptChatRepo.finalizeAssistantMessage({
+      id: input.pendingAssistantId,
       content: response.content,
       retrievedChunkIds: retrieved.chunkIds,
       aiExchangeId: response.exchangeId ?? null,
@@ -320,13 +363,37 @@ export const manuscriptChatService = {
       completionTokens: response.usage?.completionTokens ?? null,
     })
 
-    const refreshedChat = await manuscriptChatRepo.findById(chatId, userId)
-
-    return {
-      chat: refreshedChat,
-      userMessage,
-      assistantMessage,
-      citations: retrieved.citations,
+    logger.info('[manuscript-chat] background turn completed', {
+      chatId: input.chatId,
+      manuscriptId: input.manuscriptId,
+      model: response.model,
+      ms: Date.now() - start,
+      retrievedChunks: retrieved.chunkIds.length,
+      promptTokens: response.usage?.promptTokens,
+      completionTokens: response.usage?.completionTokens,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logger.error('[manuscript-chat] background turn failed', {
+      chatId: input.chatId,
+      manuscriptId: input.manuscriptId,
+      pendingAssistantId: input.pendingAssistantId,
+      ms: Date.now() - start,
+      message,
+    })
+    // Best-effort. If even this update fails the placeholder will stay
+    // 'pending' forever — the polling client gives up after the timeout
+    // and the writer can resend.
+    try {
+      await manuscriptChatRepo.errorAssistantMessage(
+        input.pendingAssistantId,
+        `The model call failed. ${message}`
+      )
+    } catch (writeErr) {
+      logger.error('[manuscript-chat] could not record error on placeholder', {
+        pendingAssistantId: input.pendingAssistantId,
+        message: writeErr instanceof Error ? writeErr.message : String(writeErr),
+      })
     }
-  },
+  }
 }

--- a/shared/ManuscriptChat.ts
+++ b/shared/ManuscriptChat.ts
@@ -23,6 +23,15 @@
 
 export type ChatMessageRole = 'user' | 'assistant'
 
+/**
+ * Lifecycle of a chat message:
+ *   - 'complete'  — terminal state for user turns and finished assistant turns
+ *   - 'pending'   — assistant placeholder while the LLM call is still running
+ *                   in the background (see migration 024 for the why)
+ *   - 'error'     — assistant turn failed; `content` holds a user-facing message
+ */
+export type ChatMessageStatus = 'pending' | 'complete' | 'error'
+
 export interface ManuscriptChat {
   id: string
   manuscriptId: string
@@ -38,7 +47,13 @@ export interface ManuscriptChatMessage {
   id: string
   chatId: string
   role: ChatMessageRole
+  /**
+   * Final assistant message text, or the user's prompt. Empty string while
+   * an assistant message is in `status='pending'` (the placeholder the
+   * server inserts before the LLM call completes).
+   */
   content: string
+  status: ChatMessageStatus
   /** chunk ids the assistant was shown for this turn. Empty for user turns. */
   retrievedChunkIds: string[]
   /** Diagnostic ai_exchanges.id for this turn. NULL for user turns. */


### PR DESCRIPTION
## Summary

Production logs showed a chat turn complete at **41,926ms** with `gpt-5`, but the user got a **503 H12 (Request timeout)** from Heroku's router because the web dyno enforces a hard **30s** limit. The work itself was correct — the server persisted the assistant message after Heroku had already closed the HTTP connection — but from the user's POV the chat was broken on every reasoning-model turn.

\`\`\`
2026-05-06T10:57:13 heroku[router]: at=error code=H12 desc="Request timeout"
                                    method=POST … service=30000ms status=503
2026-05-06T10:57:26 app[web.1]: [INFO] [manuscript-chat] turn completed {
                                  model: 'gpt-5', ms: 41926, retrievedChunks: 4,
                                  promptTokens: 3186, completionTokens: 800 }
\`\`\`

This PR switches the chat to an async/background pattern: the HTTP handler returns within ~100ms with a \`pending\` placeholder; the LLM call runs in the background and updates the placeholder when it finishes; the client polls \`GET /chats/:id\` every 2s and renders the answer when status flips to \`complete\` or \`error\`.

## Schema ([024_chat_messages_status.sql](server/src/db/migrations/024_chat_messages_status.sql))

- New \`status\` column on \`manuscript_chat_messages\`: \`'pending' | 'complete' | 'error'\`
- Existing rows default to \`complete\` so the read path is unchanged
- Partial index on \`(chat_id, status) WHERE status = 'pending'\` for the short-lived polling path

## Server changes

[server/src/repositories/manuscript-chat.repo.ts](server/src/repositories/manuscript-chat.repo.ts):
- \`appendPendingAssistant(chatId, model)\` — inserts a placeholder row with empty content + status \`pending\`
- \`finalizeAssistantMessage(id, …)\` — UPDATEs the placeholder with the LLM response, \`retrieved_chunk_ids\`, \`ai_exchange_id\`, status \`complete\`
- \`errorAssistantMessage(id, msg)\` — flips the placeholder to status \`error\` with a user-facing message

[server/src/services/manuscript-chat.service.ts](server/src/services/manuscript-chat.service.ts):
- \`POST /messages\` handler now returns within ~100ms:
  1. persist user message
  2. validate LLM client config (so misconfig surfaces as a real error, not as a placeholder that polls forever)
  3. persist a \`pending\` assistant placeholder
  4. spawn the LLM work as an **unawaited** background promise
  5. return user + placeholder
- \`runTurnInBackground()\` does retrieval + \`chatText\` + finalize. Cannot throw — every failure path flips the placeholder to \`error\` with a message the writer can read.

## Client changes ([ChatDrawer.vue](client/src/components/manuscripts/ChatDrawer.vue))

- Assistant placeholder renders with a "Thinking…" pulse while pending; \`status='error'\` rows render in red
- Polls \`GET /chats/:id\` every 2s while any message is pending; stops on resolution, timeout (5 min), drawer close, chat change, or component unmount
- Composer disabled while a pending message exists in the active chat — prevents queueing a second turn before the first lands
- Resumes polling automatically on reload if the latest assistant turn is still pending (e.g. user closed the tab and came back)
- Citations now arrive on the polled message (\`retrieved_chunk_ids\`) rather than synchronously from the POST response

## Reviewer notes

- **Background promise is fire-and-forget.** Node keeps the worker alive across HTTP requests because the promise holds a reference to the LLM client. The dyno can't be restarted mid-turn without losing the work, but Heroku web dynos restart at most once per day and the writer can re-send if a turn was interrupted.
- **5-minute polling cap.** If the LLM call exceeds 5 minutes (e.g. provider hang), polling stops and the writer gets a "refresh to check again" message. The placeholder stays pending in the DB; on next chat reload \`loadMessages()\` will pick it up and resume polling.
- **No SSE.** Polling was the simpler pragmatic fix vs. server-sent events. SSE would still require heartbeats every <55s on Heroku and a separate streaming-aware controller, which we can revisit if 2s polling latency is annoying in practice.
- **Audit trail intact.** \`ai_exchange_id\` is recorded on the finalised message, so \`/admin/ai-exchanges?manuscriptId=...\` still shows the full prompt + raw response for every turn.
- Both \`vue-tsc --noEmit\` and \`tsc -p server --noEmit\` pass.

## Test plan

- [ ] Apply migration: \`npm run migrate\`
- [ ] Open a manuscript → click **Chat** → switch model to **gpt-5** → ask a question that takes >30s
- [ ] Confirm the placeholder shows "Thinking… (gpt-5)" with a pulse, the composer is disabled, and the answer lands automatically when the LLM finishes (no H12 in the logs)
- [ ] Confirm \`/admin/ai-exchanges?manuscriptId=…\` shows the exchange with status \`ok\` and the full response
- [ ] Mid-call: close the drawer, then re-open it → polling resumes from the existing pending message; answer arrives normally
- [ ] Mid-call: reload the page → drawer reloads, sees the still-pending placeholder, resumes polling
- [ ] Force a failure (e.g. break the OpenAI key in the env, restart) → placeholder flips to status \`error\` with a red message

🤖 Generated with [Claude Code](https://claude.com/claude-code)