### PR TITLE
Show edit icon to named editors on frag cards, rows, and read page

### DIFF
--- a/client/src/components/writing/EditorsPanel.vue
+++ b/client/src/components/writing/EditorsPanel.vue
@@ -122,6 +122,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import { writingApi, userSearchApi, type UserSearchHit } from '@/api/writing'
+import { useMyGrants } from '@/composables/useMyGrants'
 import type {
   WritingBlockEditor,
   WritingBlockEditorPermission,
@@ -140,6 +141,8 @@ const editors = ref<WritingBlockEditor[]>([])
 const loading = ref(false)
 const error = ref('')
 const inviteError = ref('')
+
+const myGrants = useMyGrants()
 
 const searchQuery = ref('')
 const searchResults = ref<UserSearchHit[]>([])
@@ -197,6 +200,11 @@ async function invite(hit: UserSearchHit) {
     searchQuery.value = ''
     searchResults.value = []
     await refresh()
+    // The invitee's edit-icon affordance depends on the in-memory grant
+    // set; refresh it so a multi-tab same-user session sees the change
+    // on next mount. (The viewer is the granter, not the grantee, so
+    // this is a no-op for them, but keeps the contract consistent.)
+    await myGrants.refresh()
   } catch (e: any) {
     inviteError.value = e?.message || 'Failed to grant access'
   }
@@ -208,6 +216,7 @@ async function onChangePermission(ed: WritingBlockEditor, perm: string) {
   try {
     await writingApi.changeEditor(props.writingId, ed.userId, perm)
     await refresh()
+    await myGrants.refresh()
   } catch (e: any) {
     error.value = e?.message || 'Failed to update permission'
   }
@@ -219,6 +228,7 @@ async function onRemove(ed: WritingBlockEditor) {
   try {
     await writingApi.removeEditor(props.writingId, ed.userId)
     await refresh()
+    await myGrants.refresh()
   } catch (e: any) {
     error.value = e?.message || 'Failed to remove editor'
   }

--- a/client/src/components/writing/WritingCard.vue
+++ b/client/src/components/writing/WritingCard.vue
@@ -97,27 +97,27 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
         </svg>
       </button>
-      <template v-if="canModify">
-        <router-link
-          :to="`/write/${writing.id}`"
-          class="p-2 text-ink-lighter hover:text-ink"
-          title="Edit"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-          </svg>
-        </router-link>
-        <button
-          @click="handleDelete"
-          :disabled="deleting"
-          class="p-2 text-ink-lighter hover:text-red-600 disabled:opacity-50"
-          title="Delete"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-          </svg>
-        </button>
-      </template>
+      <router-link
+        v-if="canEdit"
+        :to="`/write/${writing.id}`"
+        class="p-2 text-ink-lighter hover:text-ink"
+        :title="isOwner || isAdmin ? 'Edit' : 'Edit (granted)'"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
+      </router-link>
+      <button
+        v-if="canDelete"
+        @click="handleDelete"
+        :disabled="deleting"
+        class="p-2 text-ink-lighter hover:text-red-600 disabled:opacity-50"
+        title="Delete"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      </button>
     </div>
   </article>
 </template>
@@ -127,6 +127,7 @@ import { computed, ref, watch } from 'vue'
 import { api } from '../../api/client'
 import { useAuth } from '../../stores/auth'
 import { useReadingStore } from '../../stores/reading'
+import { useMyGrants } from '../../composables/useMyGrants'
 import type { WritingBlock } from '../../domain/WritingBlock'
 import type { Theme } from '../../domain/Theme'
 import type { WritingReactionSummary } from '../../domain/Appreciation'
@@ -155,19 +156,33 @@ const props = withDefaults(defineProps<Props>(), {
   canMoveDown: false,
 })
 
-const { user, isAdmin } = useAuth()
+const { user, isAdmin, isAuthenticated } = useAuth()
 const readingStore = useReadingStore()
+const myGrants = useMyGrants()
 const deleting = ref(false)
 const imageError = ref(false)
+
+// Load the current user's editor grants once, then resolve cheaply via
+// the in-memory set. Safe to call unguarded — the composable no-ops on
+// repeat calls and on signed-out 401s.
+if (isAuthenticated.value) {
+  myGrants.loadOnce()
+}
 
 const isOwner = computed(() => {
   return user.value && props.writing.userId === user.value.id
 })
 
 /**
- * Can edit/delete: owner or admin
+ * Can open the editor: owner, admin, or someone who's been invited as
+ * a named editor. Delete is still owner/admin only (see canDelete).
  */
-const canModify = computed(() => {
+const canEdit = computed(() => {
+  if (!isAuthenticated.value) return false
+  return isOwner.value || isAdmin.value || myGrants.hasEditGrant(props.writing.id)
+})
+
+const canDelete = computed(() => {
   return isOwner.value || isAdmin.value
 })
 

--- a/client/src/components/writing/WritingListRow.vue
+++ b/client/src/components/writing/WritingListRow.vue
@@ -56,30 +56,30 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
         </svg>
       </button>
-      <template v-if="canModify">
-        <router-link
-          :to="`/write/${writing.id}`"
-          class="frag-row-action"
-          aria-label="Edit"
-          title="Edit"
-        >
-          <svg class="frag-row-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-          </svg>
-        </router-link>
-        <button
-          type="button"
-          @click="handleDelete"
-          :disabled="deleting"
-          class="frag-row-action"
-          aria-label="Delete"
-          title="Delete"
-        >
-          <svg class="frag-row-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-          </svg>
-        </button>
-      </template>
+      <router-link
+        v-if="canEdit"
+        :to="`/write/${writing.id}`"
+        class="frag-row-action"
+        :aria-label="isOwner || isAdmin ? 'Edit' : 'Edit (granted)'"
+        :title="isOwner || isAdmin ? 'Edit' : 'Edit (granted)'"
+      >
+        <svg class="frag-row-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
+      </router-link>
+      <button
+        v-if="canDelete"
+        type="button"
+        @click="handleDelete"
+        :disabled="deleting"
+        class="frag-row-action"
+        aria-label="Delete"
+        title="Delete"
+      >
+        <svg class="frag-row-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      </button>
     </div>
   </article>
 </template>
@@ -94,6 +94,7 @@ import { computed, ref } from 'vue'
 import { api } from '../../api/client'
 import { useAuth } from '../../stores/auth'
 import { useReadingStore } from '../../stores/reading'
+import { useMyGrants } from '../../composables/useMyGrants'
 import type { WritingBlock } from '../../domain/WritingBlock'
 import type { Theme } from '../../domain/Theme'
 import { markdownToText, isStandaloneHtmlDoc } from '../../utils/markdown'
@@ -116,12 +117,23 @@ const props = withDefaults(defineProps<Props>(), {
   canMoveDown: false,
 })
 
-const { user, isAdmin } = useAuth()
+const { user, isAdmin, isAuthenticated } = useAuth()
 const readingStore = useReadingStore()
+const myGrants = useMyGrants()
 const deleting = ref(false)
 
+if (isAuthenticated.value) {
+  myGrants.loadOnce()
+}
+
 const isOwner = computed(() => !!user.value && props.writing.userId === user.value.id)
-const canModify = computed(() => isOwner.value || isAdmin.value)
+// Owner, admin, OR named editor → can open in the editor.
+const canEdit = computed(() => {
+  if (!isAuthenticated.value) return false
+  return isOwner.value || isAdmin.value || myGrants.hasEditGrant(props.writing.id)
+})
+// Delete remains owner/admin only.
+const canDelete = computed(() => isOwner.value || isAdmin.value)
 const isRecentlyRead = computed(() => readingStore.isRecentlyRead(props.writing.id))
 const isSpa = computed(() => isStandaloneHtmlDoc(props.writing.body))
 

--- a/client/src/composables/useMyGrants.ts
+++ b/client/src/composables/useMyGrants.ts
@@ -1,0 +1,74 @@
+import { ref, computed, watch } from 'vue'
+import { api } from '../api/client'
+import { useAuth } from '../stores/auth'
+import type { ApiResponse } from '@shared/ApiResponses'
+import type { WritingBlockEditorPermission } from '@shared/WritingBlockEditor'
+
+/**
+ * Module-level singleton: the current user's editor grants on other
+ * authors' frags. Loaded once after sign-in and refreshed when the
+ * Editors panel mutates a grant.
+ *
+ * Keeps the WritingCard / WritingListRow / Read.vue edit-icon gates
+ * cheap (Set lookup, no per-card request).
+ */
+interface Grant {
+  writingBlockId: string
+  permission: WritingBlockEditorPermission
+}
+
+const grants = ref<Grant[]>([])
+const loaded = ref(false)
+const loading = ref(false)
+
+async function loadOnce(force = false): Promise<void> {
+  if (loading.value) return
+  if (loaded.value && !force) return
+  loading.value = true
+  try {
+    const res = await api.get<ApiResponse<Grant[]>>('/writing/my-grants')
+    grants.value = res.data || []
+    loaded.value = true
+  } catch {
+    // If the endpoint 401s (signed out) or 500s (migration not run),
+    // leave the grants set empty — worst case the user sees no edit
+    // icon on shared frags, which is the safe default.
+    grants.value = []
+    loaded.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+function clear(): void {
+  grants.value = []
+  loaded.value = false
+}
+
+// Auto-clear when the signed-in user changes (sign-out, account switch).
+// Runs once at module load; the watcher persists for the page lifetime.
+const { user } = useAuth()
+watch(
+  () => user.value?.id ?? null,
+  (newId, oldId) => {
+    if (newId !== oldId) clear()
+  }
+)
+
+export function useMyGrants() {
+  const grantedIds = computed(() => new Set(grants.value.map(g => g.writingBlockId)))
+
+  function hasEditGrant(writingBlockId: string): boolean {
+    return grantedIds.value.has(writingBlockId)
+  }
+
+  return {
+    grants,
+    loaded,
+    loadOnce,
+    /** Force a re-fetch — call after the Editors panel adds/removes grants. */
+    refresh: () => loadOnce(true),
+    clear,
+    hasEditGrant,
+  }
+}

--- a/client/src/pages/Read.vue
+++ b/client/src/pages/Read.vue
@@ -213,6 +213,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { api } from '../api/client'
 import { useAuth } from '../stores/auth'
+import { useMyGrants } from '../composables/useMyGrants'
 import { useReadingStore } from '../stores/reading'
 import { useNavigationOrigin } from '../stores/navigation'
 import ReadingLayout from '../layouts/ReadingLayout.vue'
@@ -233,6 +234,10 @@ import {
 
 const route = useRoute()
 const { isAuthenticated, user, isAdmin } = useAuth()
+const myGrants = useMyGrants()
+if (isAuthenticated.value) {
+  myGrants.loadOnce()
+}
 const readingStore = useReadingStore()
 const { origin: navOrigin, originLabel } = useNavigationOrigin('/home')
 
@@ -275,11 +280,13 @@ const excerpt = computed(() => {
   return text.substring(0, cut) + '...'
 })
 
-// Show the edit affordance only to the author or to admins. Falls back to
-// false when no writing is loaded or the viewer is not signed in.
+// Show the edit affordance to the author, admins, or anyone the author
+// has invited as a named editor. Falls back to false when no writing is
+// loaded or the viewer is not signed in.
 const canEdit = computed(() => {
   if (!writing.value || !isAuthenticated.value || !user.value) return false
-  return isAdmin.value || writing.value.userId === user.value.id
+  if (isAdmin.value || writing.value.userId === user.value.id) return true
+  return myGrants.hasEditGrant(writing.value.id)
 })
 
 const formattedDate = computed(() => {

--- a/server/src/controllers/writing-editor.controller.ts
+++ b/server/src/controllers/writing-editor.controller.ts
@@ -24,6 +24,24 @@ function getUserIdOrThrow(req: Request): string {
 }
 
 export const writingEditorController = {
+  /**
+   * GET /api/writing/my-grants
+   *
+   * Returns the editor grants held by the current user — one row per frag
+   * they've been invited to edit. The client uses this on app load to
+   * decide whether to surface the edit affordance on each card / row.
+   * Cheap: a single indexed lookup, returns just (writingBlockId,
+   * permission) pairs.
+   */
+  async myGrants(req: Request, res: Response) {
+    const userId = getUserIdOrThrow(req)
+    // We don't bypass for admins here: admins already see the edit
+    // affordance via the role check on the client. This endpoint is
+    // strictly "what was I personally invited to."
+    const grants = await writingEditorRepo.listFragsForUser(userId, 'edit')
+    res.json({ data: grants })
+  },
+
   async list(req: Request, res: Response) {
     const { id } = req.params
     const userId = getUserIdOrThrow(req)

--- a/server/src/routes/writing.routes.ts
+++ b/server/src/routes/writing.routes.ts
@@ -11,6 +11,11 @@ const router = Router()
 
 // Public routes (with optional auth for visibility filtering)
 router.get('/', optionalAuthMiddleware, asyncHandler(writingController.getAll))
+
+// "Frags I was invited to edit" — must be declared BEFORE the /:id route
+// so Express doesn't match the literal "my-grants" as an :id param.
+router.get('/my-grants', authMiddleware, asyncHandler(writingEditorController.myGrants))
+
 router.get('/:id', optionalAuthMiddleware, asyncHandler(writingController.getById))
 
 // Upload (authenticated users - for own essay covers)


### PR DESCRIPTION
## Summary

PR #87 added named-user edit grants on the backend, and PR #88 fixed the read-access path so grantees could load a private frag they'd been invited to edit. But the **edit icon itself** was still gated to owner-or-admin on the frag list (cards + rows) and on the Read page, so granted editors had no obvious way in. This PR finishes the surface: the pencil icon now appears wherever a user has an editor grant.

## What changed

### Server
- New endpoint **`GET /api/writing/my-grants`** ([writing-editor.controller.ts](server/src/controllers/writing-editor.controller.ts)) returning `[{writingBlockId, permission}]` for the authenticated user. Cheap: one indexed lookup.
- Route declared **before** `/:id` ([writing.routes.ts](server/src/routes/writing.routes.ts)) so Express doesn't match the literal `my-grants` as a UUID param.

### Client
- New composable [useMyGrants.ts](client/src/composables/useMyGrants.ts) — module-level singleton:
  - `loadOnce()` fetches the grant set; subsequent calls are no-ops.
  - `hasEditGrant(id)` is an in-memory `Set` lookup — cheap enough to call once per card render.
  - `refresh()` re-fetches; the Editors panel calls this after any grant mutation.
  - Auto-clears on sign-out / account switch via a watch on `useAuth().user.id`.
- [WritingCard.vue](client/src/components/writing/WritingCard.vue) and [WritingListRow.vue](client/src/components/writing/WritingListRow.vue) — the old `canModify` flag (which gated **both** edit and delete) is split:
  - `canEdit` = owner OR admin OR grantee → controls the pencil icon
  - `canDelete` = owner OR admin → controls the trash icon
- [Read.vue](client/src/pages/Read.vue) — same change to the page-level `canEdit` computed
- [EditorsPanel.vue](client/src/components/writing/EditorsPanel.vue) — calls `myGrants.refresh()` after invite / change / remove so the set stays current within the session

### UX detail

Grantees get an `Edit (granted)` tooltip on the icon to distinguish their access from authorship. Server-side the `update` permission check is unchanged — the icon visibility just matches the existing backend rule.

## Reviewer notes

- No migration. Pure surface change on top of the three earlier PRs.
- The composable's `loadOnce()` swallows 401s silently — if a user signs out and a stale component still calls it, the worst case is an empty grant set (the safe default).
- Delete behavior is intentionally unchanged. Editors can't delete the frag — that's reserved for the owner and admins, matching `canDelete` on the server.
- Pre-existing `Write.spec.ts` failures (8) remain unchanged.

## Test plan

- [ ] As Author A, invite Author B as an `edit` editor on a private frag
- [ ] As B, refresh the home page → confirm the pencil icon appears on the frag in both card view and list view
- [ ] B clicks the pencil → opens [Write.vue](client/src/pages/Write.vue), can save (covered by PR #87)
- [ ] B should **not** see the trash icon on the same frag
- [ ] As Author A, open the Editors panel and revoke B's grant → confirm the pencil disappears for B (after page refresh; cross-tab invalidation is out of scope)
- [ ] B signs out and back in as a different user → composable clears, the new user only sees their own grants
- [ ] The Read page shows the edit affordance for grantees too

🤖 Generated with [Claude Code](https://claude.com/claude-code)