### PR TITLE
Hotfix: stop emitting runtime '@shared/Manuscript' import (production crash)

### DIFF
--- a/server/src/models/Manuscript.ts
+++ b/server/src/models/Manuscript.ts
@@ -1,2 +1,27 @@
-// Re-export shared types for consistency
-export * from '@shared/Manuscript'
+// Re-export the SHARED types (interfaces, type aliases). `export type *`
+// guarantees TS strips this at compile time — nothing emitted to JS — so the
+// `@shared/*` path alias is never asked to resolve at Node runtime. (Without
+// the `type` modifier, tsc preserves `export * from '@shared/Manuscript'` in
+// the emitted JS, and Heroku crashes with ERR_MODULE_NOT_FOUND because
+// `@shared` is a TS path alias, not a real npm package.)
+export type * from '@shared/Manuscript'
+
+// ---------------------------------------------------------------------------
+// Runtime constants — kept LOCAL to the server because the `@shared/*` path
+// alias is compile-time only. The client imports MAX_SPINE_DEPTH directly
+// from `@shared/Manuscript` (vite resolves the alias at bundle time, so
+// it's fine there). Keep this value in sync with shared/Manuscript.ts; if
+// the cap ever changes, update both places AND the CHECK constraints in
+// server/src/db/migrations/030_configurable_spine_depth.sql.
+//
+// Mirrors the StoryCraft.ts model precedent — same reason, same fix.
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum number of container layers in a manuscript spine. The cap
+ * bounds tree depth so the UI's indent and the renderer's recursion
+ * stay predictable, and matches the CHECK constraint enforced by
+ * migration 030 on both manuscript_sections.level and
+ * manuscript_projects.spine_depth.
+ */
+export const MAX_SPINE_DEPTH = 4


### PR DESCRIPTION
## Summary

Heroku has been crashing in a loop since the merge of #93 with:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@shared/Manuscript'
  imported from /app/server/dist/models/Manuscript.js
\`\`\`

This PR contains the one-file fix.

## Root cause

`server/src/models/Manuscript.ts` was historically:

\`\`\`ts
// Re-export shared types for consistency
export * from '@shared/Manuscript'
\`\`\`

This worked because every export from `shared/Manuscript.ts` was a TypeScript **type**, so `tsc` erased the whole statement and the compiled `.js` was effectively empty.

Phase 2 of #93 added `export const MAX_SPINE_DEPTH = 4` to `shared/Manuscript.ts` — a **runtime value**. That forced `tsc` to preserve the import statement in the emitted JS. The `@shared/*` alias is a compile-time TypeScript path alias only (`server/tsconfig.json` `paths`) — it is **not** a real npm package, so Node's runtime resolver fails on it.

The bug only triggered for `Manuscript.ts` because `services/spine-layer.ts` (new in #93) imports `MAX_SPINE_DEPTH` (a value) from `../models/Manuscript.js`. That value-import causes Node to actually load the module at runtime, which triggers the bad re-export. Other shared models (`Theme`, `Appreciation`, `WritingBlock`, …) compile to identical-looking `export * from '@shared/X'` JS, but no consumer imports a runtime value from them, so Node never loads them and the latent issue stays dormant.

## Fix

Mirrors the existing `server/src/models/StoryCraft.ts` precedent in this codebase, which solved the same problem for the StoryCraft shared module:

- `export type * from '@shared/Manuscript'` — TS guarantees no runtime emission
- Declare `MAX_SPINE_DEPTH = 4` locally on the server with a sync-with-shared comment

The client is unaffected: it imports `MAX_SPINE_DEPTH` from `@shared/Manuscript` directly, and Vite resolves the path alias at bundle time.

## Verification

- `npm run type-check --workspace=server`: clean
- `npm run type-check --workspace=client`: clean
- All 52 pure server tests (planner + export + prompts) pass
- Phase 1 BookPreviewModal snapshot suite: 12/12 byte-identical
- `npm run build --workspace=server`: compiled `dist/models/Manuscript.js` no longer references `@shared/Manuscript` at runtime — it just exports the local constant

## Test plan

- [ ] Heroku boot logs no longer show `ERR_MODULE_NOT_FOUND` for `@shared/Manuscript`
- [ ] `/home` route serves without H10 crash errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)