### PR TITLE
Named-user edit grants and revision history for frags

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -10,6 +10,26 @@ export interface RequestOptions extends RequestInit {
   params?: Record<string, string>
 }
 
+/**
+ * Structured error returned by the API client. Carries the HTTP status,
+ * the server-supplied `code` field (when present), and any `details`
+ * payload (used by 409 optimistic-lock conflicts to carry the current
+ * server-side version). UI code can branch on `status === 409` or
+ * `code === 'CONFLICT'` to drive merge/retry flows.
+ */
+export class ApiError extends Error {
+  status: number
+  code?: string
+  details?: Record<string, unknown>
+  constructor(message: string, status: number, code?: string, details?: Record<string, unknown>) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+    this.details = details
+  }
+}
+
 // Get CSRF token from cookie (set by server)
 function getCsrfToken(): string | null {
   const cookies = document.cookie.split(';')
@@ -66,13 +86,22 @@ async function request<T>(
 
   if (!response.ok) {
     let serverMessage: string | undefined
+    let serverCode: string | undefined
+    let serverDetails: Record<string, unknown> | undefined
     try {
       const body = await response.json()
       serverMessage = body?.error
+      serverCode = body?.code
+      serverDetails = body?.details
     } catch {
       // Response body was not valid JSON (e.g. proxy HTML error page)
     }
-    throw new Error(serverMessage || `Request failed (${response.status} ${response.statusText})`)
+    throw new ApiError(
+      serverMessage || `Request failed (${response.status} ${response.statusText})`,
+      response.status,
+      serverCode,
+      serverDetails
+    )
   }
 
   // Handle empty responses (204 No Content, etc.)
@@ -119,6 +148,13 @@ export const api = {
     request<T>(endpoint, {
       ...options,
       method: 'PUT',
+      body: JSON.stringify(data)
+    }),
+
+  patch: <T>(endpoint: string, data?: unknown, options?: RequestOptions) =>
+    request<T>(endpoint, {
+      ...options,
+      method: 'PATCH',
       body: JSON.stringify(data)
     }),
 

--- a/client/src/api/writing.ts
+++ b/client/src/api/writing.ts
@@ -1,0 +1,85 @@
+/**
+ * Writing collaboration API — editors, revisions, restore, user search.
+ *
+ * Mirrors the backend route shape:
+ *   /api/writing/:id/editors                       list, upsert
+ *   /api/writing/:id/editors/:targetUserId         patch, remove
+ *   /api/writing/:id/revisions                     list
+ *   /api/writing/:id/revisions/:versionNumber      full revision (body)
+ *   /api/writing/:id/restore/:versionNumber        rollback
+ *   /api/users/search?q=                           authenticated user search
+ */
+import { api } from './client'
+import type { ApiResponse } from '@shared/ApiResponses'
+import type {
+  WritingBlockEditor,
+  WritingBlockEditorPermission,
+} from '@shared/WritingBlockEditor'
+import type {
+  WritingBlockRevision,
+  WritingBlockRevisionSummary,
+} from '@shared/WritingBlockRevision'
+import type { WritingBlock } from '@shared/WritingBlock'
+
+export interface UserSearchHit {
+  id: string
+  displayName: string
+  email: string
+}
+
+export const writingApi = {
+  // --- Editors ---
+  listEditors: (writingId: string) =>
+    api
+      .get<ApiResponse<WritingBlockEditor[]>>(`/writing/${writingId}/editors`)
+      .then(r => r.data),
+
+  upsertEditor: (
+    writingId: string,
+    body: { userId: string; permission: WritingBlockEditorPermission }
+  ) =>
+    api
+      .post<ApiResponse<WritingBlockEditor>>(`/writing/${writingId}/editors`, body)
+      .then(r => r.data),
+
+  changeEditor: (
+    writingId: string,
+    targetUserId: string,
+    permission: WritingBlockEditorPermission
+  ) =>
+    api
+      .patch<ApiResponse<WritingBlockEditor>>(
+        `/writing/${writingId}/editors/${targetUserId}`,
+        { permission }
+      )
+      .then(r => r.data),
+
+  removeEditor: (writingId: string, targetUserId: string) =>
+    api.delete(`/writing/${writingId}/editors/${targetUserId}`),
+
+  // --- Revisions ---
+  listRevisions: (writingId: string) =>
+    api
+      .get<ApiResponse<WritingBlockRevisionSummary[]>>(`/writing/${writingId}/revisions`)
+      .then(r => r.data),
+
+  getRevision: (writingId: string, versionNumber: number) =>
+    api
+      .get<ApiResponse<WritingBlockRevision>>(
+        `/writing/${writingId}/revisions/${versionNumber}`
+      )
+      .then(r => r.data),
+
+  restore: (writingId: string, versionNumber: number, note?: string) =>
+    api
+      .post<ApiResponse<WritingBlock>>(
+        `/writing/${writingId}/restore/${versionNumber}`,
+        note ? { note } : {}
+      )
+      .then(r => r.data),
+}
+
+export const userSearchApi = {
+  search: (q: string) =>
+    api.get<ApiResponse<UserSearchHit[]>>(`/users/search?q=${encodeURIComponent(q)}`).then(r => r.data),
+}

--- a/client/src/components/writing/EditorsPanel.vue
+++ b/client/src/components/writing/EditorsPanel.vue
@@ -1,0 +1,234 @@
+<template>
+  <div
+    role="dialog"
+    aria-label="Editor permissions"
+    aria-modal="true"
+    :aria-hidden="!modelValue"
+    class="fixed inset-y-0 right-0 z-40 w-full max-w-md bg-paper border-l border-line shadow-xl flex flex-col transform transition-transform duration-150 ease-out"
+    :class="modelValue ? 'translate-x-0' : 'translate-x-full'"
+    tabindex="-1"
+    @keydown.escape="close"
+  >
+    <div class="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-line shrink-0">
+      <h2 class="text-lg font-sans font-medium text-ink">Editors</h2>
+      <button
+        type="button"
+        class="p-2 -m-2 text-ink-lighter hover:text-ink rounded focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
+        aria-label="Close editors panel"
+        @click="close"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <div class="flex-1 overflow-y-auto px-4 sm:px-6 py-4 space-y-6">
+      <p class="text-sm text-ink-lighter">
+        Invite specific users to edit this frag. The original author and
+        admins always have full access. Editors with <em>manage</em> rights
+        can also add or remove other editors.
+      </p>
+
+      <!-- Invite -->
+      <div>
+        <label class="block text-sm font-medium text-ink-lighter mb-1" for="editor-search">
+          Invite by name or email
+        </label>
+        <div class="relative">
+          <input
+            id="editor-search"
+            v-model="searchQuery"
+            type="text"
+            autocomplete="off"
+            placeholder="Search active users..."
+            class="w-full px-3 py-2 text-sm border border-line rounded bg-paper text-ink focus:outline-none focus:ring-2 focus:ring-accent"
+            @input="onSearchInput"
+          />
+          <div
+            v-if="searchResults.length > 0"
+            class="absolute z-10 left-0 right-0 mt-1 bg-paper border border-line rounded shadow-lg max-h-60 overflow-y-auto"
+          >
+            <button
+              v-for="hit in searchResults"
+              :key="hit.id"
+              type="button"
+              class="w-full px-3 py-2 text-left hover:bg-line focus:bg-line text-sm text-ink"
+              @click="invite(hit)"
+            >
+              <div class="font-medium">{{ hit.displayName || hit.email }}</div>
+              <div class="text-xs text-ink-lighter">{{ hit.email }}</div>
+            </button>
+          </div>
+        </div>
+        <div class="mt-2 flex items-center gap-3">
+          <label class="text-xs text-ink-lighter">Permission:</label>
+          <select
+            v-model="pendingPermission"
+            class="text-sm border border-line rounded bg-paper text-ink px-2 py-1"
+          >
+            <option value="edit">Edit</option>
+            <option value="manage">Manage</option>
+          </select>
+        </div>
+        <p v-if="inviteError" class="mt-2 text-sm text-red-600">{{ inviteError }}</p>
+      </div>
+
+      <!-- Current grants -->
+      <div>
+        <h3 class="text-sm font-medium text-ink mb-2">Current editors</h3>
+        <p v-if="!loading && editors.length === 0" class="text-sm text-ink-lighter">
+          No editors yet. The frag is only editable by you and admins.
+        </p>
+        <ul v-else class="space-y-2">
+          <li
+            v-for="ed in editors"
+            :key="ed.id"
+            class="border border-line rounded px-3 py-2 flex items-center gap-3"
+          >
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium text-ink truncate">
+                {{ ed.userDisplayName || ed.userEmail || ed.userId }}
+              </div>
+              <div class="text-xs text-ink-lighter">
+                Granted {{ formatDate(ed.createdAt) }}
+                <span v-if="ed.grantedByDisplayName"> by {{ ed.grantedByDisplayName }}</span>
+              </div>
+            </div>
+            <select
+              :value="ed.permission"
+              class="text-xs border border-line rounded bg-paper text-ink px-1.5 py-1"
+              @change="onChangePermission(ed, ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="edit">Edit</option>
+              <option value="manage">Manage</option>
+            </select>
+            <button
+              type="button"
+              class="text-xs text-red-600 hover:underline"
+              @click="onRemove(ed)"
+            >
+              Remove
+            </button>
+          </li>
+        </ul>
+      </div>
+
+      <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { writingApi, userSearchApi, type UserSearchHit } from '@/api/writing'
+import type {
+  WritingBlockEditor,
+  WritingBlockEditorPermission,
+} from '@shared/WritingBlockEditor'
+
+const props = defineProps<{
+  modelValue: boolean
+  writingId: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+}>()
+
+const editors = ref<WritingBlockEditor[]>([])
+const loading = ref(false)
+const error = ref('')
+const inviteError = ref('')
+
+const searchQuery = ref('')
+const searchResults = ref<UserSearchHit[]>([])
+const pendingPermission = ref<WritingBlockEditorPermission>('edit')
+let searchDebounce: ReturnType<typeof setTimeout> | null = null
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+async function refresh() {
+  if (!props.writingId) return
+  loading.value = true
+  error.value = ''
+  try {
+    editors.value = await writingApi.listEditors(props.writingId)
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to load editors'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => [props.modelValue, props.writingId],
+  ([open]) => {
+    if (open) refresh()
+  },
+  { immediate: true }
+)
+
+function onSearchInput() {
+  if (searchDebounce) clearTimeout(searchDebounce)
+  const q = searchQuery.value.trim()
+  if (q.length < 2) {
+    searchResults.value = []
+    return
+  }
+  searchDebounce = setTimeout(async () => {
+    try {
+      searchResults.value = await userSearchApi.search(q)
+    } catch {
+      searchResults.value = []
+    }
+  }, 200)
+}
+
+async function invite(hit: UserSearchHit) {
+  inviteError.value = ''
+  try {
+    await writingApi.upsertEditor(props.writingId, {
+      userId: hit.id,
+      permission: pendingPermission.value,
+    })
+    searchQuery.value = ''
+    searchResults.value = []
+    await refresh()
+  } catch (e: any) {
+    inviteError.value = e?.message || 'Failed to grant access'
+  }
+}
+
+async function onChangePermission(ed: WritingBlockEditor, perm: string) {
+  if (perm !== 'edit' && perm !== 'manage') return
+  if (perm === ed.permission) return
+  try {
+    await writingApi.changeEditor(props.writingId, ed.userId, perm)
+    await refresh()
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to update permission'
+  }
+}
+
+async function onRemove(ed: WritingBlockEditor) {
+  const label = ed.userDisplayName || ed.userEmail || 'this editor'
+  if (!confirm(`Remove ${label}'s access to this frag?`)) return
+  try {
+    await writingApi.removeEditor(props.writingId, ed.userId)
+    await refresh()
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to remove editor'
+  }
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+</script>

--- a/client/src/components/writing/RevisionHistoryPanel.vue
+++ b/client/src/components/writing/RevisionHistoryPanel.vue
@@ -1,0 +1,195 @@
+<template>
+  <div
+    role="dialog"
+    aria-label="Revision history"
+    aria-modal="true"
+    :aria-hidden="!modelValue"
+    class="fixed inset-y-0 right-0 z-40 w-full max-w-md bg-paper border-l border-line shadow-xl flex flex-col transform transition-transform duration-150 ease-out"
+    :class="modelValue ? 'translate-x-0' : 'translate-x-full'"
+    tabindex="-1"
+    @keydown.escape="close"
+  >
+    <div class="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-line shrink-0">
+      <h2 class="text-lg font-sans font-medium text-ink">Revision history</h2>
+      <button
+        type="button"
+        class="p-2 -m-2 text-ink-lighter hover:text-ink rounded focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
+        aria-label="Close history panel"
+        @click="close"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <div class="flex-1 overflow-y-auto px-4 sm:px-6 py-4 space-y-4">
+      <p class="text-sm text-ink-lighter">
+        Every checkpointed save creates a new revision. Restoring a
+        revision creates a new entry — nothing is ever lost.
+      </p>
+
+      <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
+      <p v-if="!loading && revisions.length === 0" class="text-sm text-ink-lighter">No revisions yet.</p>
+
+      <ol class="space-y-2">
+        <li
+          v-for="rev in revisions"
+          :key="rev.id"
+          class="border border-line rounded px-3 py-2"
+        >
+          <div class="flex items-baseline justify-between gap-2">
+            <div class="text-sm font-medium text-ink">
+              v{{ rev.versionNumber }}
+              <span
+                v-if="rev.revisionKind !== 'edit'"
+                class="ml-1 text-xs uppercase tracking-wide text-accent"
+              >{{ rev.revisionKind }}</span>
+              <span
+                v-if="rev.restoredFromVersion"
+                class="ml-1 text-xs text-ink-lighter"
+              >from v{{ rev.restoredFromVersion }}</span>
+            </div>
+            <div class="text-xs text-ink-lighter">{{ formatDate(rev.editedAt) }}</div>
+          </div>
+          <div class="text-xs text-ink-lighter mt-0.5">
+            by {{ rev.editorDisplayName || (rev.editedBy ? 'unknown user' : 'deleted user') }}
+          </div>
+          <p v-if="rev.note" class="text-xs italic text-ink mt-1">"{{ rev.note }}"</p>
+          <div class="mt-2 flex items-center gap-3">
+            <button
+              type="button"
+              class="text-xs text-ink hover:underline"
+              :disabled="busy"
+              @click="preview(rev.versionNumber)"
+            >
+              Preview
+            </button>
+            <button
+              v-if="canRestore"
+              type="button"
+              class="text-xs text-accent hover:underline"
+              :disabled="busy"
+              @click="restore(rev.versionNumber)"
+            >
+              Restore
+            </button>
+          </div>
+        </li>
+      </ol>
+    </div>
+
+    <!-- Preview modal -->
+    <div
+      v-if="previewRev"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      @click.self="previewRev = null"
+    >
+      <div class="bg-paper rounded shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-line">
+          <div class="text-sm font-medium text-ink">
+            v{{ previewRev.versionNumber }} preview ·
+            <span class="text-ink-lighter font-normal">
+              {{ previewRev.editorDisplayName || 'unknown' }} ·
+              {{ formatDate(previewRev.editedAt) }}
+            </span>
+          </div>
+          <button
+            type="button"
+            class="text-ink-lighter hover:text-ink"
+            @click="previewRev = null"
+          >Close</button>
+        </div>
+        <div class="overflow-y-auto px-4 py-3">
+          <h3 class="font-serif text-lg text-ink mb-2">{{ previewRev.title }}</h3>
+          <div class="whitespace-pre-wrap text-sm text-ink">{{ previewRev.body }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { writingApi } from '@/api/writing'
+import type {
+  WritingBlockRevision,
+  WritingBlockRevisionSummary,
+} from '@shared/WritingBlockRevision'
+
+const props = defineProps<{
+  modelValue: boolean
+  writingId: string
+  canRestore: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'restored'): void
+}>()
+
+const revisions = ref<WritingBlockRevisionSummary[]>([])
+const loading = ref(false)
+const busy = ref(false)
+const error = ref('')
+const previewRev = ref<WritingBlockRevision | null>(null)
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+async function refresh() {
+  if (!props.writingId) return
+  loading.value = true
+  error.value = ''
+  try {
+    revisions.value = await writingApi.listRevisions(props.writingId)
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to load history'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => [props.modelValue, props.writingId],
+  ([open]) => {
+    if (open) refresh()
+  },
+  { immediate: true }
+)
+
+async function preview(versionNumber: number) {
+  busy.value = true
+  try {
+    previewRev.value = await writingApi.getRevision(props.writingId, versionNumber)
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to load revision'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function restore(versionNumber: number) {
+  if (!confirm(`Restore v${versionNumber}? The current state will be preserved as a new revision first.`)) return
+  busy.value = true
+  error.value = ''
+  try {
+    await writingApi.restore(props.writingId, versionNumber)
+    await refresh()
+    emit('restored')
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to restore revision'
+  } finally {
+    busy.value = false
+  }
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+</script>

--- a/client/src/pages/Write.vue
+++ b/client/src/pages/Write.vue
@@ -163,6 +163,39 @@
       @cancel="showCropModal = false"
     />
 
+    <!-- Collaboration panels. Only meaningful for existing frags. Server
+         enforces who's allowed to manage editors or restore history; we
+         deliberately don't gate the buttons by role so admin/manager
+         editors can also reach them without an extra round-trip. -->
+    <EditorsPanel
+      v-if="isEditing && writingId"
+      v-model="editorsPanelOpen"
+      :writing-id="writingId"
+    />
+    <RevisionHistoryPanel
+      v-if="isEditing && writingId"
+      v-model="historyPanelOpen"
+      :writing-id="writingId"
+      :can-restore="true"
+      @restored="loadWriting"
+    />
+
+    <div
+      v-if="isEditing"
+      class="fixed top-4 right-4 z-30 flex gap-2 print:hidden"
+    >
+      <button
+        type="button"
+        class="px-2 py-1 text-xs rounded border border-line bg-paper text-ink hover:bg-line"
+        @click="editorsPanelOpen = true"
+      >Editors</button>
+      <button
+        type="button"
+        class="px-2 py-1 text-xs rounded border border-line bg-paper text-ink hover:bg-line"
+        @click="historyPanelOpen = true"
+      >History</button>
+    </div>
+
     <!-- Floating zen cluster — page actions on top, AI tools below. This is
          the ONLY persistent UI on the editor surface. Nothing else.  -->
     <WritingToolsCluster
@@ -285,6 +318,9 @@ import CoverImageCropModal from '../components/writing/CoverImageCropModal.vue'
 import WritingToolsCluster from '../components/writing/WritingToolsCluster.vue'
 import WritingAssistPanel from '../components/writing/WritingAssistPanel.vue'
 import FindReplacePanel from '../components/writing/FindReplacePanel.vue'
+import EditorsPanel from '../components/writing/EditorsPanel.vue'
+import RevisionHistoryPanel from '../components/writing/RevisionHistoryPanel.vue'
+import { ApiError } from '../api/client'
 import { useBreathingCaret } from '../composables/useBreathingCaret'
 import { useWritingAssist } from '../composables/useWritingAssist'
 import type { WritingAssistMode } from '@shared/WritingAssist'
@@ -299,6 +335,18 @@ const { navigateBack } = useNavigationOrigin('/home')
 
 const writingId = computed(() => route.params.id as string | undefined)
 const isEditing = computed(() => !!writingId.value)
+
+// Optimistic-lock version of the loaded frag. We refresh this on load and
+// on every successful save; the server bumps it on its side, so any other
+// editor's save between our load and our save will trigger a 409 which
+// we surface as a "merge" prompt rather than silently overwriting.
+const currentVersion = ref<number | null>(null)
+
+// Collaboration panels. We show the buttons unconditionally on existing
+// frags; the server enforces who's actually allowed to manage editors or
+// restore revisions, so unauthorized users just see a friendly error.
+const editorsPanelOpen = ref(false)
+const historyPanelOpen = ref(false)
 
 const form = ref({
   title: '',
@@ -530,6 +578,7 @@ const loadWriting = async () => {
     error.value = null
     const response = await api.get<ApiResponse<WritingBlock>>(`/writing/${writingId.value}`)
     setFormState(response.data)
+    currentVersion.value = (response.data as WritingBlock & { currentVersion?: number }).currentVersion ?? null
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to load writing'
   } finally {
@@ -607,14 +656,16 @@ const doSubmit = async () => {
     error.value = null
 
     if (isEditing.value && writingId.value) {
-      await api.put<ApiResponse<any>>(`/writing/${writingId.value}`, {
+      const res = await api.put<ApiResponse<WritingBlock>>(`/writing/${writingId.value}`, {
         title: form.value.title,
         body: form.value.body,
         themeIds: form.value.themeIds,
         visibility: form.value.visibility,
         coverImageUrl: form.value.coverImageUrl || undefined,
-      coverImagePosition: form.value.coverImagePosition || undefined
+        coverImagePosition: form.value.coverImagePosition || undefined,
+        expectedVersion: currentVersion.value ?? undefined,
       })
+      currentVersion.value = (res.data as WritingBlock & { currentVersion?: number })?.currentVersion ?? currentVersion.value
     } else {
       await api.post<ApiResponse<any>>('/writing', {
         title: form.value.title,
@@ -631,6 +682,16 @@ const doSubmit = async () => {
     flashZenStatus('success', isEditing.value ? 'Updated' : 'Published', 1200)
     navigateBack()
   } catch (err) {
+    if (err instanceof ApiError && err.status === 409) {
+      const reload = confirm(
+        'Another editor has updated this frag since you loaded it. ' +
+        'Reload their changes? (Your current edits will be discarded — ' +
+        'cancel to keep them and copy them out manually.)'
+      )
+      if (reload) await loadWriting()
+      flashZenStatus('error', 'Save blocked: frag was updated by another editor', 4000)
+      return
+    }
     const msg = err instanceof Error ? err.message : (isEditing.value ? 'Failed to update writing' : 'Failed to publish writing')
     error.value = msg
     flashZenStatus('error', msg, 4000)

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -17,6 +17,7 @@ import commentRoutes from './routes/comment.routes.js'
 import activityRoutes from './routes/activity.routes.js'
 import adminRoutes from './routes/admin.routes.js'
 import typographyRulesRoutes from './routes/typography-rules.routes.js'
+import userRoutes from './routes/user.routes.js'
 import { uploadsController } from './controllers/uploads.controller.js'
 import { asyncHandler } from './utils/asyncHandler.js'
 import { config } from './config/env.js'
@@ -131,6 +132,7 @@ app.use('/api/comments', commentRoutes)
 app.use('/api/activity', activityRoutes)
 app.use('/api/admin', adminRoutes)
 app.use('/api/typography-rules', typographyRulesRoutes)
+app.use('/api/users', userRoutes)
 
 // Health check
 app.get('/api/health', async (req, res) => {

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express'
+import { userRepo } from '../repositories/user.repo.js'
+import { UnauthorizedError } from '../utils/errors.js'
+
+export const userController = {
+  /**
+   * GET /api/users/search?q=...
+   *
+   * Authenticated lookup used by the editors-invite UI. Returns at most
+   * 10 active users whose displayName or email starts with `q`. The
+   * caller is excluded from the results.
+   */
+  async search(req: Request, res: Response) {
+    const userId = (req as any).userId
+    if (!userId) throw new UnauthorizedError('Authentication required')
+
+    const q = typeof req.query.q === 'string' ? req.query.q : ''
+    if (q.trim().length < 2) {
+      res.json({ data: [] })
+      return
+    }
+    const users = await userRepo.search(q, userId, 10)
+    res.json({ data: users })
+  }
+}

--- a/server/src/controllers/writing-editor.controller.ts
+++ b/server/src/controllers/writing-editor.controller.ts
@@ -1,0 +1,131 @@
+import { Request, Response } from 'express'
+import { writingEditorRepo } from '../repositories/writing-editor.repo.js'
+import { userRepo } from '../repositories/user.repo.js'
+import {
+  requireManage,
+  getEffectivePermission,
+  isOwnerOrAdmin,
+  isValidGrantPermission,
+} from '../services/writing-permissions.service.js'
+import { isAdminRequest } from '../middleware/authorize.middleware.js'
+import {
+  UnauthorizedError,
+  ValidationError,
+  ForbiddenError,
+  NotFoundError,
+} from '../utils/errors.js'
+import { activityService } from '../services/activity.service.js'
+import { getClientIp, getUserAgent } from '../utils/activity-logger.js'
+
+function getUserIdOrThrow(req: Request): string {
+  const userId = (req as any).userId
+  if (!userId) throw new UnauthorizedError('Authentication required')
+  return userId
+}
+
+export const writingEditorController = {
+  async list(req: Request, res: Response) {
+    const { id } = req.params
+    const userId = getUserIdOrThrow(req)
+    const admin = isAdminRequest(req)
+    // Anyone with manage-or-higher can see the editor list. (Editors
+    // without manage rights deliberately don't see who else has access.)
+    await requireManage(id, userId, admin)
+    const editors = await writingEditorRepo.listForBlock(id)
+    res.json({ data: editors })
+  },
+
+  async upsert(req: Request, res: Response) {
+    const { id } = req.params
+    const userId = getUserIdOrThrow(req)
+    const admin = isAdminRequest(req)
+    await requireManage(id, userId, admin)
+
+    const targetUserId: unknown = req.body?.userId
+    const permission: unknown = req.body?.permission
+    if (typeof targetUserId !== 'string' || !targetUserId) {
+      throw new ValidationError('userId is required')
+    }
+    if (!isValidGrantPermission(permission)) {
+      throw new ValidationError("permission must be 'edit' or 'manage'")
+    }
+
+    const target = await userRepo.findById(targetUserId)
+    if (!target) throw new NotFoundError('Target user not found')
+
+    // The owner cannot be added as an editor of their own frag (they
+    // already have full rights), and admins don't need a grant either.
+    // We reject the request rather than silently no-op so the caller
+    // surfaces a clear UI message.
+    const targetPerm = await getEffectivePermission(id, targetUserId, target.role === 'admin')
+    if (isOwnerOrAdmin(targetPerm)) {
+      throw new ValidationError('That user already has full access to this writing block')
+    }
+
+    const grant = await writingEditorRepo.upsert(id, targetUserId, permission, userId)
+
+    await activityService.logWriting(
+      'update',
+      id,
+      userId,
+      getClientIp(req),
+      getUserAgent(req),
+      { editorChange: 'upsert', grantedUserId: targetUserId, permission }
+    )
+
+    res.status(200).json({ data: grant })
+  },
+
+  async patch(req: Request, res: Response) {
+    const { id, targetUserId } = req.params
+    const userId = getUserIdOrThrow(req)
+    const admin = isAdminRequest(req)
+    await requireManage(id, userId, admin)
+
+    const permission: unknown = req.body?.permission
+    if (!isValidGrantPermission(permission)) {
+      throw new ValidationError("permission must be 'edit' or 'manage'")
+    }
+    const grant = await writingEditorRepo.upsert(id, targetUserId, permission, userId)
+
+    await activityService.logWriting(
+      'update',
+      id,
+      userId,
+      getClientIp(req),
+      getUserAgent(req),
+      { editorChange: 'patch', grantedUserId: targetUserId, permission }
+    )
+
+    res.json({ data: grant })
+  },
+
+  async remove(req: Request, res: Response) {
+    const { id, targetUserId } = req.params
+    const userId = getUserIdOrThrow(req)
+    const admin = isAdminRequest(req)
+    const perm = await getEffectivePermission(id, userId, admin)
+
+    // Allow either the owner/admin/manager to revoke any grant,
+    // OR the editor themselves to walk away (revoke their own).
+    if (
+      perm !== 'owner' && perm !== 'admin' && perm !== 'manage'
+      && userId !== targetUserId
+    ) {
+      throw new ForbiddenError('Not authorized to revoke this grant')
+    }
+
+    await writingEditorRepo.remove(id, targetUserId)
+
+    await activityService.logWriting(
+      'update',
+      id,
+      userId,
+      getClientIp(req),
+      getUserAgent(req),
+      { editorChange: 'remove', grantedUserId: targetUserId }
+    )
+
+    res.status(204).send()
+  }
+}

--- a/server/src/controllers/writing-revision.controller.ts
+++ b/server/src/controllers/writing-revision.controller.ts
@@ -1,0 +1,78 @@
+import { Request, Response } from 'express'
+import { writingRevisionRepo } from '../repositories/writing-revision.repo.js'
+import { writingService } from '../services/writing.service.js'
+import {
+  getEffectivePermission,
+  canEdit,
+} from '../services/writing-permissions.service.js'
+import { writingRepo } from '../repositories/writing.repo.js'
+import { isAdminRequest } from '../middleware/authorize.middleware.js'
+import {
+  UnauthorizedError,
+  ValidationError,
+  ForbiddenError,
+} from '../utils/errors.js'
+import { activityService } from '../services/activity.service.js'
+import { getClientIp, getUserAgent } from '../utils/activity-logger.js'
+
+function userIdOrThrow(req: Request): string {
+  const userId = (req as any).userId
+  if (!userId) throw new UnauthorizedError('Authentication required')
+  return userId
+}
+
+export const writingRevisionController = {
+  async list(req: Request, res: Response) {
+    const { id } = req.params
+    const userId = userIdOrThrow(req)
+    const admin = isAdminRequest(req)
+    // Anyone who can read the frag can read its history. We piggyback
+    // on the same access policy as GET /writing/:id by calling findById
+    // first; this throws 404/403 consistently for unauthorized readers.
+    await writingRepo.findById(id, userId, admin)
+    const summaries = await writingRevisionRepo.listSummaries(id)
+    res.json({ data: summaries })
+  },
+
+  async getOne(req: Request, res: Response) {
+    const { id, versionNumber } = req.params
+    const userId = userIdOrThrow(req)
+    const admin = isAdminRequest(req)
+    await writingRepo.findById(id, userId, admin)
+    const v = parseInt(versionNumber, 10)
+    if (!Number.isInteger(v) || v < 1) {
+      throw new ValidationError('Invalid version number')
+    }
+    const revision = await writingRevisionRepo.getByVersion(id, v)
+    res.json({ data: revision })
+  },
+
+  async restore(req: Request, res: Response) {
+    const { id, versionNumber } = req.params
+    const userId = userIdOrThrow(req)
+    const admin = isAdminRequest(req)
+
+    const perm = await getEffectivePermission(id, userId, admin)
+    if (!canEdit(perm)) {
+      throw new ForbiddenError('Not authorized to restore this writing block')
+    }
+
+    const v = parseInt(versionNumber, 10)
+    if (!Number.isInteger(v) || v < 1) {
+      throw new ValidationError('Invalid version number')
+    }
+    const note = typeof req.body?.note === 'string' ? req.body.note : undefined
+    const writing = await writingService.restore(id, v, userId, admin, note)
+
+    await activityService.logWriting(
+      'update',
+      id,
+      userId,
+      getClientIp(req),
+      getUserAgent(req),
+      { restoredFromVersion: v }
+    )
+
+    res.json({ data: writing })
+  }
+}

--- a/server/src/controllers/writing.controller.ts
+++ b/server/src/controllers/writing.controller.ts
@@ -119,7 +119,13 @@ export const writingController = {
       themeIds: req.body.themeIds,
       visibility: req.body.visibility,
       coverImageUrl: req.body.coverImageUrl,
-      coverImagePosition: req.body.coverImagePosition
+      coverImagePosition: req.body.coverImagePosition,
+      expectedVersion: typeof req.body.expectedVersion === 'number'
+        ? req.body.expectedVersion
+        : undefined,
+      revisionNote: typeof req.body.revisionNote === 'string'
+        ? req.body.revisionNote
+        : undefined,
     }, admin)
     
     // Log update activity

--- a/server/src/db/migrations/026_writing_block_editors.sql
+++ b/server/src/db/migrations/026_writing_block_editors.sql
@@ -1,0 +1,46 @@
+-- Migration 026: Named-user edit grants on writing blocks (frags)
+--
+-- An author may grant other named users permission on a frag they own.
+-- Admins always behave as if they hold the highest permission on every
+-- frag; the frag's own user_id remains the authoritative "original author"
+-- and is never overwritten by collaborator activity.
+--
+-- Permissions (low → high, inclusive):
+--   'edit'   - may update title, body, themes, visibility, cover
+--   'manage' - may also add/remove/change editors on this frag
+--
+-- 'comment' and 'suggest' are intentionally NOT in the enum yet — they
+-- imply enforcement subsystems that do not exist (comments are currently
+-- open to any authenticated user; suggestions / tracked-changes is not
+-- implemented). Adding them later is a non-destructive ALTER on the
+-- check constraint.
+--
+-- Deletion of a frag, or of either user, cascades grants away.
+
+CREATE TABLE IF NOT EXISTS writing_block_editors (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  writing_block_id  UUID NOT NULL REFERENCES writing_blocks(id) ON DELETE CASCADE,
+  user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  granted_by        UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  permission        VARCHAR(20) NOT NULL,
+  created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT writing_block_editors_permission_chk
+    CHECK (permission IN ('edit', 'manage')),
+
+  -- At most one grant row per (frag, user). Changing a permission is an
+  -- UPDATE, not a second row, so the audit story stays clean.
+  CONSTRAINT writing_block_editors_unique_user
+    UNIQUE (writing_block_id, user_id)
+);
+
+-- "Frags I have edit rights on" lookup — used by the Shared-with-me view
+-- and by the per-request permission check.
+CREATE INDEX IF NOT EXISTS idx_writing_block_editors_user
+  ON writing_block_editors(user_id);
+
+-- "Editors on this frag" lookup — used by the Editors panel and by the
+-- writing-blocks update path.
+CREATE INDEX IF NOT EXISTS idx_writing_block_editors_block
+  ON writing_block_editors(writing_block_id);

--- a/server/src/db/migrations/027_writing_block_revisions.sql
+++ b/server/src/db/migrations/027_writing_block_revisions.sql
@@ -1,0 +1,104 @@
+-- Migration 027: Append-only revision log + optimistic-lock counter
+--
+-- Adds an authoritative, server-side audit/version history for each frag.
+-- The live HEAD (current content) stays in `writing_blocks`. This table is
+-- a pure checkpoint log: rows are NEVER updated or deleted in normal flow.
+--
+-- A rollback creates a NEW row with revision_kind='restore' carrying the
+-- body of the chosen target version, so the prior state is never lost and
+-- the audit trail tells the full story.
+--
+-- A new revision row is created on these triggers (enforced in the
+-- service layer, not the DB):
+--   1. Explicit "Save version" button (with optional note)
+--   2. Editor handoff — first save by a different author than the previous
+--      revision's edited_by causes a checkpoint of the prior state
+--   3. Time-based: previous revision is older than 30 minutes
+--   4. Pre-restore: HEAD is snapshotted before applying a rollback
+--   5. Skip no-op: if HEAD content hash matches latest revision, no row
+--
+-- Cascade rules:
+--   writing_blocks.delete → revisions cascade away
+--   users.delete          → edited_by is set NULL (we keep the row so the
+--                            history is consistent; UI shows "deleted user")
+
+CREATE TABLE IF NOT EXISTS writing_block_revisions (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  writing_block_id      UUID NOT NULL REFERENCES writing_blocks(id) ON DELETE CASCADE,
+
+  -- Monotonic per-frag, assigned by the service layer inside a transaction
+  -- holding SELECT ... FOR UPDATE on the parent row. Starts at 1.
+  version_number        INTEGER NOT NULL,
+
+  -- Who saved this revision. NULL only after that user is deleted.
+  edited_by             UUID REFERENCES users(id) ON DELETE SET NULL,
+  edited_at             TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  -- Snapshot of versioned fields. Theme associations are deliberately
+  -- excluded for now (they live in a join table and rarely change; we can
+  -- snapshot them as a separate column later if requested).
+  title                 TEXT NOT NULL,
+  body                  TEXT NOT NULL,
+  visibility            VARCHAR(50) NOT NULL,
+  cover_image_url       TEXT,
+  cover_image_position  VARCHAR(20),
+
+  -- Provenance + audit metadata.
+  revision_kind         VARCHAR(20) NOT NULL DEFAULT 'edit',
+  restored_from_version INTEGER,
+  note                  VARCHAR(500),
+
+  CONSTRAINT writing_block_revisions_kind_chk
+    CHECK (revision_kind IN ('create', 'edit', 'restore')),
+
+  -- 'restored_from_version' only meaningful when kind='restore'.
+  CONSTRAINT writing_block_revisions_restore_chk
+    CHECK (
+      (revision_kind = 'restore' AND restored_from_version IS NOT NULL)
+      OR (revision_kind <> 'restore' AND restored_from_version IS NULL)
+    ),
+
+  CONSTRAINT writing_block_revisions_visibility_chk
+    CHECK (visibility IN ('private', 'shared', 'public')),
+
+  CONSTRAINT writing_block_revisions_version_unique
+    UNIQUE (writing_block_id, version_number)
+);
+
+-- History queries: newest revisions first per frag.
+CREATE INDEX IF NOT EXISTS idx_writing_block_revisions_block_version
+  ON writing_block_revisions(writing_block_id, version_number DESC);
+
+-- "Revisions I authored" queries.
+CREATE INDEX IF NOT EXISTS idx_writing_block_revisions_user
+  ON writing_block_revisions(edited_by);
+
+-- Optimistic-lock counter on the live row. Increments on every update.
+-- Defaults to 1 for existing rows. The PUT payload carries the client's
+-- known version as expected_version; mismatch → 409 (handled in repo).
+ALTER TABLE writing_blocks
+  ADD COLUMN IF NOT EXISTS current_version INTEGER NOT NULL DEFAULT 1;
+
+-- Backfill: every existing frag becomes its own first revision so the
+-- history is never empty and rollbacks can target the original state.
+INSERT INTO writing_block_revisions (
+  writing_block_id, version_number, edited_by, edited_at,
+  title, body, visibility, cover_image_url, cover_image_position,
+  revision_kind, note
+)
+SELECT
+  wb.id,
+  1,
+  wb.user_id,
+  COALESCE(wb.updated_at, wb.created_at, NOW()),
+  wb.title,
+  wb.body,
+  COALESCE(wb.visibility, 'private'),
+  wb.cover_image_url,
+  COALESCE(wb.cover_image_position, '50% 50%'),
+  'create',
+  'Backfilled from migration 027'
+FROM writing_blocks wb
+WHERE NOT EXISTS (
+  SELECT 1 FROM writing_block_revisions r WHERE r.writing_block_id = wb.id
+);

--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -30,9 +30,11 @@ export function errorMiddleware(
       method: req.method,
     })
 
+    const details = (err as AppError & { details?: Record<string, unknown> }).details
     return res.status(statusCode).json({
       error: err.message,
-      code: err.code
+      code: err.code,
+      ...(details ? { details } : {})
     })
   }
 

--- a/server/src/models/WritingBlockEditor.ts
+++ b/server/src/models/WritingBlockEditor.ts
@@ -1,0 +1,1 @@
+export * from '@shared/WritingBlockEditor'

--- a/server/src/models/WritingBlockRevision.ts
+++ b/server/src/models/WritingBlockRevision.ts
@@ -1,0 +1,1 @@
+export * from '@shared/WritingBlockRevision'

--- a/server/src/repositories/user.repo.ts
+++ b/server/src/repositories/user.repo.ts
@@ -96,6 +96,32 @@ export const userRepo = {
   },
 
   /**
+   * Search active users by display name or email prefix. Returns a
+   * minimal payload suitable for invite-by-name UIs. Excludes the caller
+   * (`excludeUserId`) so they don't try to grant themselves rights.
+   */
+  async search(
+    query: string,
+    excludeUserId: string | null,
+    limit: number = 10
+  ): Promise<Array<Pick<User, 'id' | 'displayName' | 'email'>>> {
+    const q = query.trim()
+    if (q.length < 2) return []
+    const like = `${q.replace(/[%_]/g, m => `\\${m}`)}%`
+    const result = await pool.query(
+      `SELECT id, email, display_name AS "displayName"
+       FROM users
+       WHERE status = 'active'
+         AND ($3::uuid IS NULL OR id <> $3)
+         AND (display_name ILIKE $1 OR email ILIKE $1)
+       ORDER BY display_name ASC
+       LIMIT $2`,
+      [like, limit, excludeUserId]
+    )
+    return result.rows
+  },
+
+  /**
    * Find all users (admin-only)
    */
   async findAll(limit: number = 100, offset: number = 0): Promise<User[]> {

--- a/server/src/repositories/writing-editor.repo.ts
+++ b/server/src/repositories/writing-editor.repo.ts
@@ -1,0 +1,101 @@
+import { pool } from '../config/db.js'
+import { WritingBlockEditor, WritingBlockEditorPermission } from '../models/WritingBlockEditor.js'
+import { NotFoundError } from '../utils/errors.js'
+
+const SELECT_COLS = `
+  e.id,
+  e.writing_block_id  AS "writingBlockId",
+  e.user_id           AS "userId",
+  e.granted_by        AS "grantedBy",
+  e.permission,
+  e.created_at        AS "createdAt",
+  e.updated_at        AS "updatedAt",
+  u.display_name      AS "userDisplayName",
+  u.email             AS "userEmail",
+  g.display_name      AS "grantedByDisplayName"
+`
+
+const FROM_JOINS = `
+  FROM writing_block_editors e
+  LEFT JOIN users u ON u.id = e.user_id
+  LEFT JOIN users g ON g.id = e.granted_by
+`
+
+export const writingEditorRepo = {
+  async listForBlock(writingBlockId: string): Promise<WritingBlockEditor[]> {
+    const result = await pool.query(
+      `SELECT ${SELECT_COLS} ${FROM_JOINS}
+       WHERE e.writing_block_id = $1
+       ORDER BY e.created_at ASC`,
+      [writingBlockId]
+    )
+    return result.rows
+  },
+
+  async findGrant(writingBlockId: string, userId: string): Promise<WritingBlockEditor | null> {
+    const result = await pool.query(
+      `SELECT ${SELECT_COLS} ${FROM_JOINS}
+       WHERE e.writing_block_id = $1 AND e.user_id = $2`,
+      [writingBlockId, userId]
+    )
+    return result.rows[0] || null
+  },
+
+  async upsert(
+    writingBlockId: string,
+    userId: string,
+    permission: WritingBlockEditorPermission,
+    grantedBy: string
+  ): Promise<WritingBlockEditor> {
+    const result = await pool.query(
+      `INSERT INTO writing_block_editors (writing_block_id, user_id, granted_by, permission)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (writing_block_id, user_id)
+       DO UPDATE SET permission = EXCLUDED.permission,
+                     granted_by = EXCLUDED.granted_by,
+                     updated_at = NOW()
+       RETURNING id`,
+      [writingBlockId, userId, grantedBy, permission]
+    )
+    const grant = await this.findGrant(writingBlockId, userId)
+    if (!grant) {
+      throw new NotFoundError('Grant not found after upsert')
+    }
+    return grant
+  },
+
+  async remove(writingBlockId: string, userId: string): Promise<void> {
+    const result = await pool.query(
+      `DELETE FROM writing_block_editors
+       WHERE writing_block_id = $1 AND user_id = $2`,
+      [writingBlockId, userId]
+    )
+    if (result.rowCount === 0) {
+      throw new NotFoundError('Editor grant not found')
+    }
+  },
+
+  /**
+   * Frags the user has at least the given permission on. Used by the
+   * "Shared with me" filter on the client.
+   */
+  async listFragsForUser(
+    userId: string,
+    minPermission: WritingBlockEditorPermission = 'edit'
+  ): Promise<Array<{ writingBlockId: string; permission: WritingBlockEditorPermission }>> {
+    const allowed = permissionsAtLeast(minPermission)
+    const result = await pool.query(
+      `SELECT writing_block_id AS "writingBlockId", permission
+       FROM writing_block_editors
+       WHERE user_id = $1 AND permission = ANY($2::text[])`,
+      [userId, allowed]
+    )
+    return result.rows
+  }
+}
+
+const RANK: Record<WritingBlockEditorPermission, number> = { edit: 1, manage: 2 }
+
+function permissionsAtLeast(min: WritingBlockEditorPermission): WritingBlockEditorPermission[] {
+  return (['edit', 'manage'] as WritingBlockEditorPermission[]).filter(p => RANK[p] >= RANK[min])
+}

--- a/server/src/repositories/writing-revision.repo.ts
+++ b/server/src/repositories/writing-revision.repo.ts
@@ -1,0 +1,139 @@
+import { pool } from '../config/db.js'
+import type { PoolClient } from 'pg'
+import {
+  WritingBlockRevision,
+  WritingBlockRevisionKind,
+  WritingBlockRevisionSummary,
+} from '../models/WritingBlockRevision.js'
+import { NotFoundError } from '../utils/errors.js'
+
+const FULL_COLS = `
+  r.id,
+  r.writing_block_id     AS "writingBlockId",
+  r.version_number       AS "versionNumber",
+  r.edited_by            AS "editedBy",
+  r.edited_at            AS "editedAt",
+  r.title,
+  r.body,
+  r.visibility,
+  r.cover_image_url      AS "coverImageUrl",
+  r.cover_image_position AS "coverImagePosition",
+  r.revision_kind        AS "revisionKind",
+  r.restored_from_version AS "restoredFromVersion",
+  r.note,
+  u.display_name         AS "editorDisplayName"
+`
+
+const SUMMARY_COLS = `
+  r.id,
+  r.writing_block_id     AS "writingBlockId",
+  r.version_number       AS "versionNumber",
+  r.edited_by            AS "editedBy",
+  r.edited_at            AS "editedAt",
+  r.revision_kind        AS "revisionKind",
+  r.restored_from_version AS "restoredFromVersion",
+  r.note,
+  u.display_name         AS "editorDisplayName"
+`
+
+const JOIN = `
+  FROM writing_block_revisions r
+  LEFT JOIN users u ON u.id = r.edited_by
+`
+
+export interface RevisionSnapshot {
+  title: string
+  body: string
+  visibility: 'private' | 'shared' | 'public'
+  coverImageUrl: string | null
+  coverImagePosition: string | null
+}
+
+export const writingRevisionRepo = {
+  async listSummaries(writingBlockId: string): Promise<WritingBlockRevisionSummary[]> {
+    const result = await pool.query(
+      `SELECT ${SUMMARY_COLS} ${JOIN}
+       WHERE r.writing_block_id = $1
+       ORDER BY r.version_number DESC`,
+      [writingBlockId]
+    )
+    return result.rows
+  },
+
+  async getByVersion(
+    writingBlockId: string,
+    versionNumber: number
+  ): Promise<WritingBlockRevision> {
+    const result = await pool.query(
+      `SELECT ${FULL_COLS} ${JOIN}
+       WHERE r.writing_block_id = $1 AND r.version_number = $2`,
+      [writingBlockId, versionNumber]
+    )
+    if (result.rows.length === 0) {
+      throw new NotFoundError(`Revision ${versionNumber} not found`)
+    }
+    return result.rows[0]
+  },
+
+  async getLatest(writingBlockId: string): Promise<WritingBlockRevision | null> {
+    const result = await pool.query(
+      `SELECT ${FULL_COLS} ${JOIN}
+       WHERE r.writing_block_id = $1
+       ORDER BY r.version_number DESC
+       LIMIT 1`,
+      [writingBlockId]
+    )
+    return result.rows[0] || null
+  },
+
+  /**
+   * Insert a new revision row. Must be called inside a transaction holding
+   * a FOR UPDATE lock on the parent writing_blocks row so that
+   * version_number assignment is race-free.
+   *
+   * Returns the inserted row.
+   */
+  async insertWithinTx(
+    client: PoolClient,
+    args: {
+      writingBlockId: string
+      editedBy: string
+      snapshot: RevisionSnapshot
+      revisionKind: WritingBlockRevisionKind
+      restoredFromVersion?: number | null
+      note?: string | null
+    }
+  ): Promise<{ versionNumber: number; id: string }> {
+    const nextVersion = await client.query(
+      `SELECT COALESCE(MAX(version_number), 0) + 1 AS next
+       FROM writing_block_revisions
+       WHERE writing_block_id = $1`,
+      [args.writingBlockId]
+    )
+    const versionNumber = nextVersion.rows[0].next as number
+
+    const inserted = await client.query(
+      `INSERT INTO writing_block_revisions (
+         writing_block_id, version_number, edited_by,
+         title, body, visibility, cover_image_url, cover_image_position,
+         revision_kind, restored_from_version, note
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING id`,
+      [
+        args.writingBlockId,
+        versionNumber,
+        args.editedBy,
+        args.snapshot.title,
+        args.snapshot.body,
+        args.snapshot.visibility,
+        args.snapshot.coverImageUrl,
+        args.snapshot.coverImagePosition,
+        args.revisionKind,
+        args.restoredFromVersion ?? null,
+        args.note ?? null,
+      ]
+    )
+    return { versionNumber, id: inserted.rows[0].id }
+  },
+}

--- a/server/src/repositories/writing.repo.ts
+++ b/server/src/repositories/writing.repo.ts
@@ -1,6 +1,60 @@
 import { pool } from '../config/db.js'
+import type { PoolClient } from 'pg'
+import { createHash } from 'node:crypto'
 import { WritingBlock } from '../models/WritingBlock.js'
-import { NotFoundError, ForbiddenError } from '../utils/errors.js'
+import { NotFoundError, ForbiddenError, ConflictError } from '../utils/errors.js'
+import { writingRevisionRepo, RevisionSnapshot } from './writing-revision.repo.js'
+import {
+  getEffectivePermission,
+  canEdit,
+  canDelete,
+} from '../services/writing-permissions.service.js'
+
+/** Minutes since the latest revision after which an autosave will checkpoint. */
+const CHECKPOINT_MINUTES = 30
+
+interface HeadRow {
+  id: string
+  userId: string
+  title: string
+  body: string
+  visibility: 'private' | 'shared' | 'public'
+  coverImageUrl: string | null
+  coverImagePosition: string | null
+  currentVersion: number
+}
+
+function hashSnapshot(s: RevisionSnapshot): string {
+  return createHash('sha256')
+    .update(s.title)
+    .update('\x1f')
+    .update(s.body)
+    .update('\x1f')
+    .update(s.visibility)
+    .update('\x1f')
+    .update(s.coverImageUrl ?? '')
+    .update('\x1f')
+    .update(s.coverImagePosition ?? '')
+    .digest('hex')
+}
+
+async function lockHead(client: PoolClient, id: string): Promise<HeadRow> {
+  const result = await client.query(
+    `SELECT id, user_id AS "userId", title, body,
+            COALESCE(visibility, 'private') AS visibility,
+            cover_image_url AS "coverImageUrl",
+            COALESCE(cover_image_position, '50% 50%') AS "coverImagePosition",
+            COALESCE(current_version, 1) AS "currentVersion"
+     FROM writing_blocks
+     WHERE id = $1
+     FOR UPDATE`,
+    [id]
+  )
+  if (result.rows.length === 0) {
+    throw new NotFoundError('Writing block not found')
+  }
+  return result.rows[0]
+}
 
 /**
  * Writing repository - thin DAO layer
@@ -43,8 +97,9 @@ export const writingRepo = {
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
             COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-            wb.created_at as "createdAt", 
+            wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
+            COALESCE(wb.current_version, 1) as "currentVersion",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -67,8 +122,9 @@ export const writingRepo = {
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
             COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-            wb.created_at as "createdAt", 
+            wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
+            COALESCE(wb.current_version, 1) as "currentVersion",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -92,8 +148,9 @@ export const writingRepo = {
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
             COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-            wb.created_at as "createdAt", 
+            wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
+            COALESCE(wb.current_version, 1) as "currentVersion",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -174,8 +231,9 @@ export const writingRepo = {
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
             COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-            wb.created_at as "createdAt", 
+            wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
+            COALESCE(wb.current_version, 1) as "currentVersion",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -196,8 +254,9 @@ export const writingRepo = {
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
             COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-            wb.created_at as "createdAt", 
+            wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
+            COALESCE(wb.current_version, 1) as "currentVersion",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -218,8 +277,9 @@ export const writingRepo = {
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
             COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-            wb.created_at as "createdAt", 
+            wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
+            COALESCE(wb.current_version, 1) as "currentVersion",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -266,7 +326,7 @@ export const writingRepo = {
     }
   },
 
-  async create(writing: Omit<WritingBlock, 'id' | 'createdAt' | 'updatedAt'>): Promise<WritingBlock> {
+  async create(writing: Omit<WritingBlock, 'id' | 'createdAt' | 'updatedAt' | 'currentVersion'>): Promise<WritingBlock> {
     const client = await pool.connect()
     try {
       await client.query('BEGIN')
@@ -308,6 +368,28 @@ export const writingRepo = {
       }
       const writingBlock = writingResult.rows[0]
       
+      // Seed the revision log with the initial create-revision so every
+      // frag has at least one row in writing_block_revisions and rollbacks
+      // can always target the original state. Skipped if the revisions
+      // table doesn't exist yet (pre-migration-027 environments).
+      try {
+        await writingRevisionRepo.insertWithinTx(client, {
+          writingBlockId: writingBlock.id,
+          editedBy: writing.userId,
+          snapshot: {
+            title: writing.title,
+            body: writing.body,
+            visibility: visibility,
+            coverImageUrl: coverImageUrl,
+            coverImagePosition: coverImagePosition,
+          },
+          revisionKind: 'create',
+          note: null,
+        })
+      } catch (err: any) {
+        if (err?.code !== '42P01') throw err
+      }
+
       // Insert theme associations
       if (writing.themeIds && writing.themeIds.length > 0) {
         for (const themeId of writing.themeIds) {
@@ -333,103 +415,245 @@ export const writingRepo = {
   },
 
   /**
-   * Update writing block - enforces ownership (admin bypasses)
+   * Update writing block.
+   *
+   * Permission: owner, admin, or granted editor (edit/manage). All other
+   * users → 403.
+   *
+   * Optimistic locking: if `expectedVersion` is provided and does not
+   * match the row's `current_version`, throws ConflictError (HTTP 409)
+   * with details `{ currentVersion, expectedVersion }`. The client is
+   * expected to reload, merge, and retry.
+   *
+   * Revision history triggers (a new row is appended to
+   * writing_block_revisions on save IFF any of):
+   *   - `revisionNote` was provided ("Save version" button)
+   *   - the editor differs from the previous revision's edited_by (handoff)
+   *   - the previous revision is older than CHECKPOINT_MINUTES
+   * AND the content hash actually changed (no-op saves are skipped).
+   *
+   * Otherwise the save is treated as an autosave: HEAD is updated, the
+   * revision log is not touched, current_version is still bumped.
    */
-  async update(id: string, userId: string, updates: Partial<Pick<WritingBlock, 'title' | 'body' | 'themeIds' | 'visibility' | 'coverImagePosition'>> & Partial<{ coverImageUrl: string | null }>, isAdmin: boolean = false): Promise<WritingBlock> {
-    // First verify ownership (admin can update any)
-    const existing = await pool.query(
-      'SELECT user_id FROM writing_blocks WHERE id = $1',
-      [id]
-    )
-    if (existing.rows.length === 0) {
-      throw new NotFoundError('Writing block not found')
-    }
-    if (!isAdmin && existing.rows[0].user_id !== userId) {
+  async update(
+    id: string,
+    userId: string,
+    updates: Partial<Pick<WritingBlock, 'title' | 'body' | 'themeIds' | 'visibility' | 'coverImagePosition'>>
+      & Partial<{ coverImageUrl: string | null }>
+      & Partial<{ expectedVersion: number; revisionNote: string }>,
+    isAdmin: boolean = false
+  ): Promise<WritingBlock> {
+    const perm = await getEffectivePermission(id, userId, isAdmin)
+    if (!canEdit(perm)) {
       throw new ForbiddenError('Not authorized to update this writing block')
-    }
-
-    // Check if visibility column exists
-    let hasVisibilityColumn = true
-    try {
-      await pool.query('SELECT visibility FROM writing_blocks LIMIT 1')
-    } catch (error: any) {
-      if (error.code === '42703') {
-        hasVisibilityColumn = false
-      } else {
-        throw error
-      }
     }
 
     const client = await pool.connect()
     try {
       await client.query('BEGIN')
-      
+
+      const head = await lockHead(client, id)
+
+      if (
+        typeof updates.expectedVersion === 'number'
+        && updates.expectedVersion !== head.currentVersion
+      ) {
+        throw new ConflictError(
+          'Writing block has been updated by another editor',
+          { currentVersion: head.currentVersion, expectedVersion: updates.expectedVersion }
+        )
+      }
+
+      const newSnapshot: RevisionSnapshot = {
+        title: updates.title !== undefined ? updates.title : head.title,
+        body: updates.body !== undefined ? updates.body : head.body,
+        visibility: updates.visibility !== undefined ? updates.visibility : head.visibility,
+        coverImageUrl: updates.coverImageUrl !== undefined ? updates.coverImageUrl : head.coverImageUrl,
+        coverImagePosition: updates.coverImagePosition !== undefined ? updates.coverImagePosition : head.coverImagePosition,
+      }
+
       const fields: string[] = []
       const values: unknown[] = []
-      let paramCount = 1
+      let p = 1
+      if (updates.title !== undefined) { fields.push(`title = $${p++}`); values.push(updates.title) }
+      if (updates.body !== undefined) { fields.push(`body = $${p++}`); values.push(updates.body) }
+      if (updates.visibility !== undefined) { fields.push(`visibility = $${p++}`); values.push(updates.visibility) }
+      if (updates.coverImageUrl !== undefined) { fields.push(`cover_image_url = $${p++}`); values.push(updates.coverImageUrl) }
+      if (updates.coverImagePosition !== undefined) { fields.push(`cover_image_position = $${p++}`); values.push(updates.coverImagePosition) }
 
-      if (updates.title !== undefined) {
-        fields.push(`title = $${paramCount++}`)
-        values.push(updates.title)
-      }
-      if (updates.body !== undefined) {
-        fields.push(`body = $${paramCount++}`)
-        values.push(updates.body)
-      }
-      if (updates.visibility !== undefined && hasVisibilityColumn) {
-        fields.push(`visibility = $${paramCount++}`)
-        values.push(updates.visibility)
-      }
-      if (updates.coverImageUrl !== undefined) {
-        fields.push(`cover_image_url = $${paramCount++}`)
-        values.push(updates.coverImageUrl)
-      }
-      if (updates.coverImagePosition !== undefined) {
-        fields.push(`cover_image_position = $${paramCount++}`)
-        values.push(updates.coverImagePosition)
-      }
+      const versionedFieldChanged = fields.length > 0
+      const themesChanged = updates.themeIds !== undefined
+      const headWillChange = versionedFieldChanged || themesChanged
 
-      if (fields.length > 0) {
+      if (headWillChange) {
         fields.push(`updated_at = NOW()`)
+        fields.push(`current_version = COALESCE(current_version, 1) + 1`)
         values.push(id)
-
         await client.query(
-          `UPDATE writing_blocks
-           SET ${fields.join(', ')}
-           WHERE id = $${paramCount}`,
+          `UPDATE writing_blocks SET ${fields.join(', ')} WHERE id = $${p}`,
           values
         )
-      } else if (!hasVisibilityColumn && updates.themeIds !== undefined) {
-        // If no fields to update but themeIds need updating, still update updated_at
-        await client.query(
-          `UPDATE writing_blocks SET updated_at = NOW() WHERE id = $1`,
-          [id]
-        )
       }
 
-      // Update theme associations if provided
-      if (updates.themeIds !== undefined) {
-        // Delete existing associations
-        await client.query(
-          `DELETE FROM writing_themes WHERE writing_id = $1`,
-          [id]
-        )
-        
-        // Insert new associations
-        if (updates.themeIds.length > 0) {
-          for (const themeId of updates.themeIds) {
+      if (themesChanged) {
+        await client.query(`DELETE FROM writing_themes WHERE writing_id = $1`, [id])
+        if (updates.themeIds!.length > 0) {
+          for (const themeId of updates.themeIds!) {
             await client.query(
               `INSERT INTO writing_themes (writing_id, theme_id)
-               VALUES ($1, $2)
-               ON CONFLICT DO NOTHING`,
+               VALUES ($1, $2) ON CONFLICT DO NOTHING`,
               [id, themeId]
             )
           }
         }
       }
-      
+
+      // Decide whether this save warrants a revision row.
+      if (versionedFieldChanged) {
+        const latest = await writingRevisionRepo.getLatest(id)
+        const latestSnapshotHash = latest
+          ? hashSnapshot({
+              title: latest.title,
+              body: latest.body,
+              visibility: latest.visibility,
+              coverImageUrl: latest.coverImageUrl ?? null,
+              coverImagePosition: latest.coverImagePosition ?? null,
+            })
+          : null
+        const newHash = hashSnapshot(newSnapshot)
+        const contentChanged = latestSnapshotHash !== newHash
+
+        let reason: 'explicit' | 'handoff' | 'time' | null = null
+        if (updates.revisionNote && updates.revisionNote.trim()) {
+          reason = 'explicit'
+        } else if (latest && latest.editedBy !== userId) {
+          reason = 'handoff'
+        } else if (latest) {
+          const ageMs = Date.now() - new Date(latest.editedAt).getTime()
+          if (ageMs > CHECKPOINT_MINUTES * 60 * 1000) reason = 'time'
+        } else {
+          // No prior revision (shouldn't happen post-migration backfill,
+          // but defensive). Treat first save as an explicit checkpoint.
+          reason = 'explicit'
+        }
+
+        if (reason && contentChanged) {
+          await writingRevisionRepo.insertWithinTx(client, {
+            writingBlockId: id,
+            editedBy: userId,
+            snapshot: newSnapshot,
+            revisionKind: 'edit',
+            note: updates.revisionNote?.trim() || null,
+          })
+        }
+      }
+
       await client.query('COMMIT')
-      
+      return this.findById(id, userId, isAdmin)
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  },
+
+  /**
+   * Restore the frag to a prior revision. Creates two revision rows in
+   * one transaction: a pre-restore checkpoint of the live HEAD (so the
+   * pre-restore state is never lost), then the restored state with
+   * revision_kind='restore' and restored_from_version pointing at the
+   * target. HEAD is overwritten with the target's content.
+   *
+   * Permission: same as update (owner, admin, or editor/manage grant).
+   */
+  async restore(
+    id: string,
+    targetVersion: number,
+    userId: string,
+    isAdmin: boolean = false,
+    note?: string
+  ): Promise<WritingBlock> {
+    const perm = await getEffectivePermission(id, userId, isAdmin)
+    if (!canEdit(perm)) {
+      throw new ForbiddenError('Not authorized to restore this writing block')
+    }
+
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+
+      const head = await lockHead(client, id)
+      const target = await writingRevisionRepo.getByVersion(id, targetVersion)
+
+      const headSnapshot: RevisionSnapshot = {
+        title: head.title,
+        body: head.body,
+        visibility: head.visibility,
+        coverImageUrl: head.coverImageUrl,
+        coverImagePosition: head.coverImagePosition,
+      }
+      const targetSnapshot: RevisionSnapshot = {
+        title: target.title,
+        body: target.body,
+        visibility: target.visibility,
+        coverImageUrl: target.coverImageUrl ?? null,
+        coverImagePosition: target.coverImagePosition ?? null,
+      }
+
+      // Only checkpoint HEAD if it actually differs from the latest
+      // revision row (otherwise we'd insert a duplicate).
+      const latest = await writingRevisionRepo.getLatest(id)
+      const latestHash = latest
+        ? hashSnapshot({
+            title: latest.title,
+            body: latest.body,
+            visibility: latest.visibility,
+            coverImageUrl: latest.coverImageUrl ?? null,
+            coverImagePosition: latest.coverImagePosition ?? null,
+          })
+        : null
+      const headHash = hashSnapshot(headSnapshot)
+      if (latestHash !== headHash) {
+        await writingRevisionRepo.insertWithinTx(client, {
+          writingBlockId: id,
+          editedBy: userId,
+          snapshot: headSnapshot,
+          revisionKind: 'edit',
+          note: 'Pre-restore checkpoint',
+        })
+      }
+
+      await client.query(
+        `UPDATE writing_blocks
+         SET title = $1,
+             body = $2,
+             visibility = $3,
+             cover_image_url = $4,
+             cover_image_position = $5,
+             updated_at = NOW(),
+             current_version = COALESCE(current_version, 1) + 1
+         WHERE id = $6`,
+        [
+          targetSnapshot.title,
+          targetSnapshot.body,
+          targetSnapshot.visibility,
+          targetSnapshot.coverImageUrl,
+          targetSnapshot.coverImagePosition,
+          id,
+        ]
+      )
+
+      await writingRevisionRepo.insertWithinTx(client, {
+        writingBlockId: id,
+        editedBy: userId,
+        snapshot: targetSnapshot,
+        revisionKind: 'restore',
+        restoredFromVersion: targetVersion,
+        note: note?.trim() || `Restored from version ${targetVersion}`,
+      })
+
+      await client.query('COMMIT')
       return this.findById(id, userId, isAdmin)
     } catch (error) {
       await client.query('ROLLBACK')

--- a/server/src/routes/user.routes.ts
+++ b/server/src/routes/user.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import { userController } from '../controllers/user.controller.js'
+import { authMiddleware } from '../middleware/auth.middleware.js'
+import { asyncHandler } from '../utils/asyncHandler.js'
+
+const router = Router()
+
+// Authenticated user lookups for in-app features (e.g. "invite an
+// editor"). Admin-only user listing lives at /api/admin/users.
+router.get('/search', authMiddleware, asyncHandler(userController.search))
+
+export default router

--- a/server/src/routes/writing.routes.ts
+++ b/server/src/routes/writing.routes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express'
 import { writingController } from '../controllers/writing.controller.js'
+import { writingEditorController } from '../controllers/writing-editor.controller.js'
+import { writingRevisionController } from '../controllers/writing-revision.controller.js'
 import { uploadsController, uploadSingle } from '../controllers/uploads.controller.js'
 import { validateBody } from '../middleware/validate.middleware.js'
 import { optionalAuthMiddleware, authMiddleware } from '../middleware/auth.middleware.js'
@@ -18,6 +20,19 @@ router.post('/upload', authMiddleware, uploadSingle, asyncHandler(uploadsControl
 router.post('/', authMiddleware, validateBody(['title', 'body']), asyncHandler(writingController.create))
 router.put('/:id', authMiddleware, asyncHandler(writingController.update))
 router.delete('/:id', authMiddleware, asyncHandler(writingController.delete))
+
+// Editor grants — owner/admin/manager only. List + upsert by userId,
+// individual patch/remove by target userId.
+router.get('/:id/editors', authMiddleware, asyncHandler(writingEditorController.list))
+router.post('/:id/editors', authMiddleware, asyncHandler(writingEditorController.upsert))
+router.patch('/:id/editors/:targetUserId', authMiddleware, asyncHandler(writingEditorController.patch))
+router.delete('/:id/editors/:targetUserId', authMiddleware, asyncHandler(writingEditorController.remove))
+
+// Revision history + rollback — read mirrors GET /:id access policy;
+// restore requires edit-or-higher on the frag.
+router.get('/:id/revisions', authMiddleware, asyncHandler(writingRevisionController.list))
+router.get('/:id/revisions/:versionNumber', authMiddleware, asyncHandler(writingRevisionController.getOne))
+router.post('/:id/restore/:versionNumber', authMiddleware, asyncHandler(writingRevisionController.restore))
 
 // AI assist — six core modes (coherence, define, focus, expand, proofread,
 // factcheck) plus the four-mode "Develop" quadrant (fiction-breadth,

--- a/server/src/services/writing-permissions.service.ts
+++ b/server/src/services/writing-permissions.service.ts
@@ -1,0 +1,91 @@
+import { pool } from '../config/db.js'
+import { writingEditorRepo } from '../repositories/writing-editor.repo.js'
+import { NotFoundError, ForbiddenError } from '../utils/errors.js'
+import type { WritingBlockEditorPermission } from '../models/WritingBlockEditor.js'
+
+/**
+ * Effective permission a user has on a frag.
+ *
+ *   'owner'    - the original author. Has all rights including delete.
+ *   'admin'    - role=admin. Has all rights including delete.
+ *   'manage'   - granted editor with manage permission.
+ *   'edit'     - granted editor with edit permission.
+ *   'none'     - no rights beyond whatever the frag's visibility grants
+ *                (which is read-only at most). The caller decides whether
+ *                to return 403 or 404.
+ */
+export type EffectivePermission = 'owner' | 'admin' | 'manage' | 'edit' | 'none'
+
+export async function getEffectivePermission(
+  writingBlockId: string,
+  userId: string | null,
+  isAdmin: boolean
+): Promise<EffectivePermission> {
+  if (isAdmin) return 'admin'
+  if (!userId) return 'none'
+
+  const ownerRes = await pool.query(
+    `SELECT user_id FROM writing_blocks WHERE id = $1`,
+    [writingBlockId]
+  )
+  if (ownerRes.rows.length === 0) {
+    throw new NotFoundError('Writing block not found')
+  }
+  if (ownerRes.rows[0].user_id === userId) return 'owner'
+
+  const grant = await writingEditorRepo.findGrant(writingBlockId, userId)
+  if (!grant) return 'none'
+  return grant.permission
+}
+
+const FULL_ACCESS: EffectivePermission[] = ['owner', 'admin']
+
+export function canEdit(perm: EffectivePermission): boolean {
+  return FULL_ACCESS.includes(perm) || perm === 'manage' || perm === 'edit'
+}
+
+export function canManageEditors(perm: EffectivePermission): boolean {
+  return FULL_ACCESS.includes(perm) || perm === 'manage'
+}
+
+export function canDelete(perm: EffectivePermission): boolean {
+  return FULL_ACCESS.includes(perm)
+}
+
+export function isOwnerOrAdmin(perm: EffectivePermission): boolean {
+  return FULL_ACCESS.includes(perm)
+}
+
+export async function requireEdit(
+  writingBlockId: string,
+  userId: string | null,
+  isAdmin: boolean
+): Promise<EffectivePermission> {
+  const perm = await getEffectivePermission(writingBlockId, userId, isAdmin)
+  if (!canEdit(perm)) {
+    throw new ForbiddenError('Not authorized to edit this writing block')
+  }
+  return perm
+}
+
+export async function requireManage(
+  writingBlockId: string,
+  userId: string | null,
+  isAdmin: boolean
+): Promise<EffectivePermission> {
+  const perm = await getEffectivePermission(writingBlockId, userId, isAdmin)
+  if (!canManageEditors(perm)) {
+    throw new ForbiddenError('Not authorized to manage editors on this writing block')
+  }
+  return perm
+}
+
+const RANK: Record<WritingBlockEditorPermission, number> = { edit: 1, manage: 2 }
+
+export function isValidGrantPermission(p: unknown): p is WritingBlockEditorPermission {
+  return p === 'edit' || p === 'manage'
+}
+
+export function permissionRank(p: WritingBlockEditorPermission): number {
+  return RANK[p]
+}

--- a/server/src/services/writing.service.ts
+++ b/server/src/services/writing.service.ts
@@ -84,6 +84,8 @@ export const writingService = {
       visibility?: 'private' | 'shared' | 'public'
       coverImageUrl?: string
       coverImagePosition?: string
+      expectedVersion?: number
+      revisionNote?: string
     }>,
     isAdmin: boolean = false
   ): Promise<WritingBlock> {
@@ -94,6 +96,8 @@ export const writingService = {
       visibility?: 'private' | 'shared' | 'public'
       coverImageUrl?: string | null
       coverImagePosition?: string
+      expectedVersion?: number
+      revisionNote?: string
     }> = {}
     if (data.title !== undefined) {
       updates.title = sanitizeString(data.title)
@@ -114,8 +118,31 @@ export const writingService = {
     if (data.coverImagePosition !== undefined) {
       updates.coverImagePosition = (typeof data.coverImagePosition === 'string' && data.coverImagePosition.trim()) ? data.coverImagePosition.trim() : '50% 50%'
     }
+    if (typeof data.expectedVersion === 'number' && Number.isFinite(data.expectedVersion)) {
+      updates.expectedVersion = data.expectedVersion
+    }
+    if (typeof data.revisionNote === 'string') {
+      const trimmed = data.revisionNote.trim()
+      if (trimmed.length > 500) {
+        throw new ValidationError('Revision note must be 500 characters or less')
+      }
+      if (trimmed) updates.revisionNote = trimmed
+    }
 
     return writingRepo.update(id, userId, updates, isAdmin)
+  },
+
+  async restore(
+    id: string,
+    targetVersion: number,
+    userId: string,
+    isAdmin: boolean = false,
+    note?: string
+  ): Promise<WritingBlock> {
+    if (!Number.isInteger(targetVersion) || targetVersion < 1) {
+      throw new ValidationError('Invalid target version')
+    }
+    return writingRepo.restore(id, targetVersion, userId, isAdmin, note)
   },
 
   async delete(id: string, userId: string, isAdmin: boolean = false): Promise<void> {

--- a/server/src/utils/errors.ts
+++ b/server/src/utils/errors.ts
@@ -40,3 +40,13 @@ export class ForbiddenError extends AppError {
     this.name = 'ForbiddenError'
   }
 }
+
+export class ConflictError extends AppError {
+  constructor(
+    message: string = 'Conflict',
+    public details?: Record<string, unknown>
+  ) {
+    super(message, 409, 'CONFLICT')
+    this.name = 'ConflictError'
+  }
+}

--- a/shared/WritingBlock.ts
+++ b/shared/WritingBlock.ts
@@ -9,4 +9,10 @@ export interface WritingBlock {
   coverImagePosition?: string
   createdAt: string
   updatedAt?: string
+  /**
+   * Monotonic per-frag counter, bumped on every update. Clients send the
+   * version they loaded as `expectedVersion` in update requests; mismatch
+   * returns 409 so a co-editor's change is never silently overwritten.
+   */
+  currentVersion: number
 }

--- a/shared/WritingBlockEditor.ts
+++ b/shared/WritingBlockEditor.ts
@@ -1,0 +1,15 @@
+export type WritingBlockEditorPermission = 'edit' | 'manage'
+
+export interface WritingBlockEditor {
+  id: string
+  writingBlockId: string
+  userId: string
+  grantedBy: string
+  permission: WritingBlockEditorPermission
+  createdAt: string
+  updatedAt: string
+
+  userDisplayName?: string
+  userEmail?: string
+  grantedByDisplayName?: string
+}

--- a/shared/WritingBlockRevision.ts
+++ b/shared/WritingBlockRevision.ts
@@ -1,0 +1,33 @@
+export type WritingBlockRevisionKind = 'create' | 'edit' | 'restore'
+
+export interface WritingBlockRevision {
+  id: string
+  writingBlockId: string
+  versionNumber: number
+  editedBy: string | null
+  editedAt: string
+
+  title: string
+  body: string
+  visibility: 'private' | 'shared' | 'public'
+  coverImageUrl?: string | null
+  coverImagePosition?: string | null
+
+  revisionKind: WritingBlockRevisionKind
+  restoredFromVersion?: number | null
+  note?: string | null
+
+  editorDisplayName?: string | null
+}
+
+export interface WritingBlockRevisionSummary {
+  id: string
+  writingBlockId: string
+  versionNumber: number
+  editedBy: string | null
+  editedAt: string
+  revisionKind: WritingBlockRevisionKind
+  restoredFromVersion?: number | null
+  note?: string | null
+  editorDisplayName?: string | null
+}


### PR DESCRIPTION
## Summary

Adds per-frag collaborator permissions and a server-side revision log to writing blocks. Authors can grant named other users `edit` or `manage` access on their own frags; admins always have full access. Every save is now versioned with optimistic locking, every meaningful save is checkpointed in an append-only revision log, and any prior revision can be restored without losing the current state.

## What changed

### Schema (two migrations)
- **026** `writing_block_editors` — `(writing_block_id, user_id, granted_by, permission)` with `UNIQUE(writing_block_id, user_id)` and `CHECK (permission IN ('edit', 'manage'))`. `comment` and `suggest` were intentionally dropped — they imply enforcement subsystems that don't exist today.
- **027** `writing_block_revisions` — append-only snapshot log with `revision_kind IN ('create', 'edit', 'restore')` and `restored_from_version`. Adds `current_version` to `writing_blocks` as an optimistic-lock counter. Backfills v1 for every existing frag so rollbacks can target the original state.

### Permission model
- Original author → full RUD
- Admin → full RUD (always)
- Granted `edit` → may update title/body/themes/visibility/cover (never delete)
- Granted `manage` → everything `edit` plus add/remove other editors
- `writing_blocks.user_id` is never overwritten — original authorship is permanent

### Revision triggers
A new revision row is appended on `UPDATE` only when **all** of:
- Reason fires: explicit `revisionNote`, editor handoff (different user from prior revision), or prior revision is older than 30 min
- AND content hash differs from the latest revision (no-op dedup)

Autosaves with no checkpoint reason still update HEAD and bump `current_version`, just don't pollute the log. Restore creates a pre-restore checkpoint first, then a new `restore` revision — the table is strictly append-only.

### Optimistic locking
Client sends `expectedVersion` on PUT; server returns **409** with `details: { currentVersion, expectedVersion }` on mismatch. Client surfaces a reload prompt rather than silently overwriting a co-editor's work.

### New endpoints
- `GET    /api/writing/:id/editors` (manage+)
- `POST   /api/writing/:id/editors` (manage+)
- `PATCH  /api/writing/:id/editors/:targetUserId` (manage+)
- `DELETE /api/writing/:id/editors/:targetUserId` (manage+ or self)
- `GET    /api/writing/:id/revisions`
- `GET    /api/writing/:id/revisions/:versionNumber`
- `POST   /api/writing/:id/restore/:versionNumber` (edit+)
- `GET    /api/users/search?q=` (authenticated, ≥2 chars, excludes caller)

### UI
Top-right **Editors** and **History** buttons on existing frags open slide-out panels:
- **EditorsPanel** — invite-by-name search, list/change/remove grants with author and timestamp attribution
- **RevisionHistoryPanel** — version list with author + date + optional note, preview modal, restore button
- Added `PATCH` and a structured `ApiError` (status/code/details) to the fetch client so the UI can branch on 409

## Why

The previous model only had `visibility` (private/shared/public) and ownership-only update checks. There was no way for an author to grant a specific collaborator edit access, and no audit trail or rollback capability — once you saved, the prior state was gone. This adds:
1. Granular per-user grants (you said: ignore public editing for now; grants only)
2. A trustworthy audit trail that survives session loss (you said: not contingent on session data)
3. Restorable history with author/date attribution (you said: roll backs must be possible, audit consistency required)

## Reviewer notes

- **Migrations 026 and 027 must run before deploy.** Until they do, the new endpoints 500 on missing tables, but the existing list/get keeps working via `COALESCE(current_version, 1)`.
- Snapshot-per-revision (not diff). Storage math worked out to single-digit MB per manuscript even with aggressive autosave — fine for low-user-count, low-concurrency.
- `delete` is deliberately still owner/admin only — editors can't delete the frag, only edit it.
- `comment` and `suggest` levels are explicitly not in the enum yet. The CHECK constraint is a quick `ALTER` away when those subsystems get built.
- 8 pre-existing failures in `Write.spec.ts` (metadata panel + word count) are present on `main` and unrelated to this change.

## Test plan

- [ ] Run migrations 026 + 027 against a staging DB; confirm every existing frag has a v1 backfilled
- [ ] As Author A, create a frag, save several times — confirm 30-min checkpoint vs autosave behavior
- [ ] As Author A, grant Author B `edit`; confirm B can save, can't manage editors
- [ ] Grant B `manage`; confirm B can add/remove editors but not delete the frag
- [ ] Two browser tabs as different editors → save in tab 1, then save in tab 2 with stale `expectedVersion` → 409 + reload prompt
- [ ] Editor handoff between A and B creates a discrete revision attributed to each
- [ ] Restore a prior version → confirm HEAD reverts, a pre-restore checkpoint exists, and a `restore`-kind row points at the target version
- [ ] Admin can edit any frag without a grant; non-grantees get 403
- [ ] User search is gated to authenticated users and excludes the caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)