### PR TITLE
Add Print Essay button to Frag preview view

### DIFF
--- a/client/src/components/manuscripts/bookPreview/print.ts
+++ b/client/src/components/manuscripts/bookPreview/print.ts
@@ -34,10 +34,10 @@ export interface PrintBuildArgs {
   cfg: PreviewConfig
   /** Already-built bookFlowHtml (front matter + chapters + back matter). */
   bookFlowHtml: string
-  /** Self-contained HTML for the front cover. */
-  frontCoverHtml: string
-  /** Self-contained HTML for the back cover. */
-  backCoverHtml: string
+  /** Self-contained HTML for the front cover. Ignored when includeCovers is false. */
+  frontCoverHtml?: string
+  /** Self-contained HTML for the back cover. Ignored when includeCovers is false. */
+  backCoverHtml?: string
   /** Manuscript title for running header default. */
   bookTitle: string
   /** Author name for running header default. */
@@ -46,6 +46,13 @@ export interface PrintBuildArgs {
   documentTitle: string
   /** Print layout. */
   layout: PrintLayout
+  /**
+   * When false, omit the front and back cover pages entirely. Used by the
+   * single-essay print path on the Frag preview, which wants the same
+   * typography as the book wizard but none of the surrounding book chrome.
+   * Defaults to true (book-print behaviour).
+   */
+  includeCovers?: boolean
 }
 
 const A5_W_MM = 148
@@ -55,6 +62,7 @@ export function buildNaturalPrintHtml(args: PrintBuildArgs): string {
   const {
     cfg, bookFlowHtml, frontCoverHtml, backCoverHtml,
     bookTitle, authorName, documentTitle, layout,
+    includeCovers = true,
   } = args
 
   const fontFamily = `"${escapeCssString(cfg.typography.bodyFont)}", "Iowan Old Style", Georgia, "Times New Roman", serif`
@@ -303,9 +311,9 @@ export function buildNaturalPrintHtml(args: PrintBuildArgs): string {
   </div>
   <div class="pp-screen-only" style="height:46px;"></div>
 
-  <div class="pp-cover-page pp-cover-page-front">${frontCoverHtml}</div>
+  ${includeCovers ? `<div class="pp-cover-page pp-cover-page-front">${frontCoverHtml || ''}</div>` : ''}
   ${bookFlowHtml}
-  <div class="pp-cover-page">${backCoverHtml}</div>
+  ${includeCovers ? `<div class="pp-cover-page">${backCoverHtml || ''}</div>` : ''}
 
   <script>
     // Wait for cover artwork to fully decode before opening the print

--- a/client/src/pages/Read.vue
+++ b/client/src/pages/Read.vue
@@ -98,6 +98,29 @@
                   <path d="M21 12v7.5A2.25 2.25 0 0 1 18.75 21.75H6A2.25 2.25 0 0 1 3.75 19.5V6.75A2.25 2.25 0 0 1 6 4.5h6" />
                 </svg>
               </router-link>
+              <button
+                v-if="!isSpa"
+                type="button"
+                class="inline-flex items-center justify-center w-10 h-10 rounded text-ink-lighter hover:text-ink hover:bg-line transition-colors"
+                :aria-label="`Print ${writing.title}`"
+                title="Print essay"
+                @click="printEssay"
+              >
+                <svg
+                  class="w-5 h-5"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <!-- Heroicons "printer" -->
+                  <path d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z" />
+                </svg>
+              </button>
             </div>
           </div>
 
@@ -229,8 +252,11 @@ import {
   markdownToText,
   bodyMarkdownAfterExcerptPrefix,
   excerptPlainCutLength,
-  isStandaloneHtmlDoc
+  isStandaloneHtmlDoc,
+  renderMarkdown
 } from '../utils/markdown'
+import { buildNaturalPrintHtml, openPrintWindow } from '../components/manuscripts/bookPreview/print'
+import { defaultPaperbackProfile } from '../components/manuscripts/bookPreview/defaults'
 
 const route = useRoute()
 const { isAuthenticated, user, isAdmin } = useAuth()
@@ -306,6 +332,39 @@ const loadAppreciations = async () => {
   }
 }
 
+
+// Print the current essay using the book wizard's typography and page rules,
+// but with no covers, no front/back matter and no TOC — just the essay title
+// as a chapter-style opening followed by the rendered body. We use the
+// canonical paperback profile rather than reading a per-essay config because
+// frags have no manuscript-level book settings of their own.
+const printEssay = () => {
+  if (!writing.value || isSpa.value) return
+  const w = writing.value
+  const cfg = defaultPaperbackProfile('')
+  const titleEscaped = w.title
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+  const bodyHtml = renderMarkdown(w.body || '')
+  const flow =
+    `<section class="bp-chapter bp-chapter-opening bp-page-break-before">
+       <div class="bp-chapter-heading">${titleEscaped}</div>
+     </section>
+     <div class="bp-item bp-item-opening">${bodyHtml}</div>`
+  const html = buildNaturalPrintHtml({
+    cfg,
+    bookFlowHtml: flow,
+    bookTitle: w.title,
+    authorName: '',
+    documentTitle: w.title,
+    layout: 'a5_single',
+    includeCovers: false,
+  })
+  if (!openPrintWindow(html)) {
+    alert('Could not open the print window. Please allow pop-ups for this site.')
+  }
+}
 
 const loadWriting = async () => {
   const id = route.params.id as string


### PR DESCRIPTION
## Summary
- Adds a printer-icon button to the Frag preview (Read.vue) header that prints the individual essay using the book wizard's typography and page rules, but with no covers, front/back matter or TOC — just the title as a chapter-style opening followed by the rendered body.
- The handler uses `defaultPaperbackProfile()` because frags have no manuscript-level book settings of their own.
- `buildNaturalPrintHtml` gains an optional `includeCovers` flag (default `true`, so all existing book-print callers are byte-identical). Needed because the cover divs have an opaque dark background and forced page breaks, so passing empty cover strings alone wouldn't suppress them.
- Button is hidden when the frag is a standalone HTML SPA — book-style typography doesn't apply to interactive content.

## Files
- `client/src/components/manuscripts/bookPreview/print.ts` — added `includeCovers?: boolean` to `PrintBuildArgs`, made `frontCoverHtml`/`backCoverHtml` optional, conditional emit of cover divs.
- `client/src/pages/Read.vue` — added Print button next to Edit/Open-full-screen, added `printEssay()` handler.

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 12 `BookPreviewModal.snapshot.spec.ts` snapshot tests pass (book-print output unchanged)
- [ ] Manual: open a non-SPA frag in the Read view, click the printer icon — confirm the print window opens with title page + body using paperback typography, no covers or back matter
- [ ] Manual: open an SPA frag — confirm the print button is not shown
- [ ] Manual: print the full book via the wizard and confirm it's still byte-identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)