### PR TITLE
Fix: edit icon never appears for granted editors on first load

### DIFF
--- a/client/src/components/writing/WritingCard.vue
+++ b/client/src/components/writing/WritingCard.vue
@@ -162,13 +162,6 @@ const myGrants = useMyGrants()
 const deleting = ref(false)
 const imageError = ref(false)
 
-// Load the current user's editor grants once, then resolve cheaply via
-// the in-memory set. Safe to call unguarded — the composable no-ops on
-// repeat calls and on signed-out 401s.
-if (isAuthenticated.value) {
-  myGrants.loadOnce()
-}
-
 const isOwner = computed(() => {
   return user.value && props.writing.userId === user.value.id
 })

--- a/client/src/components/writing/WritingListRow.vue
+++ b/client/src/components/writing/WritingListRow.vue
@@ -122,10 +122,6 @@ const readingStore = useReadingStore()
 const myGrants = useMyGrants()
 const deleting = ref(false)
 
-if (isAuthenticated.value) {
-  myGrants.loadOnce()
-}
-
 const isOwner = computed(() => !!user.value && props.writing.userId === user.value.id)
 // Owner, admin, OR named editor → can open in the editor.
 const canEdit = computed(() => {

--- a/client/src/composables/useMyGrants.ts
+++ b/client/src/composables/useMyGrants.ts
@@ -29,12 +29,14 @@ async function loadOnce(force = false): Promise<void> {
     const res = await api.get<ApiResponse<Grant[]>>('/writing/my-grants')
     grants.value = res.data || []
     loaded.value = true
-  } catch {
-    // If the endpoint 401s (signed out) or 500s (migration not run),
-    // leave the grants set empty — worst case the user sees no edit
-    // icon on shared frags, which is the safe default.
+  } catch (err) {
+    // Leave loaded=false so a transient failure (e.g. the server
+    // hasn't restarted to pick up the new route) doesn't permanently
+    // suppress the edit icon. The next trigger will retry.
     grants.value = []
-    loaded.value = true
+    if (typeof console !== 'undefined') {
+      console.warn('[useMyGrants] /writing/my-grants failed', err)
+    }
   } finally {
     loading.value = false
   }
@@ -45,14 +47,22 @@ function clear(): void {
   loaded.value = false
 }
 
-// Auto-clear when the signed-in user changes (sign-out, account switch).
-// Runs once at module load; the watcher persists for the page lifetime.
+// React to auth state: fetch grants when a user appears or changes,
+// clear them on sign-out. `immediate: true` covers the case where the
+// composable is imported AFTER the user has already been restored
+// (the usual path on a page refresh).
 const { user } = useAuth()
 watch(
   () => user.value?.id ?? null,
   (newId, oldId) => {
-    if (newId !== oldId) clear()
-  }
+    if (oldId !== undefined && newId !== oldId) clear()
+    if (newId) {
+      void loadOnce(true)
+    } else {
+      clear()
+    }
+  },
+  { immediate: true }
 )
 
 export function useMyGrants() {

--- a/client/src/pages/Read.vue
+++ b/client/src/pages/Read.vue
@@ -235,9 +235,6 @@ import {
 const route = useRoute()
 const { isAuthenticated, user, isAdmin } = useAuth()
 const myGrants = useMyGrants()
-if (isAuthenticated.value) {
-  myGrants.loadOnce()
-}
 const readingStore = useReadingStore()
 const { origin: navOrigin, originLabel } = useNavigationOrigin('/home')
 


### PR DESCRIPTION
## Summary

Follow-up to PR #89. The endpoint and component wiring landed, but two bugs in [useMyGrants.ts](client/src/composables/useMyGrants.ts) meant the edit icon still wouldn't appear for granted editors in practice:

1. **Timing**: components called \`myGrants.loadOnce()\` in setup, gated on \`isAuthenticated.value\`. On a page refresh the auth-restore call is async, so at component-mount time that flag was still \`false\` — \`loadOnce()\` never fired, grants stayed empty, the icon stayed hidden.
2. **Watcher**: the clear-on-user-change watcher I added didn't itself reload grants. On the first sign-in (\`oldId === null\`), it would have wiped anything an earlier \`loadOnce()\` had populated.

The composable now owns loading via an \`immediate: true\` watch on the auth user — fetch when present, clear when absent. Components just consume \`hasEditGrant()\` reactively, no setup-time call needed.

Also: stops setting \`loaded = true\` on error, so a transient failure (e.g. dev server hadn't restarted to pick up the new \`/api/writing/my-grants\` route) doesn't permanently suppress the icon.

## Reviewer notes

- No server changes. Pure frontend fix to a composable.
- Removed the now-redundant \`if (isAuthenticated.value) myGrants.loadOnce()\` blocks from [WritingCard.vue](client/src/components/writing/WritingCard.vue), [WritingListRow.vue](client/src/components/writing/WritingListRow.vue), and [Read.vue](client/src/pages/Read.vue).
- One \`console.warn\` added on fetch failure to help diagnose deploy/restart issues.

## Test plan

- [ ] Sign in as Author B (a user with a granted \`edit\` permission on one of Author A's frags)
- [ ] Open devtools → Network: confirm \`GET /api/writing/my-grants\` returns 200 with the grant
- [ ] On the home page \`all\` filter, confirm the pencil icon now appears on the granted frag — no page reload required after sign-in
- [ ] Sign out, then sign in as a user with no grants → no edit icons on others' frags, no errors in console
- [ ] Switch accounts (sign out → sign in as different user) → grants from the prior session don't leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)