### PR TITLE
Fix: chat polling served stale (cached) messages

### DIFF
--- a/client/src/api/manuscriptChat.ts
+++ b/client/src/api/manuscriptChat.ts
@@ -47,8 +47,15 @@ export const manuscriptChatApi = {
   },
 
   get(manuscriptId: string, chatId: string): Promise<ManuscriptChatWithMessages> {
+    // cache: 'no-store' is defence in depth on top of the server's
+    // Cache-Control: no-store header. The poll path needs the freshest
+    // possible row to detect when a pending placeholder has been
+    // finalised by the background worker.
     return api
-      .get<ApiResponse<ManuscriptChatWithMessages>>(`/manuscripts/${manuscriptId}/chats/${chatId}`)
+      .get<ApiResponse<ManuscriptChatWithMessages>>(
+        `/manuscripts/${manuscriptId}/chats/${chatId}`,
+        { cache: 'no-store' }
+      )
       .then(r => r.data)
   },
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -82,6 +82,29 @@ app.use('/api', (req, res, next) => {
   generalRateLimit(req, res, next)
 })
 
+// Disable HTTP caching on every API response.
+//
+// Why: bafbe.com sits behind Cloudflare. Without an explicit Cache-Control
+// header, both the browser and Cloudflare's edge are free to apply
+// heuristic caching to GET responses. The chat-polling path was hitting
+// this — the client polled GET /chats/:id and got back a stale snapshot
+// of the assistant message (status=pending, content='') AFTER the
+// background worker had already finalised it. The result was a chat
+// that looked like it never replied, even though the server had done
+// the work.
+//
+// Marking every API response as no-store, no-cache, must-revalidate +
+// "private" guarantees neither Cloudflare nor any intermediary serves
+// stale data, and tells the browser not to keep its own copy. The
+// performance cost is negligible — the API responses are personalised
+// per user and not really cacheable to begin with.
+app.use('/api', (_req, res, next) => {
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+  res.setHeader('Pragma', 'no-cache')
+  res.setHeader('Expires', '0')
+  next()
+})
+
 // Serve uploaded images from PostgreSQL (filesystem is ephemeral on Heroku)
 app.get('/uploads/cover/:filename', asyncHandler(uploadsController.serve))
 


### PR DESCRIPTION
## Summary

After [#83](https://github.com/DRCUOA/befly/pull/83) ran the LLM call in the background and polled for the result, the client was getting back a **stale** snapshot of the assistant message. The screenshot showed an assistant turn rendered with just the model name "gpt-5" — no body, no token count — even though the server log said:

\`\`\`
[manuscript-chat] background turn completed {
  chatId: '7650ee3d-…', model: 'gpt-5', ms: 28636,
  retrievedChunks: 8, promptTokens: 1969, completionTokens: 642
}
\`\`\`

The work succeeded; the client just couldn't see it.

## Root cause

\`bafbe.com\` sits behind Cloudflare (visible in the Heroku log: \`fwd="…, 104.23.198.10"\` is a Cloudflare edge IP). Without an explicit \`Cache-Control\` header on \`/api/*\` responses, both the browser and Cloudflare's edge apply heuristic caching to GET responses. The polling \`GET /chats/:id\` was happily returning a copy of the message row from **before** the background worker ran the finalize UPDATE — so the client kept seeing \`status='pending'\` but with the placeholder's empty content (and once the cache eventually expired, only partial fields).

## Fix

**Server ([server/src/app.ts](server/src/app.ts))**
Add a middleware that sets \`Cache-Control: no-store, no-cache, must-revalidate, private\` (plus \`Pragma: no-cache\` and \`Expires: 0\` for any HTTP/1.0 intermediaries) on every \`/api/*\` response. Every API response is per-user and not really cacheable to begin with — this is the safer default for an authenticated API.

**Client ([client/src/api/manuscriptChat.ts](client/src/api/manuscriptChat.ts))**
The polling \`get()\` now passes \`cache: 'no-store'\` to fetch, so even if some intermediary ignored the response headers, the browser wouldn't reuse its own cached copy.

## Reviewer notes

- The middleware is on the whole \`/api/*\` tree, not just chat. Other endpoints (admin essays, ai-exchanges, themes, etc.) are also per-user and were vulnerable to the same caching issue — they just hadn't surfaced it because nothing else polled. This is preventative.
- No content-cacheable endpoints are affected. \`/uploads/cover/:filename\` is mounted outside \`/api\` and has its own caching path.
- Both halves type-check.

## Test plan

- [ ] Deploy → open Chat → switch model to gpt-5 → ask a question that takes ~30s
- [ ] Expected: "Thinking…" pulse for the duration, then the full reply lands automatically with completion-token count and the "Grounded in N sources" provenance panel
- [ ] Open DevTools → Network → confirm \`Cache-Control: no-store\` on the GET \`/chats/:id\` responses
- [ ] Cloudflare's CF-Cache-Status header on the response should be \`BYPASS\` or \`DYNAMIC\`, not \`HIT\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)