### PR TITLE
Render revision preview as inline word-diff vs the prior version

### DIFF
--- a/client/src/components/writing/RevisionHistoryPanel.vue
+++ b/client/src/components/writing/RevisionHistoryPanel.vue
@@ -79,7 +79,10 @@
       </ol>
     </div>
 
-    <!-- Preview modal -->
+    <!-- Preview modal — shows the chosen revision with insertions and
+         deletions vs. the immediately prior revision highlighted inline.
+         For v1 (no prior) the whole body is shown as "ins" so the reader
+         still gets a colour cue that this was the first state. -->
     <div
       v-if="previewRev"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
@@ -93,16 +96,43 @@
               {{ previewRev.editorDisplayName || 'unknown' }} ·
               {{ formatDate(previewRev.editedAt) }}
             </span>
+            <span
+              v-if="previewRev.versionNumber > 1"
+              class="text-ink-lighter font-normal"
+            >· diff vs v{{ previewRev.versionNumber - 1 }}</span>
           </div>
           <button
             type="button"
             class="text-ink-lighter hover:text-ink"
-            @click="previewRev = null"
+            @click="closePreview"
           >Close</button>
         </div>
+        <div class="px-4 pt-2 pb-1 flex items-center gap-3 text-xs border-b border-line">
+          <span class="inline-flex items-center gap-1 text-ink-lighter">
+            <span class="inline-block w-3 h-3 rounded-sm bg-green-100 border border-green-300"></span>
+            added
+          </span>
+          <span class="inline-flex items-center gap-1 text-ink-lighter">
+            <span class="inline-block w-3 h-3 rounded-sm bg-red-100 border border-red-300"></span>
+            removed
+          </span>
+          <span v-if="previewLoading" class="ml-auto text-ink-lighter">Loading…</span>
+        </div>
         <div class="overflow-y-auto px-4 py-3">
-          <h3 class="font-serif text-lg text-ink mb-2">{{ previewRev.title }}</h3>
-          <div class="whitespace-pre-wrap text-sm text-ink">{{ previewRev.body }}</div>
+          <h3 class="font-serif text-lg text-ink mb-2">
+            <template v-for="(seg, i) in titleDiff" :key="`t-${i}`">
+              <span v-if="seg.type === 'ins'" class="bg-green-100 text-green-900 rounded px-0.5">{{ seg.text }}</span>
+              <span v-else-if="seg.type === 'del'" class="bg-red-100 text-red-900 line-through rounded px-0.5">{{ seg.text }}</span>
+              <span v-else>{{ seg.text }}</span>
+            </template>
+          </h3>
+          <div class="whitespace-pre-wrap text-sm text-ink leading-relaxed">
+            <template v-for="(seg, i) in bodyDiff" :key="`b-${i}`">
+              <span v-if="seg.type === 'ins'" class="bg-green-100 text-green-900 rounded px-0.5">{{ seg.text }}</span>
+              <span v-else-if="seg.type === 'del'" class="bg-red-100 text-red-900 line-through rounded px-0.5">{{ seg.text }}</span>
+              <span v-else>{{ seg.text }}</span>
+            </template>
+          </div>
         </div>
       </div>
     </div>
@@ -110,8 +140,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { writingApi } from '@/api/writing'
+import { wordDiff, type DiffSegment } from '@/utils/word-diff'
 import type {
   WritingBlockRevision,
   WritingBlockRevisionSummary,
@@ -133,6 +164,27 @@ const loading = ref(false)
 const busy = ref(false)
 const error = ref('')
 const previewRev = ref<WritingBlockRevision | null>(null)
+// The immediately prior revision (versionNumber - 1) loaded alongside
+// the preview so we can render a word-level diff. Null when previewing
+// v1 (treated as all-insertions) or while still fetching.
+const previewPrev = ref<WritingBlockRevision | null>(null)
+const previewLoading = ref(false)
+
+const titleDiff = computed<DiffSegment[]>(() => {
+  if (!previewRev.value) return []
+  const before = previewPrev.value?.title ?? ''
+  const after = previewRev.value.title
+  if (!before) return [{ type: 'ins', text: after }]
+  return wordDiff(before, after)
+})
+
+const bodyDiff = computed<DiffSegment[]>(() => {
+  if (!previewRev.value) return []
+  const before = previewPrev.value?.body ?? ''
+  const after = previewRev.value.body
+  if (!before) return [{ type: 'ins', text: after }]
+  return wordDiff(before, after)
+})
 
 function close() {
   emit('update:modelValue', false)
@@ -161,13 +213,33 @@ watch(
 
 async function preview(versionNumber: number) {
   busy.value = true
+  previewLoading.value = true
+  previewPrev.value = null
   try {
-    previewRev.value = await writingApi.getRevision(props.writingId, versionNumber)
+    const current = await writingApi.getRevision(props.writingId, versionNumber)
+    previewRev.value = current
+    // Fetch v(N-1) in parallel with rendering so the diff snaps in as
+    // soon as it's available. If the prior fetch fails, fall back to
+    // treating the whole body as an insertion (handled in the diff
+    // computed).
+    if (versionNumber > 1) {
+      try {
+        previewPrev.value = await writingApi.getRevision(props.writingId, versionNumber - 1)
+      } catch {
+        previewPrev.value = null
+      }
+    }
   } catch (e: any) {
     error.value = e?.message || 'Failed to load revision'
   } finally {
     busy.value = false
+    previewLoading.value = false
   }
+}
+
+function closePreview() {
+  previewRev.value = null
+  previewPrev.value = null
 }
 
 async function restore(versionNumber: number) {

--- a/client/src/utils/word-diff.ts
+++ b/client/src/utils/word-diff.ts
@@ -1,0 +1,101 @@
+/**
+ * Word-level diff for prose. Splits both strings on whitespace boundaries
+ * (keeping the whitespace tokens so rendering preserves spacing), trims
+ * common prefix/suffix to limit the DP work, then runs an LCS table over
+ * the middle. Returns a flat run of segments suitable for rendering.
+ *
+ * For essay-sized inputs (≤ ~3k words) this is fast enough to run on
+ * every preview open without async work.
+ */
+
+export type DiffSegmentType = 'eq' | 'ins' | 'del'
+
+export interface DiffSegment {
+  type: DiffSegmentType
+  text: string
+}
+
+export function wordDiff(a: string, b: string): DiffSegment[] {
+  const at = tokenize(a)
+  const bt = tokenize(b)
+
+  // Strip common prefix and suffix to shrink the LCS problem.
+  let pre = 0
+  while (pre < at.length && pre < bt.length && at[pre] === bt[pre]) pre++
+  let suf = 0
+  while (
+    suf < at.length - pre &&
+    suf < bt.length - pre &&
+    at[at.length - 1 - suf] === bt[bt.length - 1 - suf]
+  ) suf++
+
+  const aMid = at.slice(pre, at.length - suf)
+  const bMid = bt.slice(pre, bt.length - suf)
+
+  const segs: DiffSegment[] = []
+  if (pre > 0) segs.push({ type: 'eq', text: at.slice(0, pre).join('') })
+  if (aMid.length || bMid.length) segs.push(...lcsDiff(aMid, bMid))
+  if (suf > 0) segs.push({ type: 'eq', text: at.slice(at.length - suf).join('') })
+
+  return mergeSegments(segs)
+}
+
+function tokenize(s: string): string[] {
+  // Split on whitespace runs but keep the runs as their own tokens so
+  // the reassembled text preserves the original spacing.
+  return s.split(/(\s+)/).filter(t => t.length > 0)
+}
+
+function lcsDiff(a: string[], b: string[]): DiffSegment[] {
+  const n = a.length
+  const m = b.length
+  if (n === 0 && m === 0) return []
+  if (n === 0) return [{ type: 'ins', text: b.join('') }]
+  if (m === 0) return [{ type: 'del', text: a.join('') }]
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1][j - 1] + 1
+        : Math.max(dp[i - 1][j], dp[i][j - 1])
+    }
+  }
+
+  const out: DiffSegment[] = []
+  let i = n
+  let j = m
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      out.unshift({ type: 'eq', text: a[i - 1] })
+      i--
+      j--
+    } else if (dp[i - 1][j] >= dp[i][j - 1]) {
+      out.unshift({ type: 'del', text: a[i - 1] })
+      i--
+    } else {
+      out.unshift({ type: 'ins', text: b[j - 1] })
+      j--
+    }
+  }
+  while (i > 0) {
+    out.unshift({ type: 'del', text: a[i - 1] })
+    i--
+  }
+  while (j > 0) {
+    out.unshift({ type: 'ins', text: b[j - 1] })
+    j--
+  }
+  return out
+}
+
+function mergeSegments(segs: DiffSegment[]): DiffSegment[] {
+  const merged: DiffSegment[] = []
+  for (const s of segs) {
+    if (!s.text) continue
+    const last = merged[merged.length - 1]
+    if (last && last.type === s.type) last.text += s.text
+    else merged.push({ type: s.type, text: s.text })
+  }
+  return merged
+}


### PR DESCRIPTION
## Summary

The revision history preview modal used to render the chosen version's body verbatim — readers had to mentally diff two versions to see what actually changed. Now it diffs version N against version N-1 and highlights insertions and deletions inline.

## What changed

- **New util** [client/src/utils/word-diff.ts](client/src/utils/word-diff.ts) — word-level diff. Tokenizes on whitespace runs (keeping the runs so spacing is preserved), trims common prefix/suffix, runs LCS over the middle. Returns a flat list of `{type: 'eq'|'ins'|'del', text}` segments. No dependency added.
- [RevisionHistoryPanel.vue](client/src/components/writing/RevisionHistoryPanel.vue):
  - When the user opens a preview, the panel fetches **both** v(N) and v(N-1) in sequence.
  - Title and body are rendered as `<span>` runs with Tailwind colour classes:
    - **green** background → inserted (additions vs prior)
    - **red** background + strikethrough → deleted (removed from prior)
    - plain → unchanged
  - Header shows `diff vs vN-1` and a small legend explains the two colours.
  - v1 (no prior revision) is shown as all-insertions so the colour cue is consistent for the first version too.
  - Falls back gracefully if the prior fetch fails: treats the whole body as an insertion rather than blocking the preview.

## Why

The user explicitly asked for changes in the preview to be visible in a different font colour, with the example showing an edit that was indistinguishable from surrounding prose. The word-level diff is the right grain for prose — character-level would be noisy (every inserted letter highlighted separately) and line-level would over-highlight (an edit inside a paragraph would mark the whole paragraph). Word-level lets a single inserted sentence read as one continuous green run.

## Performance note

For essay-scale inputs (~2.5k words → ~5k tokens), the LCS DP table is ~25M cells, which would be heavy. The prefix/suffix trim keeps the actual DP region to roughly the *edit window*, which is usually a handful of tokens. Even worst-case full rewrites stay snappy on typical hardware. If we ever hit a frag where this lags, we can swap in Myers diff.

## Test plan

- [ ] Open the History panel on a frag with several revisions, click Preview on v3 → confirm green/red highlighting against v2
- [ ] Preview v1 → entire body is green (no prior)
- [ ] Preview the "restore" revision created by a rollback → diff highlights the difference between the restored state and what HEAD was just before the restore
- [ ] Edit only the title in a revision → title diff highlights the change, body shows as all unchanged
- [ ] Browser console: no warnings about prop type mismatches or missing keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)