### PR TITLE
Add print options for characters, polyphonic, and plot

### DIFF
--- a/client/src/components/storycraft/BeatDetailPanel.vue
+++ b/client/src/components/storycraft/BeatDetailPanel.vue
@@ -14,14 +14,27 @@
           </p>
           <h3 class="text-lg font-light tracking-tight">{{ beat.title || '(untitled beat)' }}</h3>
         </div>
-        <button
-          type="button"
-          @click="$emit('close')"
-          class="p-2 text-ink-lighter hover:text-ink"
-          aria-label="Close"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
-        </button>
+        <div class="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            @click="$emit('print', beat!.id)"
+            class="p-2 text-ink-lighter hover:text-ink"
+            aria-label="Print beat"
+            title="Print this beat"
+          >
+            <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            @click="$emit('close')"
+            class="p-2 text-ink-lighter hover:text-ink"
+            aria-label="Close"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+          </button>
+        </div>
       </header>
 
       <div class="px-6 py-5 space-y-5">
@@ -169,6 +182,7 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'save', updates: Partial<Beat>): void
   (e: 'delete', beatId: string): void
+  (e: 'print', beatId: string): void
   (e: 'saveKnowledge', payload: { beatId: string; characterId: string | null; knowledgeKind: KnowledgeKind; text: string | null }): void
 }>()
 

--- a/client/src/pages/CharacterStudio.vue
+++ b/client/src/pages/CharacterStudio.vue
@@ -9,6 +9,15 @@
     >
       <template #actions>
         <button
+          v-if="characters.length > 0"
+          type="button"
+          @click="onPrintAllCharacters"
+          class="px-4 py-2 text-sm tracking-wide font-sans border border-line text-ink-light hover:text-ink hover:border-ink-lighter transition-colors"
+          title="Print all characters as one document"
+        >
+          Print all
+        </button>
+        <button
           v-if="canModify"
           type="button"
           @click="addCharacter"
@@ -392,6 +401,17 @@
                   Stitch every beat in this character's voice into one document. Pass-1 voice-coherence check.
                 </span>
               </button>
+
+              <button
+                type="button"
+                @click="onPrintCharacter"
+                class="w-full text-left px-4 py-3 border border-line text-sm text-ink-light hover:text-ink hover:border-ink-lighter transition-colors"
+              >
+                <span class="block font-medium">Print character →</span>
+                <span class="block text-xs italic text-ink-lighter mt-0.5">
+                  Print this character's identity, voice bible, arc and misreadings as a single document.
+                </span>
+              </button>
             </div>
           </aside>
         </div>
@@ -450,6 +470,7 @@ import { useAuth } from '../stores/auth'
 import ManuscriptHeader from '../components/storycraft/ManuscriptHeader.vue'
 import ManuscriptSubNav from '../components/storycraft/ManuscriptSubNav.vue'
 import FieldRow from '../components/storycraft/FieldRow.vue'
+import { printCharacter, printAllCharacters } from '../utils/storyCraftPrint'
 import type { ManuscriptProject } from '@shared/Manuscript'
 import type {
   Character,
@@ -666,6 +687,16 @@ async function deleteCharacter() {
 
 function openIsolationRead() {
   showIsolation.value = true
+}
+
+function onPrintCharacter() {
+  if (!selected.value || !manuscript.value) return
+  printCharacter(selected.value, misreadings.value, manuscript.value.title)
+}
+
+function onPrintAllCharacters() {
+  if (!manuscript.value || characters.value.length === 0) return
+  printAllCharacters(characters.value, misreadings.value, manuscript.value.title)
 }
 
 onMounted(loadAll)

--- a/client/src/pages/PlotCausality.vue
+++ b/client/src/pages/PlotCausality.vue
@@ -9,6 +9,15 @@
     >
       <template #actions>
         <button
+          v-if="beats.length > 0"
+          type="button"
+          @click="onPrintPlot"
+          class="px-4 py-2 text-sm tracking-wide font-sans border border-line text-ink-light hover:text-ink hover:border-ink-lighter transition-colors"
+          title="Print every beat with its causal link to the previous beat"
+        >
+          Print
+        </button>
+        <button
           v-if="canModify"
           type="button"
           @click="addBeat"
@@ -171,6 +180,7 @@
       @close="detailBeat = null"
       @save="onSaveBeat"
       @delete="onDeleteBeat"
+      @print="onPrintBeat"
       @save-knowledge="onSaveKnowledge"
     />
   </div>
@@ -185,6 +195,7 @@ import { useAuth } from '../stores/auth'
 import ManuscriptHeader from '../components/storycraft/ManuscriptHeader.vue'
 import ManuscriptSubNav from '../components/storycraft/ManuscriptSubNav.vue'
 import BeatDetailPanel from '../components/storycraft/BeatDetailPanel.vue'
+import { printBeat, printPlotCausality } from '../utils/storyCraftPrint'
 import type { ManuscriptProject } from '@shared/Manuscript'
 import type {
   Character,
@@ -355,6 +366,24 @@ async function addBeat() {
   } catch (err) {
     alert(err instanceof Error ? err.message : 'Failed to add beat')
   }
+}
+
+function onPrintPlot() {
+  if (!manuscript.value || beats.value.length === 0) return
+  printPlotCausality(
+    beats.value,
+    characters.value,
+    causalLinks.value,
+    beatKnowledge.value,
+    manuscript.value.title,
+  )
+}
+
+function onPrintBeat(beatId: string) {
+  if (!manuscript.value) return
+  const beat = beats.value.find(b => b.id === beatId)
+  if (!beat) return
+  printBeat(beat, characters.value, beatKnowledge.value, manuscript.value.title)
 }
 
 function openBeat(b: Beat) {

--- a/client/src/pages/PolyphonicMap.vue
+++ b/client/src/pages/PolyphonicMap.vue
@@ -9,6 +9,15 @@
     >
       <template #actions>
         <button
+          v-if="beats.length > 0"
+          type="button"
+          @click="onPrintPolyphonic"
+          class="px-4 py-2 text-sm tracking-wide font-sans border border-line text-ink-light hover:text-ink hover:border-ink-lighter transition-colors"
+          title="Print every beat's knowledge ledger as one document"
+        >
+          Print
+        </button>
+        <button
           v-if="canModify"
           type="button"
           @click="addBeat"
@@ -178,6 +187,7 @@
       @close="detailBeat = null"
       @save="onSaveBeat"
       @delete="onDeleteBeat"
+      @print="onPrintBeat"
       @save-knowledge="onSaveKnowledge"
     />
   </div>
@@ -192,6 +202,7 @@ import { useAuth } from '../stores/auth'
 import ManuscriptHeader from '../components/storycraft/ManuscriptHeader.vue'
 import ManuscriptSubNav from '../components/storycraft/ManuscriptSubNav.vue'
 import BeatDetailPanel from '../components/storycraft/BeatDetailPanel.vue'
+import { printBeat, printPolyphonicMap } from '../utils/storyCraftPrint'
 import type { ManuscriptProject } from '@shared/Manuscript'
 import type {
   Character,
@@ -358,6 +369,18 @@ async function addBeat() {
   } catch (err) {
     alert(err instanceof Error ? err.message : 'Failed to add beat')
   }
+}
+
+function onPrintPolyphonic() {
+  if (!manuscript.value || beats.value.length === 0) return
+  printPolyphonicMap(characters.value, beats.value, beatKnowledge.value, manuscript.value.title)
+}
+
+function onPrintBeat(beatId: string) {
+  if (!manuscript.value) return
+  const beat = beats.value.find(b => b.id === beatId)
+  if (!beat) return
+  printBeat(beat, characters.value, beatKnowledge.value, manuscript.value.title)
 }
 
 async function onSaveBeat(updates: Partial<Beat>) {

--- a/client/src/utils/storyCraftPrint.ts
+++ b/client/src/utils/storyCraftPrint.ts
@@ -1,0 +1,297 @@
+// Print helpers for the story-craft views (Character Studio, Polyphonic Map,
+// Plot Causality). All paths reuse the book-wizard typography via
+// `buildNaturalPrintHtml({ includeCovers: false })` so the printed output
+// looks the same as the essay print — no covers, no front/back matter,
+// just the artifact rendered as chapter-style sections.
+
+import type {
+  Beat,
+  BeatKnowledge,
+  CausalLink,
+  Character,
+  CharacterMisreading,
+  KnowledgeKind,
+} from '@shared/StoryCraft'
+import { KNOWLEDGE_KINDS } from '@shared/StoryCraft'
+import { buildNaturalPrintHtml, openPrintWindow } from '../components/manuscripts/bookPreview/print'
+import { defaultPaperbackProfile } from '../components/manuscripts/bookPreview/defaults'
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function paragraphs(text: string | null | undefined): string {
+  const s = (text || '').trim()
+  if (!s) return ''
+  return s
+    .split(/\r?\n\r?\n+/)
+    .map(p => p.trim())
+    .filter(Boolean)
+    .map(p => `<p>${escHtml(p).replace(/\r?\n/g, '<br />')}</p>`)
+    .join('')
+}
+
+// One labelled paragraph. Labels read as "Field: value." — text-indent: 0 so
+// the inline label sits flush left rather than indenting like prose.
+function field(label: string, value: string | null | undefined): string {
+  const v = (value || '').trim()
+  if (!v) return ''
+  return `<p style="text-indent: 0;"><strong>${escHtml(label)}:</strong> ${escHtml(v)}</p>`
+}
+
+function fieldList(label: string, items: string[] | undefined | null): string {
+  const cleaned = (items || []).map(i => (i || '').trim()).filter(Boolean)
+  if (!cleaned.length) return ''
+  const lis = cleaned.map(i => `<li>${escHtml(i)}</li>`).join('')
+  return `<p style="text-indent: 0;"><strong>${escHtml(label)}:</strong></p><ul>${lis}</ul>`
+}
+
+function chapterOpening(heading: string, label?: string): string {
+  const eyebrow = label ? `<div class="bp-chapter-eyebrow">${escHtml(label)}</div>` : ''
+  return `<section class="bp-chapter bp-chapter-opening bp-page-break-before">
+    ${eyebrow}
+    <div class="bp-chapter-heading">${escHtml(heading)}</div>
+  </section>`
+}
+
+function itemOpen(opening = true): string {
+  return `<div class="bp-item${opening ? ' bp-item-opening' : ''}" style="text-align: left;">`
+}
+
+function buildCharacterFlow(character: Character, misreadings: CharacterMisreading[]): string {
+  const c = character
+  const v = c.voice || {}
+  const cMisreadings = misreadings
+    .filter(m => m.characterId === c.id)
+    .sort((a, b) => a.orderIndex - b.orderIndex)
+
+  const identity = [
+    field('Full name', c.fullName),
+    field('Role', c.role),
+    field('Social position', c.socialPosition),
+    field('Contradiction', c.contradiction),
+    field('Public want', c.publicWant),
+    field('Private want', c.privateWant),
+    field('Hidden need', c.hiddenNeed),
+    field('Greatest fear', c.greatestFear),
+    field('False belief', c.falseBelief),
+    field('Wound', c.wound),
+  ].filter(Boolean).join('')
+
+  const voice = [
+    field('Sentence length', v.sentenceLength),
+    field('Rhythm', v.rhythm),
+    field('Punctuation habits', v.punctuationHabits),
+    fieldList('Preferred words', v.preferredWords),
+    fieldList('Forbidden words', v.forbiddenWords),
+    fieldList('Metaphor sources', v.metaphorSources),
+    fieldList('What they notice', v.whatTheyNotice),
+    fieldList('What they miss', v.whatTheyMiss),
+    field('What they lie about', v.whatTheyLieAbout),
+    field('What they selectively tell', v.whatTheySelectivelyTell),
+    field('What they never say directly', v.whatTheyNeverSayDirectly),
+    field('How emotion leaks', v.howEmotionLeaks),
+    field('How pressure changes the voice', v.howPressureChangesTheVoice),
+    field('Attention pattern', v.attentionPattern),
+    field('Avoidance pattern', v.avoidancePattern),
+    field('Sample sentence (neutral)', v.sampleSentenceNeutral),
+    field('Sample sentence (under pressure)', v.sampleSentenceUnderPressure),
+  ].filter(Boolean).join('')
+
+  const arc = fieldList('Arc phases', c.arcPhases)
+  const plot = fieldList('Plot functions', c.plotFunctions)
+  const misreadingsBlock = cMisreadings.length
+    ? `<p style="text-indent: 0;"><strong>Misreadings:</strong></p><ul>${cMisreadings.map(m => `<li>${escHtml(m.label)}${m.why ? ` — <em>${escHtml(m.why)}</em>` : ''}</li>`).join('')}</ul>`
+    : ''
+  const notes = c.notes ? `<p style="text-indent: 0;"><strong>Notes</strong></p>${paragraphs(c.notes)}` : ''
+
+  const sections: string[] = []
+  if (identity) sections.push(`<h3 class="bp-h3">Identity</h3>${identity}`)
+  if (voice) sections.push(`<h3 class="bp-h3">Voice bible</h3>${voice}`)
+  if (arc) sections.push(`<h3 class="bp-h3">Arc</h3>${arc}`)
+  if (plot) sections.push(`<h3 class="bp-h3">Plot functions</h3>${plot}`)
+  if (misreadingsBlock) sections.push(`<h3 class="bp-h3">Misreadings</h3>${misreadingsBlock}`)
+  if (notes) sections.push(`<h3 class="bp-h3">Notes</h3>${notes}`)
+
+  const body = sections.length
+    ? sections.join('')
+    : '<p><em>(No details captured yet.)</em></p>'
+
+  return chapterOpening(c.name, c.role || undefined)
+    + `${itemOpen()}${body}</div>`
+}
+
+function buildBeatFlow(
+  beat: Beat,
+  characters: Character[],
+  knowledge: BeatKnowledge[],
+  link?: CausalLink | null,
+  prevBeat?: Beat | null,
+): string {
+  const b = beat
+  const pov = characters.find(c => c.id === (b.povCharacterId || ''))
+  const eyebrow = [b.label, pov?.name, b.timelinePoint].filter(Boolean).join(' · ')
+
+  const linkRow = link && prevBeat
+    ? `<p style="text-indent: 0; font-style: italic; color: #6a5f4d;">${escHtml(formatSnake(link.linkType))} (from "${escHtml(prevBeat.title || prevBeat.label || 'previous beat')}")${link.note ? ` — ${escHtml(link.note)}` : ''}</p>`
+    : ''
+
+  const meta = [
+    field('Movement', b.movement),
+    field('Scene function', b.sceneFunctionType ? formatSnake(b.sceneFunctionType) : null),
+    field('Withholding level', b.withholdingLevel),
+  ].filter(Boolean).join('')
+
+  const events = [
+    b.outerEvent ? `<p style="text-indent: 0;"><strong>Outer event:</strong></p>${paragraphs(b.outerEvent)}` : '',
+    b.innerTurn ? `<p style="text-indent: 0;"><strong>Inner turn:</strong></p>${paragraphs(b.innerTurn)}` : '',
+    b.voiceConstraint ? `<p style="text-indent: 0;"><strong>Voice constraint:</strong></p>${paragraphs(b.voiceConstraint)}` : '',
+    b.finalImage ? `<p style="text-indent: 0;"><strong>Final image:</strong></p>${paragraphs(b.finalImage)}` : '',
+  ].filter(Boolean).join('')
+
+  const irony = [
+    b.uniquePerception ? `<p style="text-indent: 0;"><strong>Unique perception:</strong></p>${paragraphs(b.uniquePerception)}` : '',
+    b.blindSpot ? `<p style="text-indent: 0;"><strong>Blind spot:</strong></p>${paragraphs(b.blindSpot)}` : '',
+    b.misreading ? `<p style="text-indent: 0;"><strong>Misreading:</strong></p>${paragraphs(b.misreading)}` : '',
+    b.readerInference ? `<p style="text-indent: 0;"><strong>Reader inference:</strong></p>${paragraphs(b.readerInference)}` : '',
+    b.reasonForNextPovSwitch ? `<p style="text-indent: 0;"><strong>Reason for next POV switch:</strong></p>${paragraphs(b.reasonForNextPovSwitch)}` : '',
+  ].filter(Boolean).join('')
+
+  const ledger = buildKnowledgeLedger(beat, characters, knowledge)
+
+  const sections: string[] = []
+  if (meta) sections.push(meta)
+  if (events) sections.push(`<h3 class="bp-h3">Scene</h3>${events}`)
+  if (irony) sections.push(`<h3 class="bp-h3">Voice & irony</h3>${irony}`)
+  if (ledger) sections.push(`<h3 class="bp-h3">Knowledge ledger</h3>${ledger}`)
+
+  const body = sections.length
+    ? sections.join('')
+    : '<p><em>(No details captured yet.)</em></p>'
+
+  const heading = b.title || b.label || '(untitled beat)'
+  return chapterOpening(heading, eyebrow || undefined)
+    + `${itemOpen()}${linkRow}${body}</div>`
+}
+
+function buildKnowledgeLedger(
+  beat: Beat,
+  characters: Character[],
+  knowledge: BeatKnowledge[],
+): string {
+  const beatKnow = knowledge.filter(k => k.beatId === beat.id)
+  if (!beatKnow.length) return ''
+
+  const rows: { label: string; characterId: string | null }[] = [
+    { label: 'Reader', characterId: null },
+    ...characters.map(c => ({ label: c.name, characterId: c.id })),
+  ]
+  const parts: string[] = []
+  for (const row of rows) {
+    const cells: string[] = []
+    for (const kind of KNOWLEDGE_KINDS) {
+      const entry = beatKnow.find(
+        k => (k.characterId ?? null) === row.characterId && k.knowledgeKind === kind,
+      )
+      const text = entry?.text?.trim()
+      if (text) cells.push(`<li><strong>${escHtml(formatKind(kind))}:</strong> ${escHtml(text)}</li>`)
+    }
+    if (cells.length) {
+      parts.push(`<p style="text-indent: 0;"><strong>${escHtml(row.label)}</strong></p><ul>${cells.join('')}</ul>`)
+    }
+  }
+  return parts.join('')
+}
+
+function formatSnake(s: string): string {
+  return s.replace(/_/g, ' ')
+}
+
+function formatKind(kind: KnowledgeKind): string {
+  return kind.charAt(0).toUpperCase() + kind.slice(1)
+}
+
+function launch(
+  bookFlowHtml: string,
+  bookTitle: string,
+  documentTitle: string,
+): void {
+  const cfg = defaultPaperbackProfile('')
+  const html = buildNaturalPrintHtml({
+    cfg,
+    bookFlowHtml,
+    bookTitle,
+    authorName: '',
+    documentTitle,
+    layout: 'a5_single',
+    includeCovers: false,
+  })
+  if (!openPrintWindow(html)) {
+    alert('Could not open the print window. Please allow pop-ups for this site.')
+  }
+}
+
+export function printCharacter(
+  character: Character,
+  misreadings: CharacterMisreading[],
+  manuscriptTitle: string,
+): void {
+  const flow = buildCharacterFlow(character, misreadings)
+  launch(flow, manuscriptTitle, `${manuscriptTitle} — ${character.name}`)
+}
+
+export function printAllCharacters(
+  characters: Character[],
+  misreadings: CharacterMisreading[],
+  manuscriptTitle: string,
+): void {
+  const sorted = [...characters].sort((a, b) => a.orderIndex - b.orderIndex)
+  const flow = sorted.map(c => buildCharacterFlow(c, misreadings)).join('')
+  launch(flow, manuscriptTitle, `${manuscriptTitle} — Characters`)
+}
+
+export function printBeat(
+  beat: Beat,
+  characters: Character[],
+  knowledge: BeatKnowledge[],
+  manuscriptTitle: string,
+): void {
+  const flow = buildBeatFlow(beat, characters, knowledge)
+  const heading = beat.title || beat.label || 'Beat'
+  launch(flow, manuscriptTitle, `${manuscriptTitle} — ${heading}`)
+}
+
+export function printPolyphonicMap(
+  characters: Character[],
+  beats: Beat[],
+  knowledge: BeatKnowledge[],
+  manuscriptTitle: string,
+): void {
+  const sortedBeats = [...beats].sort((a, b) => a.orderIndex - b.orderIndex)
+  const flow = sortedBeats.map(b => buildBeatFlow(b, characters, knowledge)).join('')
+  launch(flow, manuscriptTitle, `${manuscriptTitle} — Polyphonic Map`)
+}
+
+export function printPlotCausality(
+  beats: Beat[],
+  characters: Character[],
+  causalLinks: CausalLink[],
+  knowledge: BeatKnowledge[],
+  manuscriptTitle: string,
+): void {
+  const sortedBeats = [...beats].sort((a, b) => a.orderIndex - b.orderIndex)
+  const linkByTarget = new Map<string, CausalLink>()
+  for (const l of causalLinks) linkByTarget.set(l.toBeatId, l)
+  const flow = sortedBeats
+    .map((b, i) => {
+      const link = linkByTarget.get(b.id) || null
+      const prev = i > 0 ? sortedBeats[i - 1] : null
+      return buildBeatFlow(b, characters, knowledge, link, prev)
+    })
+    .join('')
+  launch(flow, manuscriptTitle, `${manuscriptTitle} — Plot Causality`)
+}


### PR DESCRIPTION
## Summary
Brings the existing book-typography print path (essay print, [#95](https://github.com/DRCUOA/befly/pull/95)) into the manuscript story-craft views.

### Character Studio
- **`Print all`** in the header — one document with every character as a chapter-style section.
- **`Print character →`** block button in the right sidebar (matches the `Isolation read →` pattern) — prints the selected character's identity, voice bible, arc phases, plot functions, misreadings and notes.

### Polyphonic Map
- **`Print`** in the header — every beat in order, each rendered with its full knowledge ledger (Reader row + per-character known/suspected/misread/hidden/silent).
- Per-beat print: a printer-icon button on the BeatDetailPanel emits `@print` which the page handles by launching a single-beat print.

### Plot Causality
- **`Print`** in the header — every beat in order, each prefixed with its causal link to the previous beat (e.g. *"because (from \"Garden meeting\")"*).
- Per-beat print: same BeatDetailPanel icon.

## Implementation
New module `client/src/utils/storyCraftPrint.ts` exports five entry points: `printCharacter`, `printAllCharacters`, `printBeat`, `printPolyphonicMap`, `printPlotCausality`. All call `buildNaturalPrintHtml({ includeCovers: false })` with the canonical paperback profile, so the output looks the same as the essay print — book typography, no covers, no front/back matter, just chapter-style sections.

`BeatDetailPanel` stays pure UI — it emits `@print` with the beat id and the parent page (Polyphonic or Plot) does the actual print call. That keeps the panel decoupled from data and reusable across both views.

## Files
- `client/src/utils/storyCraftPrint.ts` (new, +319 lines)
- `client/src/pages/CharacterStudio.vue` (+31 / -0)
- `client/src/pages/PolyphonicMap.vue` (+23 / -1)
- `client/src/pages/PlotCausality.vue` (+29 / -1)
- `client/src/components/storycraft/BeatDetailPanel.vue` (+21 / -8)

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 12 `BookPreviewModal.snapshot.spec.ts` snapshot tests pass (book-print output unchanged)
- [ ] Manual — Character Studio: select a character, click `Print character →`, verify the single-character doc opens with identity / voice bible / arc / misreadings / notes
- [ ] Manual — Character Studio: click `Print all`, verify every character appears as its own chapter-style section
- [ ] Manual — Polyphonic Map: click `Print` (header), verify every beat appears with full knowledge ledger
- [ ] Manual — Polyphonic Map: open a beat detail panel, click the printer icon, verify the single beat prints
- [ ] Manual — Plot Causality: click `Print` (header), verify every beat appears with its causal link to the previous
- [ ] Manual — Plot Causality: open a beat detail panel, click the printer icon, verify the single beat prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)