### PR TITLE
Force transparent body background for individual essay prints

### DIFF
--- a/client/src/components/manuscripts/bookPreview/print.ts
+++ b/client/src/components/manuscripts/bookPreview/print.ts
@@ -170,7 +170,10 @@ export function buildNaturalPrintHtml(args: PrintBuildArgs): string {
   // closing the <script> tag early. Empty prefix suppresses the labels.
   const labelPrefixJs = JSON.stringify(bookTitle.trim().slice(0, 4)).replace(/<\//g, '<\\/')
   const overlayCss = editorMarginOverlay
-    ? `body {
+    ? `html, body {
+        background: transparent;
+      }
+      body {
         width: ${contentWidthMm}mm;
         margin-left: auto;
         margin-right: auto;


### PR DESCRIPTION
## Summary
Follow-up to [#97](https://github.com/DRCUOA/befly/pull/97). The existing book-print CSS sets `html, body { background: ${paperColor} }` — with the default paperback profile `paper.color` is `'cream'` (`#f4ecdd`), which leaked through to the essay-print preview as a darker page background. The overlay path now overrides both `html` and `body` to `background: transparent` so individual-essay prints render on plain white.

## Why this works
`html, body { background: transparent }` is appended to the stylesheet AFTER the original `html, body { ... background: ${paperColor} }` rule, so the cascade picks transparent. The override is wrapped in the same `editorMarginOverlay` conditional that gates the rest of the overlay CSS, so book-wizard print is untouched.

## Files
- `client/src/components/manuscripts/bookPreview/print.ts` — 4 insertions, 1 deletion

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 12 `BookPreviewModal.snapshot.spec.ts` snapshot tests pass (book-print output unchanged)
- [ ] Manual: print a frag, confirm the page background is plain white (no cream tint)
- [ ] Manual: print the full book via the wizard, confirm cream paper tint still appears as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)