### PR TITLE
Pin editor-margin labels to a fixed-width right-aligned gutter box

### DIFF
--- a/client/src/components/manuscripts/bookPreview/print.ts
+++ b/client/src/components/manuscripts/bookPreview/print.ts
@@ -181,13 +181,18 @@ export function buildNaturalPrintHtml(args: PrintBuildArgs): string {
       }
       .editor-margin-label {
         position: absolute;
-        left: -13mm;
+        left: -15mm;
+        width: 14mm;
+        box-sizing: border-box;
+        padding-right: 1mm;
+        text-align: right;
         transform: translateY(-50%);
-        font: 6pt -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, sans-serif;
+        font: 7pt -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, sans-serif;
         color: #888;
         white-space: nowrap;
         letter-spacing: 0.02em;
         pointer-events: none;
+        overflow: hidden;
       }`
     : ''
 


### PR DESCRIPTION
## Problem
Editor-margin labels were positioned with `left: -13mm` and their natural text width. Short ranges like `S2 34-39` fit inside the gutter, but longer ranges like `Smal 1000-2000` render ~15mm wide — the right edge of the label crossed body's left edge and **overlapped the essay text**.

## Fix
Make each label a fixed 14mm-wide box with `text-align: right`, `padding-right: 1mm`, and `overflow: hidden`:

```css
.editor-margin-label {
  position: absolute;
  left: -15mm;
  width: 14mm;
  box-sizing: border-box;
  padding-right: 1mm;
  text-align: right;
  transform: translateY(-50%);
  font: 7pt …;
  color: #888;
  white-space: nowrap;
  letter-spacing: 0.02em;
  pointer-events: none;
  overflow: hidden;
}
```

The right edge of the box now sits 1mm to the left of body, so the rightmost visible character is **always in the gutter** regardless of label text length. Any overflow gets clipped on the left side (off-page on verso pages, into the outer margin on recto pages) rather than into body content.

Also bumped the font from 6pt to 7pt for legibility — the fixed-width container makes longer ranges fit safely now.

## Verification
- The label box spans `-15mm` to `-1mm` from body's left edge.
- On recto pages (inside-gutter 0.8in = 20.3mm), the box sits at page-left + 5.3 to + 19.3mm — fully on page, fully in the gutter.
- On verso pages (outside 0.65in = 16.5mm), the box sits at page-left + 1.5 to + 15.5mm — fully on page, fully in the gutter.

## Files
- `client/src/components/manuscripts/bookPreview/print.ts` — 7 insertions, 2 deletions

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 12 `BookPreviewModal.snapshot.spec.ts` snapshot tests pass (book-print output unchanged)
- [ ] Manual: print a frag with line numbers that would produce long labels (e.g. an essay over ~200 lines) and confirm labels stay in the left gutter
- [ ] Manual: print a frag and confirm labels are still readable at 7pt and aligned with band midpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)