### PR TITLE
Gate shared visibility on admin-approved per-user flag

### DIFF
--- a/client/src/pages/Admin.vue
+++ b/client/src/pages/Admin.vue
@@ -151,6 +151,21 @@
                   {{ u.status }}
                 </span>
 
+                <!-- Shared-content access badge. Off by default for new
+                     signups; admins toggle this to grant read access to
+                     other users' shared-visibility frags. -->
+                <span
+                  class="inline-block px-2 py-1 text-xs rounded font-medium"
+                  :class="u.sharedAccess
+                    ? 'bg-blue-100 text-blue-800'
+                    : 'bg-gray-100 text-gray-600'"
+                  :title="u.sharedAccess
+                    ? 'Can read other users\' shared-visibility frags'
+                    : 'Cannot see others\' shared frags until approved'"
+                >
+                  {{ u.sharedAccess ? 'shared: on' : 'shared: off' }}
+                </span>
+
                 <span class="text-xs text-ink-lighter hidden sm:inline">{{ formatDate(u.createdAt) }}</span>
 
                 <!-- Role Toggle -->
@@ -177,6 +192,18 @@
                     : 'border-green-300 text-green-700 hover:bg-green-50'"
                 >
                   {{ u.status === 'active' ? 'Suspend' : 'Activate' }}
+                </button>
+
+                <!-- Shared-access toggle -->
+                <button
+                  @click="toggleSharedAccess(u)"
+                  :disabled="actionInProgress === u.id"
+                  class="px-2.5 py-1 text-xs rounded border transition-colors disabled:opacity-50"
+                  :class="u.sharedAccess
+                    ? 'border-blue-300 text-blue-700 hover:bg-blue-50'
+                    : 'border-green-300 text-green-700 hover:bg-green-50'"
+                >
+                  {{ u.sharedAccess ? 'Revoke shared' : 'Approve shared' }}
                 </button>
 
                 <!-- Delete User -->
@@ -1406,6 +1433,20 @@ const toggleStatus = async (u: User) => {
     showFeedback(`${u.displayName} is now ${newStatus}`)
   } catch (err) {
     showFeedback(err instanceof Error ? err.message : 'Failed to update status', 'error')
+  } finally {
+    actionInProgress.value = null
+  }
+}
+
+const toggleSharedAccess = async (u: User) => {
+  try {
+    actionInProgress.value = u.id
+    const next = !u.sharedAccess
+    await api.put(`/admin/users/${u.id}`, { sharedAccess: next })
+    u.sharedAccess = next
+    showFeedback(`${u.displayName} ${next ? 'can now read' : 'can no longer read'} other users' shared frags`)
+  } catch (err) {
+    showFeedback(err instanceof Error ? err.message : 'Failed to update shared access', 'error')
   } finally {
     actionInProgress.value = null
   }

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -195,7 +195,7 @@ export const adminController = {
   async updateUser(req: Request, res: Response) {
     const { id } = req.params
     const adminUserId = (req as any).userId
-    const { role, status, displayName, latitude, longitude } = req.body
+    const { role, status, displayName, latitude, longitude, sharedAccess } = req.body
 
     // Prevent admin from demoting themselves
     if (id === adminUserId && role && role !== 'admin') {
@@ -223,6 +223,9 @@ export const adminController = {
     if (longitude !== undefined && (typeof longitude !== 'number' || longitude < -180 || longitude > 180)) {
       throw new ValidationError('Longitude must be a number between -180 and 180')
     }
+    if (sharedAccess !== undefined && typeof sharedAccess !== 'boolean') {
+      throw new ValidationError('sharedAccess must be a boolean')
+    }
 
     const updates: Record<string, any> = {}
     if (role !== undefined) updates.role = role
@@ -230,6 +233,7 @@ export const adminController = {
     if (displayName !== undefined) updates.displayName = displayName
     if (latitude !== undefined) updates.latitude = latitude
     if (longitude !== undefined) updates.longitude = longitude
+    if (sharedAccess !== undefined) updates.sharedAccess = sharedAccess
 
     if (Object.keys(updates).length === 0) {
       throw new ValidationError('No updates provided')

--- a/server/src/controllers/writing-revision.controller.ts
+++ b/server/src/controllers/writing-revision.controller.ts
@@ -6,7 +6,7 @@ import {
   canEdit,
 } from '../services/writing-permissions.service.js'
 import { writingRepo } from '../repositories/writing.repo.js'
-import { isAdminRequest } from '../middleware/authorize.middleware.js'
+import { isAdminRequest, hasSharedAccess } from '../middleware/authorize.middleware.js'
 import {
   UnauthorizedError,
   ValidationError,
@@ -29,7 +29,7 @@ export const writingRevisionController = {
     // Anyone who can read the frag can read its history. We piggyback
     // on the same access policy as GET /writing/:id by calling findById
     // first; this throws 404/403 consistently for unauthorized readers.
-    await writingRepo.findById(id, userId, admin)
+    await writingRepo.findById(id, userId, admin, hasSharedAccess(req))
     const summaries = await writingRevisionRepo.listSummaries(id)
     res.json({ data: summaries })
   },
@@ -38,7 +38,7 @@ export const writingRevisionController = {
     const { id, versionNumber } = req.params
     const userId = userIdOrThrow(req)
     const admin = isAdminRequest(req)
-    await writingRepo.findById(id, userId, admin)
+    await writingRepo.findById(id, userId, admin, hasSharedAccess(req))
     const v = parseInt(versionNumber, 10)
     if (!Number.isInteger(v) || v < 1) {
       throw new ValidationError('Invalid version number')

--- a/server/src/controllers/writing.controller.ts
+++ b/server/src/controllers/writing.controller.ts
@@ -5,7 +5,7 @@ import { LlmConfigurationError, LlmRequestError } from '../services/llm/llm-clie
 import { UnauthorizedError, ValidationError } from '../utils/errors.js'
 import { activityService } from '../services/activity.service.js'
 import { getClientIp, getUserAgent, getUserId } from '../utils/activity-logger.js'
-import { isAdminRequest } from '../middleware/authorize.middleware.js'
+import { isAdminRequest, hasSharedAccess } from '../middleware/authorize.middleware.js'
 import { logger } from '../utils/logger.js'
 import type {
   WritingAssistMode,
@@ -40,9 +40,10 @@ export const writingController = {
   async getAll(req: Request, res: Response) {
     const userId = (req as any).userId || null // From optionalAuthMiddleware
     const admin = isAdminRequest(req)
+    const sharedAccess = hasSharedAccess(req)
     const limit = parseInt(req.query.limit as string) || 50
     const offset = parseInt(req.query.offset as string) || 0
-    const writings = await writingService.getAll(userId, limit, offset, admin)
+    const writings = await writingService.getAll(userId, limit, offset, admin, sharedAccess)
     
     // Log view activity
     await activityService.logView(
@@ -61,7 +62,8 @@ export const writingController = {
     const { id } = req.params
     const userId = (req as any).userId || null // From optionalAuthMiddleware
     const admin = isAdminRequest(req)
-    const writing = await writingService.getById(id, userId, admin)
+    const sharedAccess = hasSharedAccess(req)
+    const writing = await writingService.getById(id, userId, admin, sharedAccess)
     
     // Log view activity
     await activityService.logWriting(
@@ -232,7 +234,8 @@ export const writingController = {
       const result = await writingAssistService.run(
         { writingId: id, request, model },
         userId,
-        admin
+        admin,
+        hasSharedAccess(req)
       )
       logger.info('[writing-assist] request ok', {
         writingId: id,

--- a/server/src/db/migrations/028_user_shared_access.sql
+++ b/server/src/db/migrations/028_user_shared_access.sql
@@ -1,0 +1,24 @@
+-- Migration 028: Admin-gated access to shared-visibility content
+--
+-- A frag with visibility='shared' is meant to be readable by other
+-- authenticated users of the system — but only ones an admin has
+-- explicitly approved. This adds a per-user flag the admin can toggle;
+-- unapproved users see only public frags + their own + frags they're
+-- a named editor on.
+--
+-- Asymmetric: shared_access only gates READING others' shared frags.
+-- Setting your own frag to visibility='shared' is unrestricted (it's
+-- harmless if no unapproved user can see it).
+--
+-- Grandfather: every existing active user is flagged TRUE at migration
+-- time so the change does not silently revoke current access. New
+-- signups default to FALSE and need explicit admin approval.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS shared_access BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE users SET shared_access = TRUE WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_users_shared_access
+  ON users(shared_access)
+  WHERE shared_access = TRUE;

--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -33,7 +33,8 @@ export async function authMiddleware(
     // Attach userId and userRole to request for use in controllers
     ;(req as any).userId = userId
     ;(req as any).userRole = user.role || 'user'
-    
+    ;(req as any).userSharedAccess = Boolean(user.sharedAccess)
+
     next()
   } catch (error) {
     next(new UnauthorizedError('Invalid or expired token'))
@@ -60,6 +61,7 @@ export async function optionalAuthMiddleware(
       if (user) {
         ;(req as any).userId = userId
         ;(req as any).userRole = user.role || 'user'
+        ;(req as any).userSharedAccess = Boolean(user.sharedAccess)
       }
     } catch (error) {
       // Silently fail for optional auth

--- a/server/src/middleware/authorize.middleware.ts
+++ b/server/src/middleware/authorize.middleware.ts
@@ -44,3 +44,13 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction) {
 export function isAdminRequest(req: Request): boolean {
   return (req as any).userRole === 'admin'
 }
+
+/**
+ * Helper to check if the current user has admin-granted access to
+ * shared-visibility content. Admins are always considered to have it.
+ * Returns false for unauthenticated requests.
+ */
+export function hasSharedAccess(req: Request): boolean {
+  if ((req as any).userRole === 'admin') return true
+  return Boolean((req as any).userSharedAccess)
+}

--- a/server/src/repositories/user.repo.ts
+++ b/server/src/repositories/user.repo.ts
@@ -8,8 +8,10 @@ import { NotFoundError } from '../utils/errors.js'
 export const userRepo = {
   async findByEmail(email: string): Promise<UserWithPassword | null> {
     const result = await pool.query(
-      `SELECT id, email, password_hash as "passwordHash", display_name as "displayName", 
-              COALESCE(role, 'user') as role, status, created_at as "createdAt", updated_at as "updatedAt"
+      `SELECT id, email, password_hash as "passwordHash", display_name as "displayName",
+              COALESCE(role, 'user') as role, status,
+              COALESCE(shared_access, FALSE) as "sharedAccess",
+              created_at as "createdAt", updated_at as "updatedAt"
        FROM users
        WHERE email = $1`,
       [email]
@@ -21,8 +23,9 @@ export const userRepo = {
     // Check if role column exists, if not use COALESCE to default to 'user'
     const result = await pool.query(
       `SELECT id, email, display_name as "displayName", 
-              COALESCE(role, 'user') as role, 
-              status, 
+              COALESCE(role, 'user') as role,
+              status,
+              COALESCE(shared_access, FALSE) as "sharedAccess",
               created_at as "createdAt", updated_at as "updatedAt",
               latitude, longitude
        FROM users
@@ -49,28 +52,32 @@ export const userRepo = {
       {
         query: `INSERT INTO users (email, password_hash, display_name, role, username)
                 VALUES ($1, $2, $3, $4, $1)
-                RETURNING id, email, display_name as "displayName", COALESCE(role, 'user') as role, status, 
+                RETURNING id, email, display_name as "displayName", COALESCE(role, 'user') as role, status,
+                          COALESCE(shared_access, FALSE) as "sharedAccess",
                           created_at as "createdAt", updated_at as "updatedAt"`,
         values: [user.email, user.passwordHash, user.displayName, role]
       },
       {
         query: `INSERT INTO users (email, password_hash, display_name, username)
                 VALUES ($1, $2, $3, $1)
-                RETURNING id, email, display_name as "displayName", 'user' as role, status, 
+                RETURNING id, email, display_name as "displayName", 'user' as role, status,
+                          COALESCE(shared_access, FALSE) as "sharedAccess",
                           created_at as "createdAt", updated_at as "updatedAt"`,
         values: [user.email, user.passwordHash, user.displayName]
       },
       {
         query: `INSERT INTO users (email, password_hash, display_name, role)
                 VALUES ($1, $2, $3, $4)
-                RETURNING id, email, display_name as "displayName", COALESCE(role, 'user') as role, status, 
+                RETURNING id, email, display_name as "displayName", COALESCE(role, 'user') as role, status,
+                          COALESCE(shared_access, FALSE) as "sharedAccess",
                           created_at as "createdAt", updated_at as "updatedAt"`,
         values: [user.email, user.passwordHash, user.displayName, role]
       },
       {
         query: `INSERT INTO users (email, password_hash, display_name)
                 VALUES ($1, $2, $3)
-                RETURNING id, email, display_name as "displayName", 'user' as role, status, 
+                RETURNING id, email, display_name as "displayName", 'user' as role, status,
+                          COALESCE(shared_access, FALSE) as "sharedAccess",
                           created_at as "createdAt", updated_at as "updatedAt"`,
         values: [user.email, user.passwordHash, user.displayName]
       }
@@ -127,8 +134,9 @@ export const userRepo = {
   async findAll(limit: number = 100, offset: number = 0): Promise<User[]> {
     const result = await pool.query(
       `SELECT id, email, display_name as "displayName", 
-              COALESCE(role, 'user') as role, 
-              status, 
+              COALESCE(role, 'user') as role,
+              status,
+              COALESCE(shared_access, FALSE) as "sharedAccess",
               created_at as "createdAt", updated_at as "updatedAt",
               latitude, longitude
        FROM users
@@ -165,6 +173,7 @@ export const userRepo = {
     role: 'user' | 'admin'
     latitude: number
     longitude: number
+    sharedAccess: boolean
   }>): Promise<User> {
     const fields: string[] = []
     const values: unknown[] = []
@@ -194,6 +203,10 @@ export const userRepo = {
       fields.push(`longitude = $${paramCount++}`)
       values.push(updates.longitude)
     }
+    if (updates.sharedAccess !== undefined) {
+      fields.push(`shared_access = $${paramCount++}`)
+      values.push(updates.sharedAccess)
+    }
 
     if (fields.length === 0) {
       const user = await this.findById(id)
@@ -208,7 +221,8 @@ export const userRepo = {
       `UPDATE users
        SET ${fields.join(', ')}
        WHERE id = $${paramCount}
-       RETURNING id, email, display_name as "displayName", COALESCE(role, 'user') as role, status, 
+       RETURNING id, email, display_name as "displayName", COALESCE(role, 'user') as role, status,
+                 COALESCE(shared_access, FALSE) as "sharedAccess",
                  created_at as "createdAt", updated_at as "updatedAt", latitude, longitude`,
       values
     )

--- a/server/src/repositories/writing.repo.ts
+++ b/server/src/repositories/writing.repo.ts
@@ -68,7 +68,13 @@ export const writingRepo = {
    * - Own private/shared/public blocks
    * - Others' shared/public blocks
    */
-  async findAll(userId: string | null, limit: number = 50, offset: number = 0, isAdmin: boolean = false): Promise<WritingBlock[]> {
+  async findAll(
+    userId: string | null,
+    limit: number = 50,
+    offset: number = 0,
+    isAdmin: boolean = false,
+    userSharedAccess: boolean = false
+  ): Promise<WritingBlock[]> {
     let query: string
     let params: unknown[]
 
@@ -112,12 +118,17 @@ export const writingRepo = {
         `
         params = [limit, offset]
       } else if (userId) {
-        // Authenticated: own blocks + shared/public from others
+        // Authenticated, non-admin. Read access is granted when ANY of:
+        //   - user is the owner (any visibility, incl. private)
+        //   - visibility = 'public' (anyone)
+        //   - visibility = 'shared' AND user is admin-approved for shared
+        //   - user has a row in writing_block_editors (named editor on a
+        //     private/shared/public frag)
         query = `
-          SELECT 
-            wb.id, 
-            wb.user_id as "userId", 
-            wb.title, 
+          SELECT
+            wb.id,
+            wb.user_id as "userId",
+            wb.title,
             wb.body,
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
@@ -131,12 +142,19 @@ export const writingRepo = {
             ) as "themeIds"
           FROM writing_blocks wb
           LEFT JOIN writing_themes wt ON wb.id = wt.writing_id
-          WHERE wb.user_id = $1 OR COALESCE(wb.visibility, 'private') IN ('shared', 'public')
+          WHERE
+            wb.user_id = $1
+            OR COALESCE(wb.visibility, 'private') = 'public'
+            OR (COALESCE(wb.visibility, 'private') = 'shared' AND $4::boolean)
+            OR EXISTS (
+              SELECT 1 FROM writing_block_editors wbe
+              WHERE wbe.writing_block_id = wb.id AND wbe.user_id = $1
+            )
           GROUP BY wb.id, wb.user_id, wb.title, wb.body, wb.visibility, wb.cover_image_url, wb.cover_image_position, wb.created_at, wb.updated_at
           ORDER BY wb.created_at DESC
           LIMIT $2 OFFSET $3
         `
-        params = [userId, limit, offset]
+        params = [userId, limit, offset, userSharedAccess]
       } else {
         // Unauthenticated: only public blocks
         query = `
@@ -203,7 +221,12 @@ export const writingRepo = {
    * - Owner can access any visibility
    * - Others can only access shared/public
    */
-  async findById(id: string, userId: string | null, isAdmin: boolean = false): Promise<WritingBlock> {
+  async findById(
+    id: string,
+    userId: string | null,
+    isAdmin: boolean = false,
+    userSharedAccess: boolean = false
+  ): Promise<WritingBlock> {
     // Check if visibility column exists
     let hasVisibilityColumn = true
     try {
@@ -245,11 +268,13 @@ export const writingRepo = {
         `
         params = [id]
       } else if (userId) {
+        // Same access rules as findAll's authenticated branch:
+        // owner, public, shared+approved, or named-editor grant.
         query = `
-          SELECT 
-            wb.id, 
-            wb.user_id as "userId", 
-            wb.title, 
+          SELECT
+            wb.id,
+            wb.user_id as "userId",
+            wb.title,
             wb.body,
             COALESCE(wb.visibility, 'private') as visibility,
             wb.cover_image_url as "coverImageUrl",
@@ -263,10 +288,18 @@ export const writingRepo = {
             ) as "themeIds"
           FROM writing_blocks wb
           LEFT JOIN writing_themes wt ON wb.id = wt.writing_id
-          WHERE wb.id = $1 AND (wb.user_id = $2 OR COALESCE(wb.visibility, 'private') IN ('shared', 'public'))
+          WHERE wb.id = $1 AND (
+            wb.user_id = $2
+            OR COALESCE(wb.visibility, 'private') = 'public'
+            OR (COALESCE(wb.visibility, 'private') = 'shared' AND $3::boolean)
+            OR EXISTS (
+              SELECT 1 FROM writing_block_editors wbe
+              WHERE wbe.writing_block_id = wb.id AND wbe.user_id = $2
+            )
+          )
           GROUP BY wb.id, wb.user_id, wb.title, wb.body, wb.visibility, wb.cover_image_url, wb.cover_image_position, wb.created_at, wb.updated_at
         `
-        params = [id, userId]
+        params = [id, userId, userSharedAccess]
       } else {
         query = `
           SELECT 

--- a/server/src/services/writing-assist.service.ts
+++ b/server/src/services/writing-assist.service.ts
@@ -214,7 +214,8 @@ export const writingAssistService = {
   async run(
     input: RunWritingAssistInput,
     userId: string | null,
-    isAdmin: boolean = false
+    isAdmin: boolean = false,
+    userSharedAccess: boolean = false
   ): Promise<WritingAssistResponse> {
     logger.debug('[writing-assist] service.run start', {
       writingId: input.writingId,
@@ -226,7 +227,7 @@ export const writingAssistService = {
     // 1. Authorize. Reusing writingService.getById means the caller sees
     //    exactly the same NotFound / Forbidden semantics as the regular
     //    writing endpoints — and we keep the access policy in one place.
-    const writing = await writingService.getById(input.writingId, userId, isAdmin)
+    const writing = await writingService.getById(input.writingId, userId, isAdmin, userSharedAccess)
     logger.debug('[writing-assist] writing loaded', {
       writingId: writing.id,
       titleLen: writing.title?.length ?? 0,

--- a/server/src/services/writing.service.ts
+++ b/server/src/services/writing.service.ts
@@ -22,12 +22,23 @@ function validateCoverImagePath(pathOrUrl: string): void {
  * Writing service - business logic layer
  */
 export const writingService = {
-  async getAll(userId: string | null, limit?: number, offset?: number, isAdmin: boolean = false): Promise<WritingBlock[]> {
-    return writingRepo.findAll(userId, limit || 50, offset || 0, isAdmin)
+  async getAll(
+    userId: string | null,
+    limit?: number,
+    offset?: number,
+    isAdmin: boolean = false,
+    userSharedAccess: boolean = false
+  ): Promise<WritingBlock[]> {
+    return writingRepo.findAll(userId, limit || 50, offset || 0, isAdmin, userSharedAccess)
   },
 
-  async getById(id: string, userId: string | null, isAdmin: boolean = false): Promise<WritingBlock> {
-    return writingRepo.findById(id, userId, isAdmin)
+  async getById(
+    id: string,
+    userId: string | null,
+    isAdmin: boolean = false,
+    userSharedAccess: boolean = false
+  ): Promise<WritingBlock> {
+    return writingRepo.findById(id, userId, isAdmin, userSharedAccess)
   },
 
   async create(data: {

--- a/shared/User.ts
+++ b/shared/User.ts
@@ -4,6 +4,13 @@ export interface User {
   displayName: string
   role: 'user' | 'admin'
   status: 'active' | 'inactive' | 'suspended'
+  /**
+   * Admin-gated access to other users' shared-visibility content.
+   * False by default for new signups; toggled by an admin via the
+   * user-edit form. Does NOT affect ability to set one's own frags
+   * to shared visibility (that's unrestricted).
+   */
+  sharedAccess: boolean
   createdAt: string
   updatedAt: string
   /** Optional: used for admin map pins */


### PR DESCRIPTION
## Summary

Fixes a bug introduced by PR #87 (named editors couldn't actually read the private frags they had edit rights on), and tightens read access to `shared`-visibility frags by gating them on an admin-approved per-user flag.

## What changed

### Two read-access rule updates

**1. Private frags now respect editor grants.**
After PR #87, a user with `edit` on a private frag couldn't load it — the read check at [writing.repo.ts:207](server/src/repositories/writing.repo.ts:207) was still owner-only. The new authenticated-user predicate matches when **any** of:
- user is the owner (any visibility)
- `visibility = 'public'`
- `visibility = 'shared'` AND user is admin-approved (see #2)
- `EXISTS` row in `writing_block_editors` for this frag + user

**2. New per-user `shared_access` flag, toggled by admins.**
Migration **028** adds `users.shared_access BOOLEAN NOT NULL DEFAULT FALSE`. To read another user's `shared` frag, you now need this flag flipped on (admins always have it implicitly). Asymmetric: setting your **own** frag to `shared` is still unrestricted — it just won't be visible to other unapproved users.

### Grandfather migration

All currently-active users are backfilled to `shared_access = TRUE`, so today's behavior is preserved on rollout. New signups default to `FALSE` and need explicit admin approval before they can see anyone else's shared content.

### Plumbing

- [shared/User.ts](shared/User.ts) — added `sharedAccess: boolean` to the shared User type
- [user.repo.ts](server/src/repositories/user.repo.ts) — all SELECT/RETURNING paths surface `sharedAccess`; `update` accepts the new field
- [auth.middleware.ts](server/src/middleware/auth.middleware.ts) — attaches `userSharedAccess` to `req` in both `authMiddleware` and `optionalAuthMiddleware`
- [authorize.middleware.ts](server/src/middleware/authorize.middleware.ts) — new `hasSharedAccess(req)` helper (admins always true)
- [writing.repo.ts](server/src/repositories/writing.repo.ts) — `findAll` and `findById` take a `userSharedAccess` param; predicates updated as above
- `writing.service`, `writing-assist.service`, and `writing-revision.controller` threaded with the new param so the access policy stays consistent across every read path
- [admin.controller.ts:195](server/src/controllers/admin.controller.ts:195) — `updateUser` accepts `sharedAccess` with boolean validation

### UI

Admin user list ([Admin.vue](client/src/pages/Admin.vue)) grows a `shared: on/off` badge per user and an Approve / Revoke button. PUT to `/admin/users/:id` with `{ sharedAccess: boolean }`.

## Why

Two motivations:
1. PR #87's editor-grant feature was effectively dead in the water without the read-side fix — grantees got 404 on the very frags they were granted access to.
2. Per request: tighten what `shared` actually means. Now it's "shared with other admin-approved users" rather than "shared with anyone logged in". The new model leaves the existing three-state visibility intact while making `shared` meaningfully different from `public`.

## Reviewer notes

- Run migration 028 before deploy. Grandfathering means rollout is a no-op for existing users; new signups are tighter.
- Asymmetric on purpose: anyone can set their own frag to `shared`, but only approved users can see other people's. If you'd rather make this symmetric (block unapproved users from selecting `shared` visibility), say so and I'll add the check.
- `delete` still uses `userSharedAccess = false` default — harmless because delete is owner/admin only and the owner branch of the predicate doesn't consult `sharedAccess`.
- 8 pre-existing failures in `Write.spec.ts` remain (same set as on main); unrelated.

## Test plan

- [ ] Run migration 028 against a staging DB; confirm every existing active user has `shared_access = TRUE`
- [ ] Create a new signup → confirm `shared_access` defaults to `FALSE`
- [ ] As Author A, set a frag to `shared`. As User B (`shared_access = FALSE`), confirm B does **not** see the frag in the list or by direct URL
- [ ] Admin flips B's `shared_access` to `TRUE` → B now sees A's shared frag
- [ ] As Author A, grant Author C `edit` on a `private` frag → C can now open and edit it (this is the PR #87 bug fix)
- [ ] B (unapproved) can still set their own frag to `shared` — the visibility selector isn't gated
- [ ] Admin user list shows the badge and the Approve/Revoke button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)