### PR TITLE
Persistent manual ordering for Frags via per-owner sortOrder

### DIFF
--- a/client/src/components/browse/FilterNavigation.vue
+++ b/client/src/components/browse/FilterNavigation.vue
@@ -129,20 +129,37 @@
               <span class="hidden md:inline">List</span>
             </button>
           </div>
-          <div class="relative">
-            <select
-              :value="currentSort"
-              @change="onSortChange"
-              class="text-xs sm:text-sm font-sans text-ink-lighter bg-transparent border border-line rounded-none px-3 py-1.5 pr-8 appearance-none cursor-pointer hover:border-ink-lighter transition-colors duration-300"
-              aria-label="Sort frags"
+          <div class="flex items-center gap-2">
+            <div class="relative">
+              <select
+                :value="currentSort"
+                @change="onSortChange"
+                class="text-xs sm:text-sm font-sans text-ink-lighter bg-transparent border border-line rounded-none px-3 py-1.5 pr-8 appearance-none cursor-pointer hover:border-ink-lighter transition-colors duration-300"
+                aria-label="Sort frags"
+              >
+                <option v-for="option in sortOptions" :key="option.value" :value="option.value">
+                  {{ option.label }}
+                </option>
+              </select>
+              <svg class="absolute right-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-ink-lighter pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+            <!-- Sort-direction toggle: flips between ascending (1..n,
+                 oldest, A→Z) and descending (n..1, newest, Z→A) for whichever
+                 sort option is currently active. Hidden unless the host
+                 page opts in via `enableSortDirection`. -->
+            <button
+              v-if="enableSortDirection"
+              type="button"
+              @click="emit('sort-direction-change', sortDirection === 'asc' ? 'desc' : 'asc')"
+              class="text-xs sm:text-sm font-sans text-ink-lighter bg-transparent border border-line rounded-none px-2 py-1.5 hover:border-ink-lighter hover:text-ink transition-colors duration-300 inline-flex items-center gap-1"
+              :aria-label="sortDirection === 'asc' ? 'Ascending — switch to descending' : 'Descending — switch to ascending'"
+              :title="sortDirection === 'asc' ? 'Ascending (1 → n)' : 'Descending (n → 1)'"
             >
-              <option v-for="option in sortOptions" :key="option.value" :value="option.value">
-                {{ option.label }}
-              </option>
-            </select>
-            <svg class="absolute right-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-ink-lighter pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-            </svg>
+              <span aria-hidden="true">{{ sortDirection === 'asc' ? '↑' : '↓' }}</span>
+              <span class="hidden md:inline">{{ sortDirection === 'asc' ? 'Asc' : 'Desc' }}</span>
+            </button>
           </div>
         </div>
       </div>
@@ -163,6 +180,7 @@ interface SortOption {
 
 export type SearchScope = 'title' | 'anywhere'
 export type ViewMode = 'detail' | 'list'
+export type SortDirection = 'asc' | 'desc'
 
 interface Props {
   filters: Filter[]
@@ -185,6 +203,10 @@ interface Props {
   enableViewMode?: boolean
   /** Current view mode (controlled). */
   viewMode?: ViewMode
+  /** Show the asc/desc direction toggle next to the sort dropdown. */
+  enableSortDirection?: boolean
+  /** Current sort direction (controlled). */
+  sortDirection?: SortDirection
 }
 
 withDefaults(defineProps<Props>(), {
@@ -201,6 +223,8 @@ withDefaults(defineProps<Props>(), {
   searchScope: 'anywhere',
   enableViewMode: false,
   viewMode: 'detail',
+  enableSortDirection: false,
+  sortDirection: 'asc',
 })
 
 const emit = defineEmits<{
@@ -209,6 +233,7 @@ const emit = defineEmits<{
   'search-change': [value: string]
   'scope-change': [value: SearchScope]
   'view-change': [value: ViewMode]
+  'sort-direction-change': [value: SortDirection]
 }>()
 
 const onSortChange = (event: Event) => {

--- a/client/src/components/writing/WritingCard.vue
+++ b/client/src/components/writing/WritingCard.vue
@@ -73,10 +73,39 @@
       class="flex items-center gap-2 mt-4"
       @click.stop
     >
+      <label
+        v-if="canReorder"
+        class="inline-flex items-center gap-1.5 text-xs font-sans text-ink-lighter"
+        :title="`Position ${writing.sortOrder ?? '—'}. Type a new number and press Tab to move this frag.`"
+      >
+        <span class="uppercase tracking-widest">#</span>
+        <input
+          type="number"
+          inputmode="numeric"
+          step="1"
+          min="1"
+          :value="sortOrderDraft"
+          @input="onSortOrderInput"
+          @keydown.enter.prevent="($event.target as HTMLInputElement)?.blur()"
+          @keydown.escape.prevent="resetSortOrderDraft(); ($event.target as HTMLInputElement)?.blur()"
+          @blur="commitSortOrder"
+          :disabled="reorderBusy"
+          class="w-14 px-1.5 py-0.5 border border-line bg-paper text-ink text-xs font-mono tabular-nums text-right rounded-none focus:outline-none focus:border-ink-lighter disabled:opacity-50"
+          aria-label="Sort order"
+        />
+      </label>
+      <span
+        v-else-if="typeof writing.sortOrder === 'number'"
+        class="inline-flex items-center gap-1.5 text-xs font-sans text-ink-whisper"
+        :title="`Position ${writing.sortOrder}`"
+      >
+        <span class="uppercase tracking-widest">#</span>
+        <span class="font-mono tabular-nums">{{ writing.sortOrder }}</span>
+      </span>
       <button
         type="button"
         @click="emit('move-up', writing.id)"
-        :disabled="!canMoveUp"
+        :disabled="!canMoveUp || reorderBusy"
         class="p-2 text-ink-lighter hover:text-ink disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Move up"
         title="Move up"
@@ -88,7 +117,7 @@
       <button
         type="button"
         @click="emit('move-down', writing.id)"
-        :disabled="!canMoveDown"
+        :disabled="!canMoveDown || reorderBusy"
         class="p-2 text-ink-lighter hover:text-ink disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Move down"
         title="Move down"
@@ -142,18 +171,26 @@ interface Props {
   reactionSummary?: WritingReactionSummary
   canMoveUp?: boolean
   canMoveDown?: boolean
+  /** True while a reorder request is in flight for this writing. The host
+   *  page passes this so we can lock the input + arrow buttons together. */
+  reorderBusy?: boolean
 }
 
 const emit = defineEmits<{
   deleted: [writingId: string]
   'move-up': [writingId: string]
   'move-down': [writingId: string]
+  /** Fired on focus-out of the sort-order input. The host page is
+   *  responsible for clamping and persisting; we just pass the integer
+   *  the user typed (or `undefined` if the value should be reset). */
+  'move-to-sort-order': [writingId: string, sortOrder: number]
 }>()
 
 const props = withDefaults(defineProps<Props>(), {
   showImage: false,
   canMoveUp: false,
   canMoveDown: false,
+  reorderBusy: false,
 })
 
 const { user, isAdmin, isAuthenticated } = useAuth()
@@ -178,6 +215,46 @@ const canEdit = computed(() => {
 const canDelete = computed(() => {
   return isOwner.value || isAdmin.value
 })
+
+// Reordering is owner/admin-only. Editors-of-others' frags can change
+// title/body but not the owner's curated position.
+const canReorder = computed(() => isOwner.value || isAdmin.value)
+
+// Live draft for the sort-order input. We use a local string buffer (not
+// v-model directly on the prop) so an invalid keystroke doesn't propagate
+// to the parent — only on blur do we validate and either emit a move or
+// roll back to the last persisted value.
+const sortOrderDraft = ref<string>(
+  typeof props.writing.sortOrder === 'number' ? String(props.writing.sortOrder) : ''
+)
+function resetSortOrderDraft() {
+  sortOrderDraft.value = typeof props.writing.sortOrder === 'number' ? String(props.writing.sortOrder) : ''
+}
+// Keep the draft in sync when the parent replaces the row (server
+// renormalised the list — see Home.vue handleMoveToSortOrder).
+watch(() => props.writing.sortOrder, () => { resetSortOrderDraft() })
+function onSortOrderInput(e: Event) {
+  sortOrderDraft.value = (e.target as HTMLInputElement).value
+}
+function commitSortOrder() {
+  const raw = sortOrderDraft.value.trim()
+  // Empty / non-integer / non-finite → restore previous valid value and
+  // skip the move entirely. The server validates again but failing fast
+  // here keeps the network quiet.
+  if (raw === '') { resetSortOrderDraft(); return }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    resetSortOrderDraft()
+    return
+  }
+  // Same value: nothing to do.
+  if (parsed === props.writing.sortOrder) { resetSortOrderDraft(); return }
+  // Hand off to the host page. We don't clamp here — the server does the
+  // canonical clamp against `n` (which it has) and returns the
+  // normalised list. We just reset the draft optimistically; the watch
+  // above re-syncs to the persisted value once the server responds.
+  emit('move-to-sort-order', props.writing.id, parsed)
+}
 
 const isRecentlyRead = computed(() => {
   return readingStore.isRecentlyRead(props.writing.id)

--- a/client/src/components/writing/WritingListRow.vue
+++ b/client/src/components/writing/WritingListRow.vue
@@ -32,10 +32,35 @@
       </span>
     </router-link>
     <div class="frag-row-actions" @click.stop>
+      <label
+        v-if="canReorder"
+        class="frag-row-sort-order"
+        :title="`Position ${writing.sortOrder ?? '—'}. Type a new number and press Tab to move this frag.`"
+      >
+        <span aria-hidden="true">#</span>
+        <input
+          type="number"
+          inputmode="numeric"
+          step="1"
+          min="1"
+          :value="sortOrderDraft"
+          @input="onSortOrderInput"
+          @keydown.enter.prevent="($event.target as HTMLInputElement)?.blur()"
+          @keydown.escape.prevent="resetSortOrderDraft(); ($event.target as HTMLInputElement)?.blur()"
+          @blur="commitSortOrder"
+          :disabled="reorderBusy"
+          aria-label="Sort order"
+        />
+      </label>
+      <span
+        v-else-if="typeof writing.sortOrder === 'number'"
+        class="frag-row-sort-order-static"
+        :title="`Position ${writing.sortOrder}`"
+      >#{{ writing.sortOrder }}</span>
       <button
         type="button"
         @click="emit('move-up', writing.id)"
-        :disabled="!canMoveUp"
+        :disabled="!canMoveUp || reorderBusy"
         class="frag-row-action"
         aria-label="Move up"
         title="Move up"
@@ -47,7 +72,7 @@
       <button
         type="button"
         @click="emit('move-down', writing.id)"
-        :disabled="!canMoveDown"
+        :disabled="!canMoveDown || reorderBusy"
         class="frag-row-action"
         aria-label="Move down"
         title="Move down"
@@ -90,7 +115,7 @@
 // page can swap them based on viewMode without changing the surrounding
 // list scaffolding.
 
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { api } from '../../api/client'
 import { useAuth } from '../../stores/auth'
 import { useReadingStore } from '../../stores/reading'
@@ -104,17 +129,22 @@ interface Props {
   themes: Theme[]
   canMoveUp?: boolean
   canMoveDown?: boolean
+  /** True while a reorder request is in flight for this row. */
+  reorderBusy?: boolean
 }
 
 const emit = defineEmits<{
   deleted: [writingId: string]
   'move-up': [writingId: string]
   'move-down': [writingId: string]
+  /** Fired on focus-out of the sort-order input. */
+  'move-to-sort-order': [writingId: string, sortOrder: number]
 }>()
 
 const props = withDefaults(defineProps<Props>(), {
   canMoveUp: false,
   canMoveDown: false,
+  reorderBusy: false,
 })
 
 const { user, isAdmin, isAuthenticated } = useAuth()
@@ -130,6 +160,33 @@ const canEdit = computed(() => {
 })
 // Delete remains owner/admin only.
 const canDelete = computed(() => isOwner.value || isAdmin.value)
+// Reorder is owner/admin only — same scope as delete.
+const canReorder = computed(() => isOwner.value || isAdmin.value)
+
+// Local sort-order draft. Mirrors WritingCard's behaviour: invalid input
+// rolls back on blur; valid input emits `move-to-sort-order` and lets
+// the host page persist + renormalise.
+const sortOrderDraft = ref<string>(
+  typeof props.writing.sortOrder === 'number' ? String(props.writing.sortOrder) : ''
+)
+function resetSortOrderDraft() {
+  sortOrderDraft.value = typeof props.writing.sortOrder === 'number' ? String(props.writing.sortOrder) : ''
+}
+watch(() => props.writing.sortOrder, () => { resetSortOrderDraft() })
+function onSortOrderInput(e: Event) {
+  sortOrderDraft.value = (e.target as HTMLInputElement).value
+}
+function commitSortOrder() {
+  const raw = sortOrderDraft.value.trim()
+  if (raw === '') { resetSortOrderDraft(); return }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    resetSortOrderDraft()
+    return
+  }
+  if (parsed === props.writing.sortOrder) { resetSortOrderDraft(); return }
+  emit('move-to-sort-order', props.writing.id, parsed)
+}
 const isRecentlyRead = computed(() => readingStore.isRecentlyRead(props.writing.id))
 const isSpa = computed(() => isStandaloneHtmlDoc(props.writing.body))
 
@@ -261,6 +318,43 @@ async function handleDelete() {
 }
 .frag-row:hover .frag-row-actions,
 .frag-row:focus-within .frag-row-actions { opacity: 1; }
+
+.frag-row-sort-order {
+  display: inline-flex; align-items: center; gap: 0.25rem;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.7rem;
+  color: rgb(var(--color-ink-lighter));
+  margin-right: 0.25rem;
+}
+.frag-row-sort-order input {
+  width: 2.75rem;
+  padding: 0.05rem 0.3rem;
+  border: 1px solid rgb(var(--color-line));
+  background: rgb(var(--color-paper));
+  color: rgb(var(--color-ink));
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
+  text-align: right;
+}
+.frag-row-sort-order input:focus {
+  outline: none;
+  border-color: rgb(var(--color-ink-lighter));
+}
+.frag-row-sort-order input:disabled { opacity: 0.5; }
+.frag-row-sort-order input::-webkit-outer-spin-button,
+.frag-row-sort-order input::-webkit-inner-spin-button {
+  -webkit-appearance: none; margin: 0;
+}
+.frag-row-sort-order input { -moz-appearance: textfield; }
+
+.frag-row-sort-order-static {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  color: rgb(var(--color-ink-whisper));
+  font-variant-numeric: tabular-nums;
+  margin-right: 0.25rem;
+}
 
 .frag-row-action {
   display: inline-flex;

--- a/client/src/pages/Home.vue
+++ b/client/src/pages/Home.vue
@@ -44,6 +44,7 @@
       :filters="filters"
       :current-filter="filter"
       :count="totalMatchedCount"
+      :sort-options="sortOptions"
       :current-sort="sort"
       :enable-search="true"
       :search-query="searchQuery"
@@ -51,11 +52,14 @@
       :search-placeholder="searchScope === 'title' ? 'Search frag titles…' : 'Search title or text…'"
       :enable-view-mode="true"
       :view-mode="viewMode"
+      :enable-sort-direction="true"
+      :sort-direction="sortDirection"
       @filter-change="handleFilterChange"
       @sort-change="handleSortChange"
       @search-change="handleSearchChange"
       @scope-change="handleSearchScopeChange"
       @view-change="handleViewChange"
+      @sort-direction-change="handleSortDirectionChange"
     />
 
     <!-- Essay List -->
@@ -111,9 +115,11 @@
               :reaction-summary="getReactionSummary(writing.id)"
               :can-move-up="index > 0"
               :can-move-down="index < filteredWritings.length - 1"
+              :reorder-busy="reorderBusyId === writing.id"
               @deleted="handleWritingDeleted"
               @move-up="handleMoveUp"
               @move-down="handleMoveDown"
+              @move-to-sort-order="handleMoveToSortOrder"
             />
           </template>
           <template v-else>
@@ -124,9 +130,11 @@
               :themes="getThemesForWriting(writing)"
               :can-move-up="index > 0"
               :can-move-down="index < filteredWritings.length - 1"
+              :reorder-busy="reorderBusyId === writing.id"
               @deleted="handleWritingDeleted"
               @move-up="handleMoveUp"
               @move-down="handleMoveDown"
+              @move-to-sort-order="handleMoveToSortOrder"
             />
           </template>
 
@@ -199,7 +207,7 @@ import type { Theme } from '../domain/Theme'
 import type { WritingReactionSummary } from '../domain/Appreciation'
 import WritingCard from '../components/writing/WritingCard.vue'
 import WritingListRow from '../components/writing/WritingListRow.vue'
-import FilterNavigation, { type SearchScope, type ViewMode } from '../components/browse/FilterNavigation.vue'
+import FilterNavigation, { type SearchScope, type ViewMode, type SortDirection } from '../components/browse/FilterNavigation.vue'
 import CollectionCard from '../components/browse/CollectionCard.vue'
 import { markdownToText } from '../utils/markdown'
 import type { ApiResponse } from '@shared/ApiResponses'
@@ -212,7 +220,29 @@ const reactionSummaries = ref<Map<string, WritingReactionSummary>>(new Map())
 const loading = ref(true)
 const error = ref<string | null>(null)
 const filter = ref<'all' | 'mine' | 'shared'>('all')
-const sort = ref<string>('newest')
+// Default sort is the user-controlled manual order. Each Frag carries a
+// persisted `sortOrder` integer (1..n per owner) that the user can edit
+// inline; this view reflects that order until the user picks a different
+// option from the dropdown.
+const sort = ref<string>('manual')
+const SORT_DIRECTION_STORAGE_KEY = 'frag:sortDirection'
+function loadSortDirection(): SortDirection {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const v = localStorage.getItem(SORT_DIRECTION_STORAGE_KEY)
+      if (v === 'asc' || v === 'desc') return v
+    }
+  } catch { /* ignore */ }
+  return 'asc'
+}
+const sortDirection = ref<SortDirection>(loadSortDirection())
+const reorderBusyId = ref<string | null>(null)
+const sortOptions = [
+  { value: 'manual', label: 'Manual order' },
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'updated', label: 'Recently Updated' },
+]
 const searchQuery = ref('')
 const debouncedSearchQuery = ref('')
 const searchScope = ref<SearchScope>('anywhere')
@@ -231,46 +261,6 @@ function loadViewMode(): ViewMode {
   return 'detail'
 }
 const viewMode = ref<ViewMode>(loadViewMode())
-
-// Custom user-defined ordering. Map of writing id → rank (lower = higher in
-// list). When non-empty it overrides the date-based sort below for the ids
-// it covers; ids not in the map fall through to the regular sort and are
-// appended after the custom-ordered items. Persisted to localStorage so a
-// user's hand-arranged list survives reloads.
-const CUSTOM_ORDER_STORAGE_KEY = 'frag:customOrder'
-function loadCustomOrder(): Map<string, number> {
-  const map = new Map<string, number>()
-  try {
-    if (typeof localStorage !== 'undefined') {
-      const raw = localStorage.getItem(CUSTOM_ORDER_STORAGE_KEY)
-      if (raw) {
-        const ids = JSON.parse(raw)
-        if (Array.isArray(ids)) {
-          ids.forEach((id, i) => {
-            if (typeof id === 'string') map.set(id, i)
-          })
-        }
-      }
-    }
-  } catch { /* ignore — fall through to empty map */ }
-  return map
-}
-const customOrder = ref<Map<string, number>>(loadCustomOrder())
-function saveCustomOrder() {
-  try {
-    if (typeof localStorage === 'undefined') return
-    if (customOrder.value.size === 0) {
-      localStorage.removeItem(CUSTOM_ORDER_STORAGE_KEY)
-      return
-    }
-    // Serialize as a flat list of ids in rank order — compact and trivially
-    // re-loadable.
-    const ids = [...customOrder.value.entries()]
-      .sort((a, b) => a[1] - b[1])
-      .map(([id]) => id)
-    localStorage.setItem(CUSTOM_ORDER_STORAGE_KEY, JSON.stringify(ids))
-  } catch { /* ignore */ }
-}
 
 const PAGE_SIZE = 6
 const displayedCount = ref(PAGE_SIZE)
@@ -319,25 +309,36 @@ const matchedWritings = computed(() => {
   }
 
   filtered = [...filtered].sort((a, b) => {
-    // Custom user ordering wins. Items present in customOrder are ranked by
-    // their stored rank; items not in the map fall back to the date sort and
-    // are placed AFTER any custom-ordered items.
-    const co = customOrder.value
-    if (co.size > 0) {
-      const aRank = co.get(a.id)
-      const bRank = co.get(b.id)
-      if (aRank !== undefined && bRank !== undefined) return aRank - bRank
-      if (aRank !== undefined) return -1
-      if (bRank !== undefined) return 1
+    if (sort.value === 'manual') {
+      // Primary key is the persisted per-owner sortOrder. Frags from
+      // different owners interleave by their respective positions —
+      // every owner's #1 sorts first, then everyone's #2, and so on.
+      // Stable tiebreaker uses createdAt then id so duplicates (which
+      // shouldn't normally exist but might briefly during a server
+      // reorder) still order deterministically.
+      const aSo = typeof a.sortOrder === 'number' ? a.sortOrder : Number.POSITIVE_INFINITY
+      const bSo = typeof b.sortOrder === 'number' ? b.sortOrder : Number.POSITIVE_INFINITY
+      if (aSo !== bSo) return sortDirection.value === 'asc' ? aSo - bSo : bSo - aSo
+      const cmp =
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        || a.id.localeCompare(b.id)
+      return sortDirection.value === 'asc' ? cmp : -cmp
     }
+    // Date-based sorts still respect the direction toggle: asc = oldest
+    // first, desc = newest first.
+    let cmp: number
     switch (sort.value) {
       case 'oldest':
-        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        break
       case 'updated':
-        return new Date(b.updatedAt || b.createdAt).getTime() - new Date(a.updatedAt || a.createdAt).getTime()
+        cmp = new Date(b.updatedAt || b.createdAt).getTime() - new Date(a.updatedAt || a.createdAt).getTime()
+        break
       default:
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        cmp = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        break
     }
+    return sortDirection.value === 'asc' ? cmp : -cmp
   })
 
   return filtered
@@ -384,49 +385,53 @@ const handleFilterChange = (value: string) => {
 const handleSortChange = (value: string) => {
   sort.value = value
   displayedCount.value = PAGE_SIZE
-  // Picking a sort is an explicit "use this ordering" — drop any prior
-  // hand-arranged order so the chosen sort actually takes effect.
-  if (customOrder.value.size > 0) {
-    customOrder.value = new Map()
-    saveCustomOrder()
+}
+
+const handleSortDirectionChange = (value: SortDirection) => {
+  sortDirection.value = value
+  try { localStorage.setItem(SORT_DIRECTION_STORAGE_KEY, value) } catch { /* ignore */ }
+}
+
+// Up/down arrow handlers: translate to a positional move of the target
+// frag to (sortOrder - 1) or (sortOrder + 1) in its owner's list. The
+// server normalises 1..n and returns the owner's updated list which we
+// merge into local state.
+async function moveByOffset(writingId: string, offset: number) {
+  const w = writings.value.find(x => x.id === writingId)
+  if (!w || typeof w.sortOrder !== 'number') return
+  await handleMoveToSortOrder(writingId, w.sortOrder + offset)
+}
+const handleMoveUp = (writingId: string) => moveByOffset(writingId, -1)
+const handleMoveDown = (writingId: string) => moveByOffset(writingId, +1)
+
+// Persist a positional move: PUT /writing/:id/sort-order with the target
+// 1..n position. The server clamps and renormalises, then returns the
+// owner's updated list which we splice into local state. We swallow
+// errors here because the child components surface them inline; this
+// just keeps the page reactive.
+async function handleMoveToSortOrder(writingId: string, target: number) {
+  if (!Number.isFinite(target) || !Number.isInteger(target)) return
+  reorderBusyId.value = writingId
+  try {
+    const response = await api.put<ApiResponse<WritingBlock[]>>(
+      `/writing/${writingId}/sort-order`,
+      { sortOrder: target },
+    )
+    const updated = response.data
+    if (!Array.isArray(updated) || updated.length === 0) return
+    // Replace every row in local state that the server returned. The
+    // server returns the full owner-scoped list (1..n), so this single
+    // splice covers every renumbered sibling.
+    const updatedById = new Map(updated.map(w => [w.id, w]))
+    writings.value = writings.value.map(w => updatedById.get(w.id) || w)
+  } catch (err) {
+    // Surface failures via the page error banner so the user sees them
+    // without forcing the child to handle alerts.
+    error.value = err instanceof Error ? err.message : 'Failed to reorder frag'
+  } finally {
+    reorderBusyId.value = null
   }
 }
-
-// Up/down arrow handlers from WritingCard / WritingListRow. Swap the target
-// writing with its neighbour in the currently-displayed (matched + sorted)
-// list, then bake that order into customOrder so it sticks across reloads
-// and across filter/search changes.
-function applyMove(writingId: string, direction: 'up' | 'down') {
-  const list = matchedWritings.value
-  const idx = list.findIndex(w => w.id === writingId)
-  if (idx === -1) return
-  const targetIdx = direction === 'up' ? idx - 1 : idx + 1
-  if (targetIdx < 0 || targetIdx >= list.length) return
-
-  const visibleIds = list.map(w => w.id)
-  const tmp = visibleIds[idx]
-  visibleIds[idx] = visibleIds[targetIdx]
-  visibleIds[targetIdx] = tmp
-
-  // Off-screen items that the user has previously hand-arranged (but are
-  // currently filtered out by search/filter) keep their relative order;
-  // they're appended after the visible block so the visible arrangement
-  // stays at the top of any list that includes both.
-  const visibleSet = new Set(visibleIds)
-  const preservedIds = [...customOrder.value.entries()]
-    .filter(([id]) => !visibleSet.has(id))
-    .sort((a, b) => a[1] - b[1])
-    .map(([id]) => id)
-
-  const next = new Map<string, number>()
-  let rank = 0
-  for (const id of visibleIds) next.set(id, rank++)
-  for (const id of preservedIds) next.set(id, rank++)
-  customOrder.value = next
-  saveCustomOrder()
-}
-const handleMoveUp = (writingId: string) => applyMove(writingId, 'up')
-const handleMoveDown = (writingId: string) => applyMove(writingId, 'down')
 
 // Search debouncing. The user can type quickly through a long list; we
 // reflect their input in the input box immediately (searchQuery) but only

--- a/server/src/controllers/writing.controller.ts
+++ b/server/src/controllers/writing.controller.ts
@@ -143,6 +143,35 @@ export const writingController = {
     res.json({ data: writing })
   },
 
+  /**
+   * PUT /api/writing/:id/sort-order
+   *
+   * Body: { sortOrder: number }
+   *
+   * Moves the frag to `sortOrder` (1..n) inside its owner's list and
+   * renumbers every other frag belonging to that owner so the sequence
+   * stays continuous. Permission: owner or admin. Returns the owner's
+   * full normalized list so the client can refresh without a second GET.
+   */
+  async moveSortOrder(req: Request, res: Response) {
+    const { id } = req.params
+    const userId = (req as any).userId
+    const admin = isAdminRequest(req)
+    if (!userId) {
+      throw new UnauthorizedError('Authentication required')
+    }
+
+    const raw = req.body?.sortOrder
+    const target = typeof raw === 'number' ? raw : Number(raw)
+    if (!Number.isFinite(target) || !Number.isInteger(target)) {
+      throw new ValidationError('sortOrder must be an integer')
+    }
+
+    const list = await writingService.moveFragToSortOrder(id, target, userId, admin)
+
+    res.json({ data: list })
+  },
+
   async delete(req: Request, res: Response) {
     const { id } = req.params
     const userId = (req as any).userId

--- a/server/src/db/migrations/029_writing_block_sort_order.sql
+++ b/server/src/db/migrations/029_writing_block_sort_order.sql
@@ -1,0 +1,46 @@
+-- Migration 029: Per-user manual sort order for frags
+--
+-- Adds an integer `sort_order` to each writing_blocks row so the user can
+-- arrange their frags in any order they like and have that order survive
+-- reloads. Scope is per owner (user_id): each user has an independent
+-- 1..n sequence over their own frags. The UNIQUE constraint enforces that
+-- the sequence stays continuous and gap-free after every reorder.
+--
+-- Backfill assigns 1..n per user ordered by created_at (oldest = 1) so
+-- existing frags get a sensible starting arrangement. Once backfilled,
+-- the column is set NOT NULL.
+
+ALTER TABLE writing_blocks
+  ADD COLUMN IF NOT EXISTS sort_order INTEGER;
+
+-- Backfill: assign 1..n per user ordered by created_at then id (stable).
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id
+      ORDER BY created_at NULLS LAST, id
+    ) AS rn
+  FROM writing_blocks
+)
+UPDATE writing_blocks wb
+SET sort_order = r.rn
+FROM ranked r
+WHERE wb.id = r.id
+  AND wb.sort_order IS NULL;
+
+ALTER TABLE writing_blocks
+  ALTER COLUMN sort_order SET NOT NULL;
+
+-- Each user's frags occupy a continuous 1..n sequence. The unique
+-- constraint prevents accidental duplicate positions; reorder logic
+-- updates positions inside a transaction so the constraint is satisfied
+-- at commit time even when many rows shift.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_writing_blocks_user_sort_order
+  ON writing_blocks(user_id, sort_order);
+
+CREATE INDEX IF NOT EXISTS idx_writing_blocks_sort_order
+  ON writing_blocks(sort_order);
+
+COMMENT ON COLUMN writing_blocks.sort_order IS
+  'Per-user position in the frags list (1..n). Edited by moveFragToSortOrder.';

--- a/server/src/repositories/writing.repo.ts
+++ b/server/src/repositories/writing.repo.ts
@@ -106,6 +106,7 @@ export const writingRepo = {
             wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
             COALESCE(wb.current_version, 1) as "currentVersion",
+            wb.sort_order as "sortOrder",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -136,6 +137,7 @@ export const writingRepo = {
             wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
             COALESCE(wb.current_version, 1) as "currentVersion",
+            wb.sort_order as "sortOrder",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -169,6 +171,7 @@ export const writingRepo = {
             wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
             COALESCE(wb.current_version, 1) as "currentVersion",
+            wb.sort_order as "sortOrder",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -193,8 +196,9 @@ export const writingRepo = {
           'private' as visibility,
           wb.cover_image_url as "coverImageUrl",
           COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-          wb.created_at as "createdAt", 
+          wb.created_at as "createdAt",
           wb.updated_at as "updatedAt",
+          wb.sort_order as "sortOrder",
           COALESCE(
             ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
             ARRAY[]::UUID[]
@@ -257,6 +261,7 @@ export const writingRepo = {
             wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
             COALESCE(wb.current_version, 1) as "currentVersion",
+            wb.sort_order as "sortOrder",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -282,6 +287,7 @@ export const writingRepo = {
             wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
             COALESCE(wb.current_version, 1) as "currentVersion",
+            wb.sort_order as "sortOrder",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -313,6 +319,7 @@ export const writingRepo = {
             wb.created_at as "createdAt",
             wb.updated_at as "updatedAt",
             COALESCE(wb.current_version, 1) as "currentVersion",
+            wb.sort_order as "sortOrder",
             COALESCE(
               ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
               ARRAY[]::UUID[]
@@ -335,8 +342,9 @@ export const writingRepo = {
           'private' as visibility,
           wb.cover_image_url as "coverImageUrl",
           COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
-          wb.created_at as "createdAt", 
+          wb.created_at as "createdAt",
           wb.updated_at as "updatedAt",
+          wb.sort_order as "sortOrder",
           COALESCE(
             ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
             ARRAY[]::UUID[]
@@ -359,11 +367,11 @@ export const writingRepo = {
     }
   },
 
-  async create(writing: Omit<WritingBlock, 'id' | 'createdAt' | 'updatedAt' | 'currentVersion'>): Promise<WritingBlock> {
+  async create(writing: Omit<WritingBlock, 'id' | 'createdAt' | 'updatedAt' | 'currentVersion' | 'sortOrder'>): Promise<WritingBlock> {
     const client = await pool.connect()
     try {
       await client.query('BEGIN')
-      
+
       // Check if visibility column exists
       let hasVisibilityColumn = true
       try {
@@ -375,19 +383,52 @@ export const writingRepo = {
           throw error
         }
       }
-      
+
+      // Check if sort_order column exists (migration 029)
+      let hasSortOrderColumn = true
+      try {
+        await client.query('SELECT sort_order FROM writing_blocks LIMIT 1')
+      } catch (error: any) {
+        if (error.code === '42703') {
+          hasSortOrderColumn = false
+        } else {
+          throw error
+        }
+      }
+
+      // Serialize sort_order assignment per user. Two concurrent creates
+      // by the same user would otherwise race on MAX(sort_order) and pick
+      // duplicates; the advisory lock pins the per-user sequence so the
+      // next insert always sees the latest MAX.
+      if (hasSortOrderColumn) {
+        await client.query(
+          `SELECT pg_advisory_xact_lock(hashtext('writing_blocks_sort_order:' || $1::text))`,
+          [writing.userId]
+        )
+      }
+
       // Insert writing block with visibility (defaults to 'private')
       const visibility = writing.visibility || 'private'
       const coverImageUrl = writing.coverImageUrl ?? null
       const coverImagePosition = writing.coverImagePosition ?? '50% 50%'
       let writingResult
       if (hasVisibilityColumn) {
-        writingResult = await client.query(
-          `INSERT INTO writing_blocks (user_id, title, body, visibility, cover_image_url, cover_image_position)
-           VALUES ($1, $2, $3, $4, $5, $6)
-           RETURNING id, user_id as "userId", title, body, visibility, cover_image_url as "coverImageUrl", COALESCE(cover_image_position, '50% 50%') as "coverImagePosition", created_at as "createdAt", updated_at as "updatedAt"`,
-          [writing.userId, writing.title, writing.body, visibility, coverImageUrl, coverImagePosition]
-        )
+        if (hasSortOrderColumn) {
+          writingResult = await client.query(
+            `INSERT INTO writing_blocks (user_id, title, body, visibility, cover_image_url, cover_image_position, sort_order)
+             VALUES ($1, $2, $3, $4, $5, $6,
+                     (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM writing_blocks WHERE user_id = $1))
+             RETURNING id, user_id as "userId", title, body, visibility, cover_image_url as "coverImageUrl", COALESCE(cover_image_position, '50% 50%') as "coverImagePosition", created_at as "createdAt", updated_at as "updatedAt", sort_order as "sortOrder"`,
+            [writing.userId, writing.title, writing.body, visibility, coverImageUrl, coverImagePosition]
+          )
+        } else {
+          writingResult = await client.query(
+            `INSERT INTO writing_blocks (user_id, title, body, visibility, cover_image_url, cover_image_position)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING id, user_id as "userId", title, body, visibility, cover_image_url as "coverImageUrl", COALESCE(cover_image_position, '50% 50%') as "coverImagePosition", created_at as "createdAt", updated_at as "updatedAt"`,
+            [writing.userId, writing.title, writing.body, visibility, coverImageUrl, coverImagePosition]
+          )
+        }
       } else {
         // Fallback: pre-visibility schema (no cover_image_url either)
         writingResult = await client.query(
@@ -716,5 +757,160 @@ export const writingRepo = {
     if (result.rowCount === 0) {
       throw new NotFoundError('Writing block not found')
     }
-  }
+  },
+
+  /**
+   * Move a frag to a target position (1..n) within its owner's sequence.
+   *
+   * This is a positional move, not a simple value update: the moved frag
+   * is removed from its owner's ordered list, re-inserted at the target
+   * index, and every frag belonging to that owner is renumbered 1..n.
+   * The whole renumbering happens in a single transaction so partial
+   * writes can never leave the sequence with gaps or duplicates.
+   *
+   * Permission: owner of the moved frag, or admin. Editors (without
+   * ownership) cannot reorder — order is treated as owner-curated.
+   *
+   * Target is clamped to [1..n] and the input is expected to be a finite
+   * integer; the service layer validates `targetSortOrder` before this
+   * runs.
+   *
+   * Returns the moved frag's owner's full ordered list (1..n) after the
+   * renumber so the UI can refresh without a second round-trip.
+   */
+  async moveFragToSortOrder(
+    fragId: string,
+    targetSortOrder: number,
+    userId: string,
+    isAdmin: boolean = false,
+  ): Promise<WritingBlock[]> {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+
+      // Identify the owner whose list we'll renumber. Admin can move
+      // anyone's frag; in that case we renumber the owner's list, not
+      // the admin's. Non-admin can only move their own frags.
+      const ownerRow = await client.query(
+        `SELECT user_id FROM writing_blocks WHERE id = $1`,
+        [fragId]
+      )
+      if (ownerRow.rows.length === 0) {
+        throw new NotFoundError('Writing block not found')
+      }
+      const ownerId: string = ownerRow.rows[0].user_id
+      if (!isAdmin && ownerId !== userId) {
+        throw new ForbiddenError('Not authorized to reorder this writing block')
+      }
+
+      // Serialize against concurrent moves/creates for the same owner.
+      // Same advisory-lock key as create() so a reorder can't interleave
+      // with a new-frag insert and produce duplicate positions.
+      await client.query(
+        `SELECT pg_advisory_xact_lock(hashtext('writing_blocks_sort_order:' || $1::text))`,
+        [ownerId]
+      )
+
+      // Load all of the owner's frags, ordered by current sort_order with
+      // a stable fallback to (created_at, id) so duplicate or NULL
+      // positions still sort deterministically — the renumber below will
+      // clean them up.
+      const allRows = await client.query(
+        `SELECT id, sort_order
+         FROM writing_blocks
+         WHERE user_id = $1
+         ORDER BY sort_order ASC NULLS LAST, created_at ASC NULLS LAST, id ASC
+         FOR UPDATE`,
+        [ownerId]
+      )
+
+      const ids: string[] = allRows.rows.map((r: any) => r.id)
+      const fromIdx = ids.indexOf(fragId)
+      if (fromIdx === -1) {
+        // Shouldn't happen — the row exists (ownerRow above) and we
+        // selected the owner's full set.
+        throw new NotFoundError('Writing block not found')
+      }
+
+      const n = ids.length
+
+      // Remove from current position, then insert at the clamped target.
+      // Target arrives 1-based; convert to 0-based, clamp to [0..n-1].
+      const targetIdx0 = Math.max(0, Math.min(n - 1, targetSortOrder - 1))
+
+      const reordered = ids.slice()
+      reordered.splice(fromIdx, 1)
+      reordered.splice(targetIdx0, 0, fragId)
+
+      // Two-phase renumber to avoid colliding with the
+      // UNIQUE(user_id, sort_order) constraint mid-update: shift every
+      // row into a temporary negative-offset range first, then write the
+      // final positions. Negative values are not used by the normal flow
+      // (positions are >= 1), so they don't collide with rows we haven't
+      // touched yet.
+      const TEMP_OFFSET = n + 1
+      for (let i = 0; i < reordered.length; i++) {
+        await client.query(
+          `UPDATE writing_blocks SET sort_order = $1 WHERE id = $2`,
+          [-(i + 1 + TEMP_OFFSET), reordered[i]]
+        )
+      }
+      for (let i = 0; i < reordered.length; i++) {
+        await client.query(
+          `UPDATE writing_blocks SET sort_order = $1 WHERE id = $2`,
+          [i + 1, reordered[i]]
+        )
+      }
+
+      await client.query('COMMIT')
+
+      // Return the owner's normalized 1..n list. We deliberately re-query
+      // (rather than synthesize the rows from the in-memory `reordered`
+      // array) so the caller gets fully-populated WritingBlock records,
+      // including theme associations and visibility-derived fields, that
+      // match what findAll would have returned.
+      return this.findAllForOwner(ownerId)
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  },
+
+  /**
+   * Internal: list every frag owned by `ownerId`, ordered by sort_order.
+   * Used by moveFragToSortOrder to return the post-renumber list to the
+   * client without going through the visibility-filtered findAll.
+   */
+  async findAllForOwner(ownerId: string): Promise<WritingBlock[]> {
+    const result = await pool.query(
+      `SELECT
+         wb.id,
+         wb.user_id as "userId",
+         wb.title,
+         wb.body,
+         COALESCE(wb.visibility, 'private') as visibility,
+         wb.cover_image_url as "coverImageUrl",
+         COALESCE(wb.cover_image_position, '50% 50%') as "coverImagePosition",
+         wb.created_at as "createdAt",
+         wb.updated_at as "updatedAt",
+         COALESCE(wb.current_version, 1) as "currentVersion",
+         wb.sort_order as "sortOrder",
+         COALESCE(
+           ARRAY_AGG(wt.theme_id) FILTER (WHERE wt.theme_id IS NOT NULL),
+           ARRAY[]::UUID[]
+         ) as "themeIds"
+       FROM writing_blocks wb
+       LEFT JOIN writing_themes wt ON wb.id = wt.writing_id
+       WHERE wb.user_id = $1
+       GROUP BY wb.id, wb.user_id, wb.title, wb.body, wb.visibility, wb.cover_image_url, wb.cover_image_position, wb.created_at, wb.updated_at
+       ORDER BY wb.sort_order ASC`,
+      [ownerId]
+    )
+    return result.rows.map((row: any) => ({
+      ...row,
+      themeIds: row.themeIds || [],
+    }))
+  },
 }

--- a/server/src/routes/writing.routes.ts
+++ b/server/src/routes/writing.routes.ts
@@ -24,6 +24,7 @@ router.post('/upload', authMiddleware, uploadSingle, asyncHandler(uploadsControl
 // Protected routes require authentication
 router.post('/', authMiddleware, validateBody(['title', 'body']), asyncHandler(writingController.create))
 router.put('/:id', authMiddleware, asyncHandler(writingController.update))
+router.put('/:id/sort-order', authMiddleware, asyncHandler(writingController.moveSortOrder))
 router.delete('/:id', authMiddleware, asyncHandler(writingController.delete))
 
 // Editor grants — owner/admin/manager only. List + upsert by userId,

--- a/server/src/services/writing.service.ts
+++ b/server/src/services/writing.service.ts
@@ -158,5 +158,24 @@ export const writingService = {
 
   async delete(id: string, userId: string, isAdmin: boolean = false): Promise<void> {
     return writingRepo.delete(id, userId, isAdmin)
-  }
+  },
+
+  /**
+   * Move a frag to a target position within its owner's list. Validates
+   * the target is a finite integer and clamping is left to the repo
+   * (which has access to the owner's current count `n`). Returns the
+   * normalized 1..n list for the owner so the UI can refresh in one
+   * round-trip.
+   */
+  async moveFragToSortOrder(
+    fragId: string,
+    targetSortOrder: number,
+    userId: string,
+    isAdmin: boolean = false,
+  ): Promise<WritingBlock[]> {
+    if (typeof targetSortOrder !== 'number' || !Number.isFinite(targetSortOrder) || !Number.isInteger(targetSortOrder)) {
+      throw new ValidationError('targetSortOrder must be an integer')
+    }
+    return writingRepo.moveFragToSortOrder(fragId, targetSortOrder, userId, isAdmin)
+  },
 }

--- a/shared/WritingBlock.ts
+++ b/shared/WritingBlock.ts
@@ -15,4 +15,10 @@ export interface WritingBlock {
    * returns 409 so a co-editor's change is never silently overwritten.
    */
   currentVersion: number
+  /**
+   * Per-owner position in the frags list. 1..n where n is the owner's
+   * total frag count. Edited via the move endpoint; updating it directly
+   * is not supported because reorder must shift every other frag.
+   */
+  sortOrder: number
 }


### PR DESCRIPTION
## Summary

Adds a persisted `sortOrder` integer to each Frag so users can arrange their list however they like and have it survive reloads. Replaces the previous `localStorage`-only custom-order logic with a server-backed sequence that stays normalised as 1..n per owner.

## What changed

**Data model** ([029_writing_block_sort_order.sql](server/src/db/migrations/029_writing_block_sort_order.sql))
- Adds `sort_order INTEGER NOT NULL` to `writing_blocks`.
- Backfills existing rows per owner using `ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at, id)`.
- Adds `UNIQUE(user_id, sort_order)` so duplicates and gaps are impossible.

**Reorder as a positional move** ([writing.repo.ts](server/src/repositories/writing.repo.ts))
- New `moveFragToSortOrder(fragId, targetSortOrder, userId, isAdmin)` follows the rule literally:
  1. Load every frag for the owner, ordered by `(sort_order, created_at, id)` with `FOR UPDATE`.
  2. Splice the moved frag out and back in at the clamped target index.
  3. Renumber every row 1..n in **two phases** (negative temp values → final positions) so the `UNIQUE` constraint can never be violated mid-update.
  4. Return the owner's normalised list so the UI refreshes in one round-trip.
- `create()` takes a `pg_advisory_xact_lock` keyed on the owner before inserting with `MAX(sort_order)+1`, so concurrent creates by the same user can't collide.
- `moveFragToSortOrder` uses the same lock key, so a reorder can't interleave with a new-frag insert.

**API**
- `PUT /api/writing/:id/sort-order` body `{ sortOrder: number }`. Returns the owner's full normalised 1..n list. Owner-or-admin only.

**Frags view UI**
- Default sort is now manual order, driven by the server's `sortOrder`. Asc/desc toggle next to the sort dropdown (`enableSortDirection` opt-in on `FilterNavigation`); preference persists in `localStorage`.
- `WritingCard` and `WritingListRow` each render an inline numeric `#NN` input bound to a local draft string. On blur: empty / non-integer / NaN restores the previous valid value; same value is a no-op; an integer fires `move-to-sort-order` to the host. Esc resets, Enter commits via blur.
- Up/down arrow buttons translate to `sortOrder ± 1` moves on the server (no more local-only state).
- Removed the old `frag:customOrder` localStorage code from `Home.vue` — the server is now the source of truth.

## Scope

`sortOrder` is scoped **per owner**: each user has their own 1..n sequence over their own frags. Frags from different owners interleave in the mixed Frags view by their respective positions (everyone's #1 first, then everyone's #2, etc.). Reorder is owner/admin-only; named editors can edit content but not curate position.

## Test plan

- [ ] Run migrations on a populated DB and verify every owner ends up with a contiguous 1..n sequence.
- [ ] Create a new frag — confirm it lands at the owner's `MAX(sort_order)+1`.
- [ ] Edit a frag's `#` field to a mid-list value and tab away. Confirm the list normalises and reload preserves the order.
- [ ] Type `999`, `-1`, `abc`, blank into the `#` field — confirm clamping (999 → n, -1 → 1) and invalid-input rollback.
- [ ] Toggle asc/desc — confirm display flips but the persisted `sort_order` doesn't change.
- [ ] Click up/down arrows — confirm equivalent to ±1 move and that the owner's list renormalises.
- [ ] Delete a frag — confirm the rest of the list is still consistent (no gaps in the sequence are exposed; new creates still get `MAX+1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)