### PR TITLE
Expand MyLibrary with personal fields, manual edit, and scan telemetry

### DIFF
--- a/client/src/api/library.ts
+++ b/client/src/api/library.ts
@@ -1,11 +1,24 @@
 /**
  * Library API client. Wraps the /api/library endpoints used by the
  * MyLibrary view: list, ISBN lookup (server-side enrichment via
- * @library-pals/isbn), create, update notes, delete.
+ * @library-pals/isbn), create, update, delete, and scan-funnel telemetry.
  */
 import { api } from './client'
 import type { ApiResponse } from '@shared/ApiResponses'
-import type { LibraryBook, LibraryBookLookup } from '@shared/LibraryBook'
+import type {
+  LibraryBook,
+  LibraryBookLookup,
+  LibraryBookUpdate,
+  LibraryScanEventInput,
+} from '@shared/LibraryBook'
+
+export type LibraryCreatePayload = LibraryBookLookup & Partial<{
+  read: boolean
+  readMotivation: number
+  physicalCondition: number
+  owner: string
+  notes: string
+}>
 
 export const libraryApi = {
   list: () =>
@@ -14,12 +27,18 @@ export const libraryApi = {
   lookup: (isbn: string) =>
     api.get<ApiResponse<LibraryBookLookup>>(`/library/lookup/${encodeURIComponent(isbn)}`).then(r => r.data),
 
-  create: (book: LibraryBookLookup & { notes?: string }) =>
+  create: (book: LibraryCreatePayload) =>
     api.post<ApiResponse<LibraryBook>>('/library', book).then(r => r.data),
 
-  updateNotes: (id: string, notes: string) =>
-    api.patch<ApiResponse<LibraryBook>>(`/library/${id}/notes`, { notes }).then(r => r.data),
+  update: (id: string, updates: LibraryBookUpdate) =>
+    api.patch<ApiResponse<LibraryBook>>(`/library/${id}`, updates).then(r => r.data),
 
   delete: (id: string) =>
     api.delete<void>(`/library/${id}`),
+
+  /** Fire-and-forget client-side telemetry for the scan funnel. */
+  logScanEvent: (event: LibraryScanEventInput) =>
+    api.post<void>('/library/telemetry', event).catch(err => {
+      console.error('library telemetry write failed', err)
+    }),
 }

--- a/client/src/components/library/BookEditor.vue
+++ b/client/src/components/library/BookEditor.vue
@@ -1,0 +1,307 @@
+<template>
+  <div class="bg-paper border border-line p-4 sm:p-6 max-w-2xl w-full">
+    <div class="flex items-start justify-between mb-4 gap-3">
+      <h3 class="text-lg font-light tracking-tight">{{ title }}</h3>
+      <button @click="emit('cancel')" class="text-ink-lighter hover:text-ink p-1" aria-label="Cancel">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Identity row -->
+    <div class="flex gap-4 mb-4">
+      <img
+        v-if="form.thumbnail"
+        :src="form.thumbnail"
+        :alt="form.title"
+        class="w-20 h-28 object-cover border border-line shrink-0"
+      />
+      <div class="flex-1 min-w-0 text-sm">
+        <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-0.5">ISBN</p>
+        <p class="font-mono text-ink">{{ form.isbn || '—' }}</p>
+        <p v-if="form.provider" class="text-xs text-ink-lighter mt-1">via {{ form.provider }}</p>
+      </div>
+    </div>
+
+    <!-- Bibliographic fields -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
+      <label class="block sm:col-span-2">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Title</span>
+        <input v-model="form.title" type="text" class="input" />
+      </label>
+
+      <label class="block sm:col-span-2">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Authors (comma-separated)</span>
+        <input v-model="authorsText" type="text" class="input" />
+      </label>
+
+      <label class="block">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Publisher</span>
+        <input v-model="form.publisher" type="text" class="input" />
+      </label>
+
+      <label class="block">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Published date</span>
+        <input v-model="form.publishedDate" type="text" placeholder="YYYY or YYYY-MM-DD" class="input" />
+      </label>
+
+      <label class="block">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Page count</span>
+        <input v-model.number="pageCountInput" type="number" min="0" class="input" />
+      </label>
+
+      <label class="block">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Language</span>
+        <input v-model="form.language" type="text" placeholder="en" class="input" />
+      </label>
+
+      <label class="block sm:col-span-2">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Cover URL</span>
+        <input v-model="form.thumbnail" type="url" class="input" />
+      </label>
+
+      <label class="block sm:col-span-2">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Categories (comma-separated)</span>
+        <input v-model="categoriesText" type="text" class="input" />
+      </label>
+
+      <label class="block sm:col-span-2">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Description</span>
+        <textarea v-model="form.description" rows="3" class="input"></textarea>
+      </label>
+    </div>
+
+    <!-- Personal fields -->
+    <div class="border-t border-line pt-4 mb-4">
+      <p class="text-xs uppercase tracking-widest text-ink-lighter mb-3">Your appraisal</p>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+        <label class="flex items-center gap-3 cursor-pointer">
+          <span class="text-xs uppercase tracking-widest text-ink-lighter">Read</span>
+          <button
+            type="button"
+            role="switch"
+            :aria-checked="form.read"
+            @click="form.read = !form.read"
+            class="toggle"
+            :class="form.read ? 'toggle-on' : ''"
+          >
+            <span class="toggle-knob" />
+          </button>
+          <span class="text-sm text-ink">{{ form.read ? 'Read' : 'Not read' }}</span>
+        </label>
+
+        <label class="block">
+          <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Owner</span>
+          <input v-model="form.owner" type="text" placeholder="e.g. me, study shelf" class="input" />
+        </label>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+        <RangeSlider
+          v-model="form.readMotivation"
+          label="Read motivation"
+          low-label="Don't want to"
+          high-label="Strongly want to"
+        />
+        <RangeSlider
+          v-model="form.physicalCondition"
+          label="Physical condition"
+          low-label="Wrecked"
+          high-label="Mint"
+        />
+      </div>
+
+      <label class="block">
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Notes</span>
+        <textarea
+          v-model="form.notes"
+          rows="3"
+          placeholder="Why this book matters to your project…"
+          class="input"
+        ></textarea>
+      </label>
+    </div>
+
+    <div v-if="errorMessage" class="text-sm text-red-700 mb-3">{{ errorMessage }}</div>
+
+    <div class="flex gap-2 justify-end">
+      <button
+        @click="emit('cancel')"
+        class="px-4 py-2 text-sm tracking-wide font-sans border border-line text-ink-light hover:text-ink"
+        :disabled="busy"
+      >
+        Cancel
+      </button>
+      <button
+        @click="onSave"
+        :disabled="busy"
+        class="px-4 py-2 bg-ink text-paper text-sm tracking-wide font-sans hover:bg-ink-light transition-colors disabled:opacity-50"
+      >
+        {{ busy ? 'Saving…' : saveLabel }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, computed, watch } from 'vue'
+import type { LibraryBook, LibraryBookLookup } from '@shared/LibraryBook'
+import RangeSlider from './RangeSlider.vue'
+
+export interface EditorForm {
+  isbn: string
+  title: string
+  authors: string[]
+  publisher: string
+  publishedDate: string
+  description: string
+  pageCount: number | null
+  thumbnail: string
+  categories: string[]
+  language: string
+  provider: string
+  /** Carried through unchanged — never shown in the form, never edited. */
+  raw: Record<string, unknown> | null
+  read: boolean
+  readMotivation: number
+  physicalCondition: number
+  owner: string
+  notes: string
+}
+
+/** Accept either a saved book (edit) or a lookup result (entry). */
+type EditorInput = Partial<LibraryBook> & Partial<LibraryBookLookup>
+
+const props = defineProps<{
+  /** Starting values. */
+  initial: EditorInput
+  /** Header copy. */
+  title: string
+  /** Primary action label. */
+  saveLabel: string
+  /** Disable buttons while parent is saving. */
+  busy: boolean
+  /** Optional error string from the parent. */
+  errorMessage?: string | null
+}>()
+
+const emit = defineEmits<{
+  save: [form: EditorForm]
+  cancel: []
+}>()
+
+const form = reactive<EditorForm>({
+  isbn: props.initial.isbn ?? '',
+  title: props.initial.title ?? '',
+  authors: [...(props.initial.authors ?? [])],
+  publisher: props.initial.publisher ?? '',
+  publishedDate: props.initial.publishedDate ?? '',
+  description: props.initial.description ?? '',
+  pageCount: props.initial.pageCount ?? null,
+  thumbnail: props.initial.thumbnail ?? '',
+  categories: [...(props.initial.categories ?? [])],
+  language: props.initial.language ?? '',
+  provider: props.initial.provider ?? '',
+  raw: props.initial.raw ?? null,
+  read: (props.initial as Partial<LibraryBook>).read ?? false,
+  readMotivation: (props.initial as Partial<LibraryBook>).readMotivation ?? 50,
+  physicalCondition: (props.initial as Partial<LibraryBook>).physicalCondition ?? 100,
+  owner: (props.initial as Partial<LibraryBook>).owner ?? '',
+  notes: (props.initial as Partial<LibraryBook>).notes ?? '',
+})
+
+// Bind comma-separated text to array fields for ergonomic editing.
+const authorsText = computed({
+  get: () => form.authors.join(', '),
+  set: (v: string) => {
+    form.authors = v.split(',').map(s => s.trim()).filter(Boolean)
+  },
+})
+const categoriesText = computed({
+  get: () => form.categories.join(', '),
+  set: (v: string) => {
+    form.categories = v.split(',').map(s => s.trim()).filter(Boolean)
+  },
+})
+
+const pageCountInput = computed({
+  get: () => form.pageCount,
+  set: (v) => {
+    form.pageCount = typeof v === 'number' && !Number.isNaN(v) ? v : null
+  },
+})
+
+// Re-seed when the parent swaps the book under us (e.g. opening the editor
+// on a different row without unmounting).
+watch(() => props.initial, (next) => {
+  Object.assign(form, {
+    isbn: next.isbn ?? '',
+    title: next.title ?? '',
+    authors: [...(next.authors ?? [])],
+    publisher: next.publisher ?? '',
+    publishedDate: next.publishedDate ?? '',
+    description: next.description ?? '',
+    pageCount: next.pageCount ?? null,
+    thumbnail: next.thumbnail ?? '',
+    categories: [...(next.categories ?? [])],
+    language: next.language ?? '',
+    provider: next.provider ?? '',
+    raw: next.raw ?? null,
+    read: (next as Partial<LibraryBook>).read ?? false,
+    readMotivation: (next as Partial<LibraryBook>).readMotivation ?? 50,
+    physicalCondition: (next as Partial<LibraryBook>).physicalCondition ?? 100,
+    owner: (next as Partial<LibraryBook>).owner ?? '',
+    notes: (next as Partial<LibraryBook>).notes ?? '',
+  })
+})
+
+function onSave() {
+  emit('save', { ...form, authors: [...form.authors], categories: [...form.categories] })
+}
+</script>
+
+<style scoped>
+.input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-line, #d6d3d1);
+  background: var(--color-paper, #fafaf9);
+  color: var(--color-ink, #1c1917);
+  font-size: 0.875rem;
+}
+.input::placeholder {
+  color: var(--color-ink-lighter, #a8a29e);
+}
+.input:focus {
+  outline: none;
+  border-color: var(--color-ink, #1c1917);
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  border-radius: 999px;
+  background: #d6d3d1;
+  transition: background-color 0.2s;
+}
+.toggle-on {
+  background: var(--color-ink, #1c1917);
+}
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s;
+}
+.toggle-on .toggle-knob {
+  transform: translateX(18px);
+}
+</style>

--- a/client/src/components/library/BookJsonModal.vue
+++ b/client/src/components/library/BookJsonModal.vue
@@ -1,0 +1,79 @@
+<template>
+  <div
+    class="fixed inset-0 z-50 bg-black/60 flex items-start sm:items-center justify-center p-4 overflow-y-auto"
+    role="dialog"
+    aria-modal="true"
+    @click.self="emit('close')"
+  >
+    <div class="bg-paper border border-line p-4 sm:p-6 w-full max-w-2xl mt-8 sm:mt-0">
+      <div class="flex items-start justify-between mb-3 gap-3">
+        <div class="min-w-0">
+          <h3 class="text-lg font-light tracking-tight truncate">{{ heading }}</h3>
+          <p v-if="subhead" class="text-xs text-ink-lighter truncate">{{ subhead }}</p>
+        </div>
+        <div class="flex items-center gap-1 shrink-0">
+          <button
+            @click="copy"
+            class="text-xs px-2 py-1 border border-line text-ink-light hover:text-ink"
+            :title="copied ? 'Copied' : 'Copy JSON'"
+          >
+            {{ copied ? 'Copied' : 'Copy' }}
+          </button>
+          <button @click="emit('close')" class="text-ink-lighter hover:text-ink p-1" aria-label="Close">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <pre class="json-pre">{{ pretty }}</pre>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = defineProps<{
+  data: unknown
+  heading: string
+  subhead?: string
+}>()
+
+const emit = defineEmits<{ close: [] }>()
+
+const pretty = computed(() => {
+  try {
+    return JSON.stringify(props.data, null, 2)
+  } catch {
+    return String(props.data)
+  }
+})
+
+const copied = ref(false)
+async function copy() {
+  try {
+    await navigator.clipboard.writeText(pretty.value)
+    copied.value = true
+    setTimeout(() => (copied.value = false), 1500)
+  } catch {
+    // Clipboard access can be blocked — silent fail is fine for a preview.
+  }
+}
+</script>
+
+<style scoped>
+.json-pre {
+  max-height: 60vh;
+  overflow: auto;
+  padding: 0.75rem;
+  background: var(--color-surface, #f5f5f4);
+  border: 1px solid var(--color-line, #d6d3d1);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--color-ink, #1c1917);
+  white-space: pre;
+}
+</style>

--- a/client/src/components/library/IsbnScanner.vue
+++ b/client/src/components/library/IsbnScanner.vue
@@ -87,10 +87,19 @@ import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { BrowserMultiFormatReader, IScannerControls } from '@zxing/browser'
 import { BarcodeFormat, DecodeHintType } from '@zxing/library'
 
+export interface ScanDetectedPayload {
+  isbn: string
+  durationMs: number
+  scanner: 'zxing' | 'manual'
+  format?: string
+}
+
 const emit = defineEmits<{
-  detected: [isbn: string]
+  detected: [payload: ScanDetectedPayload]
   close: []
 }>()
+
+const startedAt = Date.now()
 
 const videoEl = ref<HTMLVideoElement | null>(null)
 const devices = ref<MediaDeviceInfo[]>([])
@@ -158,7 +167,12 @@ async function start() {
           if (text.length === 13 || text.length === 10) {
             if (text !== lastCode.value) {
               lastCode.value = text
-              emit('detected', text)
+              emit('detected', {
+                isbn: text,
+                durationMs: Date.now() - startedAt,
+                scanner: 'zxing',
+                format: result.getBarcodeFormat ? String(result.getBarcodeFormat()) : undefined,
+              })
             }
           }
         }
@@ -208,7 +222,11 @@ function submitManual() {
     cameraError.value = 'ISBN must be 10 or 13 digits.'
     return
   }
-  emit('detected', digits)
+  emit('detected', {
+    isbn: digits,
+    durationMs: Date.now() - startedAt,
+    scanner: 'manual',
+  })
 }
 
 onMounted(async () => {

--- a/client/src/components/library/RangeSlider.vue
+++ b/client/src/components/library/RangeSlider.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="range-slider">
+    <div class="flex items-baseline justify-between mb-1">
+      <label :for="id" class="text-xs uppercase tracking-widest text-ink-lighter">
+        {{ label }}
+      </label>
+      <span class="text-sm font-medium tabular-nums text-ink">{{ value }}</span>
+    </div>
+    <input
+      :id="id"
+      type="range"
+      :min="min"
+      :max="max"
+      :step="step"
+      :value="value"
+      @input="onInput"
+      @wheel.prevent="onWheel"
+      class="w-full range-input"
+    />
+    <div v-if="lowLabel || highLabel" class="flex justify-between text-[10px] uppercase tracking-widest text-ink-lighter mt-1">
+      <span>{{ lowLabel }}</span>
+      <span>{{ highLabel }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * Single-knob 0-100 slider. Backed by a native <input type="range"> so
+ * touch and keyboard work out of the box; a wheel handler lets a mouse
+ * user nudge by 1 with the scroll wheel. The thumb is sized for finger
+ * use on iPad/Android.
+ */
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  modelValue: number
+  label: string
+  min?: number
+  max?: number
+  step?: number
+  lowLabel?: string
+  highLabel?: string
+}>(), {
+  min: 0,
+  max: 100,
+  step: 1,
+  lowLabel: '',
+  highLabel: '',
+})
+
+const emit = defineEmits<{ 'update:modelValue': [value: number] }>()
+
+const id = computed(() => `range-${Math.random().toString(36).slice(2, 9)}`)
+const value = computed(() => clamp(Math.round(props.modelValue), props.min, props.max))
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n))
+}
+
+function onInput(e: Event) {
+  const v = Number((e.target as HTMLInputElement).value)
+  emit('update:modelValue', clamp(Math.round(v), props.min, props.max))
+}
+
+/** Mouse wheel: one notch = one step. Up increases, down decreases. */
+function onWheel(e: WheelEvent) {
+  const delta = e.deltaY > 0 ? -props.step : props.step
+  emit('update:modelValue', clamp(value.value + delta, props.min, props.max))
+}
+</script>
+
+<style scoped>
+.range-input {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  touch-action: pan-y;
+}
+
+/* Track */
+.range-input::-webkit-slider-runnable-track {
+  height: 4px;
+  background: var(--color-line, #d6d3d1);
+  border-radius: 2px;
+}
+.range-input::-moz-range-track {
+  height: 4px;
+  background: var(--color-line, #d6d3d1);
+  border-radius: 2px;
+}
+
+/* Thumb — sized for finger use on touch screens */
+.range-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 22px;
+  width: 22px;
+  background: var(--color-ink, #1c1917);
+  border: 2px solid var(--color-paper, #fafaf9);
+  border-radius: 50%;
+  margin-top: -9px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+.range-input::-moz-range-thumb {
+  height: 22px;
+  width: 22px;
+  background: var(--color-ink, #1c1917);
+  border: 2px solid var(--color-paper, #fafaf9);
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.range-input:focus {
+  outline: none;
+}
+.range-input:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+}
+.range-input:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+}
+</style>

--- a/client/src/pages/MyLibrary.vue
+++ b/client/src/pages/MyLibrary.vue
@@ -29,7 +29,7 @@
         <input
           v-model="search"
           type="search"
-          placeholder="Search title, author, ISBN"
+          placeholder="Search title, author, ISBN, owner"
           class="flex-1 min-w-[12rem] px-3 py-2 border border-line bg-paper text-ink text-sm placeholder:text-ink-lighter"
         />
 
@@ -68,82 +68,57 @@
       aria-modal="true"
       @click.self="closeScanner"
     >
-      <div class="w-full max-w-xl mt-8 sm:mt-0">
+      <div class="w-full max-w-2xl mt-8 sm:mt-0">
         <IsbnScanner
-          v-if="!lookupBusy && !pendingBook"
+          v-if="!lookupBusy && !pendingLookup"
           @detected="handleDetected"
           @close="closeScanner"
         />
 
-        <!-- Lookup spinner -->
-        <div
-          v-else-if="lookupBusy"
-          class="bg-paper border border-line p-6 text-center"
-        >
+        <div v-else-if="lookupBusy" class="bg-paper border border-line p-6 text-center">
           <p class="text-sm text-ink-light">Looking up ISBN {{ pendingIsbn }}&hellip;</p>
         </div>
 
-        <!-- Confirm-before-save sheet -->
-        <div
-          v-else-if="pendingBook"
-          class="bg-paper border border-line p-4 sm:p-6"
-        >
-          <div class="flex items-start justify-between mb-4 gap-3">
-            <h3 class="text-lg font-light tracking-tight">Add this book?</h3>
-            <button @click="closeScanner" class="text-ink-lighter hover:text-ink p-1" aria-label="Cancel">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-
-          <div class="flex gap-4 mb-4">
-            <img
-              v-if="pendingBook.thumbnail"
-              :src="pendingBook.thumbnail"
-              :alt="pendingBook.title"
-              class="w-20 h-28 object-cover border border-line shrink-0"
-            />
-            <div class="flex-1 min-w-0">
-              <p class="text-base font-medium text-ink">{{ pendingBook.title || '(no title)' }}</p>
-              <p v-if="pendingBook.authors.length" class="text-sm text-ink-light">
-                {{ pendingBook.authors.join(', ') }}
-              </p>
-              <p class="text-xs text-ink-lighter mt-1 truncate">
-                ISBN {{ pendingBook.isbn }}<span v-if="pendingBook.publisher"> &middot; {{ pendingBook.publisher }}</span>
-              </p>
-            </div>
-          </div>
-
-          <label class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Notes (optional)</label>
-          <textarea
-            v-model="pendingNotes"
-            rows="3"
-            class="w-full px-3 py-2 border border-line bg-paper text-ink text-sm placeholder:text-ink-lighter"
-            placeholder="Why this book matters to your project…"
-          ></textarea>
-
-          <div v-if="saveError" class="text-sm text-red-700 mt-3">{{ saveError }}</div>
-
-          <div class="flex gap-2 mt-4 justify-end">
-            <button
-              @click="closeScanner"
-              class="px-4 py-2 text-sm tracking-wide font-sans border border-line text-ink-light hover:text-ink"
-              :disabled="saving"
-            >
-              Cancel
-            </button>
-            <button
-              @click="saveBook"
-              :disabled="saving"
-              class="px-4 py-2 bg-ink text-paper text-sm tracking-wide font-sans hover:bg-ink-light transition-colors disabled:opacity-50"
-            >
-              {{ saving ? 'Adding…' : 'Add to library' }}
-            </button>
-          </div>
-        </div>
+        <BookEditor
+          v-else-if="pendingLookup"
+          :initial="pendingLookup"
+          :title="'Add this book?'"
+          :save-label="'Add to library'"
+          :busy="saving"
+          :error-message="saveError"
+          @save="onCreateSave"
+          @cancel="closeScanner"
+        />
       </div>
     </div>
+
+    <!-- Edit modal -->
+    <div
+      v-if="editing"
+      class="fixed inset-0 z-50 bg-black/60 flex items-start sm:items-center justify-center p-4 overflow-y-auto"
+      role="dialog"
+      aria-modal="true"
+      @click.self="cancelEdit"
+    >
+      <BookEditor
+        :initial="editing"
+        :title="'Edit book'"
+        :save-label="'Save changes'"
+        :busy="saving"
+        :error-message="saveError"
+        @save="onUpdateSave"
+        @cancel="cancelEdit"
+      />
+    </div>
+
+    <!-- JSON modal -->
+    <BookJsonModal
+      v-if="jsonViewing"
+      :data="jsonViewing.raw ?? jsonFallback(jsonViewing)"
+      :heading="jsonViewing.title || jsonViewing.isbn"
+      :subhead="jsonViewing.provider ? `ISBN ${jsonViewing.isbn} · via ${jsonViewing.provider}` : `ISBN ${jsonViewing.isbn}`"
+      @close="jsonViewing = null"
+    />
 
     <!-- Body -->
     <div class="w-full px-4 sm:px-6 md:px-8 py-10 sm:py-14 bg-paper">
@@ -192,19 +167,57 @@
                 No cover
               </span>
             </div>
+
             <h3 class="text-sm font-medium text-ink line-clamp-2 mb-1">{{ b.title || '(no title)' }}</h3>
-            <p v-if="b.authors.length" class="text-xs text-ink-light line-clamp-1 mb-2">
+            <p v-if="b.authors.length" class="text-xs text-ink-light line-clamp-1">
               {{ b.authors.join(', ') }}
             </p>
-            <p class="text-[10px] tracking-widest uppercase text-ink-lighter mt-auto">
+            <p class="text-[11px] text-ink-lighter mt-0.5">
+              <span v-if="b.publishedDate">{{ b.publishedDate }}</span>
+              <span v-if="b.publisher && b.publishedDate"> &middot; </span>
+              <span v-if="b.publisher">{{ b.publisher }}</span>
+            </p>
+            <p v-if="b.owner" class="text-[11px] text-ink-light mt-0.5">
+              Owner: {{ b.owner }}
+            </p>
+
+            <!-- Status chips -->
+            <div class="flex flex-wrap gap-1.5 mt-2">
+              <span
+                class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border"
+                :class="b.read ? 'border-ink text-ink' : 'border-line text-ink-lighter'"
+              >
+                {{ b.read ? 'Read' : 'Unread' }}
+              </span>
+              <span class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light" :title="'Want-to-read score (0–100)'">
+                Want {{ b.readMotivation }}
+              </span>
+              <span class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light" :title="'Physical condition (0–100)'">
+                Cond {{ b.physicalCondition }}
+              </span>
+            </div>
+
+            <p class="text-[10px] tracking-widest uppercase text-ink-lighter mt-2">
               ISBN {{ b.isbn }}
             </p>
-            <div class="flex justify-end mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+
+            <!-- Action bar -->
+            <div class="flex items-center justify-end gap-1 mt-2 -mb-1">
+              <button @click="jsonViewing = b" class="icon-btn" :title="'View raw metadata'" aria-label="View raw metadata">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
+              <button @click="startEdit(b)" class="icon-btn" :title="'Edit book'" aria-label="Edit book">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              </button>
               <button
                 @click="handleDelete(b)"
                 :disabled="deleting === b.id"
-                class="p-1 text-ink-lighter hover:text-red-600"
-                title="Remove from library"
+                class="icon-btn hover:!text-red-600"
+                :title="'Remove from library'"
                 aria-label="Remove from library"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -220,7 +233,7 @@
           <li
             v-for="b in filteredBooks"
             :key="b.id"
-            class="flex items-center gap-4 p-3 sm:p-4 hover:bg-surface transition-colors"
+            class="flex items-start sm:items-center gap-4 p-3 sm:p-4 hover:bg-surface transition-colors"
           >
             <img
               v-if="b.thumbnail"
@@ -237,21 +250,47 @@
               <p v-if="b.authors.length" class="text-xs text-ink-light truncate">
                 {{ b.authors.join(', ') }}
               </p>
-              <p class="text-[10px] tracking-widest uppercase text-ink-lighter truncate">
-                ISBN {{ b.isbn }}<span v-if="b.publisher"> &middot; {{ b.publisher }}</span><span v-if="b.publishedDate"> &middot; {{ b.publishedDate }}</span>
+              <p class="text-[11px] text-ink-lighter truncate">
+                <span v-if="b.publishedDate">{{ b.publishedDate }}</span>
+                <span v-if="b.publisher"> &middot; {{ b.publisher }}</span>
+                <span v-if="b.pageCount"> &middot; {{ b.pageCount }} pp</span>
+                <span v-if="b.language"> &middot; {{ b.language }}</span>
               </p>
+              <p class="text-[10px] tracking-widest uppercase text-ink-lighter truncate">
+                ISBN {{ b.isbn }}<span v-if="b.owner"> &middot; Owner: {{ b.owner }}</span>
+              </p>
+              <div class="flex flex-wrap gap-1.5 mt-1">
+                <span
+                  class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border"
+                  :class="b.read ? 'border-ink text-ink' : 'border-line text-ink-lighter'"
+                >{{ b.read ? 'Read' : 'Unread' }}</span>
+                <span class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light">Want {{ b.readMotivation }}</span>
+                <span class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light">Cond {{ b.physicalCondition }}</span>
+              </div>
             </div>
-            <button
-              @click="handleDelete(b)"
-              :disabled="deleting === b.id"
-              class="p-2 text-ink-lighter hover:text-red-600"
-              title="Remove from library"
-              aria-label="Remove from library"
-            >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            <div class="flex items-center gap-1 shrink-0">
+              <button @click="jsonViewing = b" class="icon-btn" :title="'View raw metadata'" aria-label="View raw metadata">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-            </button>
+              </button>
+              <button @click="startEdit(b)" class="icon-btn" :title="'Edit book'" aria-label="Edit book">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              </button>
+              <button
+                @click="handleDelete(b)"
+                :disabled="deleting === b.id"
+                class="icon-btn hover:!text-red-600"
+                :title="'Remove from library'"
+                aria-label="Remove from library"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
           </li>
         </ul>
       </div>
@@ -260,11 +299,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { libraryApi } from '../api/library'
 import { ApiError } from '../api/client'
-import type { LibraryBook, LibraryBookLookup } from '@shared/LibraryBook'
-import IsbnScanner from '../components/library/IsbnScanner.vue'
+import type { LibraryBook, LibraryBookLookup, LibraryBookUpdate } from '@shared/LibraryBook'
+import IsbnScanner, { type ScanDetectedPayload } from '../components/library/IsbnScanner.vue'
+import BookEditor, { type EditorForm } from '../components/library/BookEditor.vue'
+import BookJsonModal from '../components/library/BookJsonModal.vue'
 
 type ViewMode = 'cards' | 'list'
 
@@ -279,14 +320,18 @@ const viewMode = ref<ViewMode>(((): ViewMode => {
   return stored === 'list' ? 'list' : 'cards'
 })())
 
+// Scan / lookup state
 const scannerOpen = ref(false)
 const lookupBusy = ref(false)
 const pendingIsbn = ref<string | null>(null)
-const pendingBook = ref<LibraryBookLookup | null>(null)
-const pendingNotes = ref('')
+const pendingLookup = ref<LibraryBookLookup | null>(null)
 const saving = ref(false)
 const saveError = ref<string | null>(null)
 const deleting = ref<string | null>(null)
+
+// Edit / view state
+const editing = ref<LibraryBook | null>(null)
+const jsonViewing = ref<LibraryBook | LibraryBookLookup | null>(null)
 
 const filteredBooks = computed(() => {
   const q = search.value.trim().toLowerCase()
@@ -295,16 +340,13 @@ const filteredBooks = computed(() => {
     b.title.toLowerCase().includes(q)
     || b.authors.some(a => a.toLowerCase().includes(q))
     || b.isbn.includes(q)
+    || b.owner.toLowerCase().includes(q)
   )
 })
 
-// Persist view choice so a writer keeps their preferred display.
-function setView(v: ViewMode) {
-  viewMode.value = v
+watch(viewMode, v => {
   try { localStorage.setItem(STORAGE_KEY_VIEW, v) } catch { /* ignore */ }
-}
-import { watch } from 'vue'
-watch(viewMode, v => setView(v))
+})
 
 async function load() {
   try {
@@ -322,8 +364,7 @@ function openScanner() {
   scannerOpen.value = true
   lookupBusy.value = false
   pendingIsbn.value = null
-  pendingBook.value = null
-  pendingNotes.value = ''
+  pendingLookup.value = null
   saveError.value = null
 }
 
@@ -331,24 +372,33 @@ function closeScanner() {
   scannerOpen.value = false
   lookupBusy.value = false
   pendingIsbn.value = null
-  pendingBook.value = null
-  pendingNotes.value = ''
+  pendingLookup.value = null
   saveError.value = null
 }
 
-async function handleDetected(isbn: string) {
-  if (lookupBusy.value || pendingBook.value) return
-  pendingIsbn.value = isbn
+async function handleDetected(payload: ScanDetectedPayload) {
+  if (lookupBusy.value || pendingLookup.value) return
+  pendingIsbn.value = payload.isbn
+
+  // Log the scan-phase event (camera/manual reach).
+  libraryApi.logScanEvent({
+    phase: 'scan',
+    isbn: payload.isbn,
+    succeeded: true,
+    durationMs: payload.durationMs,
+    scanner: payload.scanner,
+    provider: payload.format,
+  })
+
   lookupBusy.value = true
   saveError.value = null
   try {
-    pendingBook.value = await libraryApi.lookup(isbn)
+    pendingLookup.value = await libraryApi.lookup(payload.isbn)
   } catch (err) {
     saveError.value = err instanceof Error ? err.message : 'Lookup failed'
-    // Keep dialog open so user can read the error; provide a minimal stub
-    // so they can still save with just the ISBN if they want to.
-    pendingBook.value = {
-      isbn,
+    // Keep the editor open with a stub so the user can fill in by hand.
+    pendingLookup.value = {
+      isbn: payload.isbn,
       title: '',
       authors: [],
       publisher: '',
@@ -358,18 +408,37 @@ async function handleDetected(isbn: string) {
       thumbnail: '',
       categories: [],
       language: '',
+      provider: '',
+      raw: null,
     }
   } finally {
     lookupBusy.value = false
   }
 }
 
-async function saveBook() {
-  if (!pendingBook.value) return
+async function onCreateSave(form: EditorForm) {
   saving.value = true
   saveError.value = null
   try {
-    const created = await libraryApi.create({ ...pendingBook.value, notes: pendingNotes.value })
+    const created = await libraryApi.create({
+      isbn: form.isbn,
+      title: form.title,
+      authors: form.authors,
+      publisher: form.publisher,
+      publishedDate: form.publishedDate,
+      description: form.description,
+      pageCount: form.pageCount,
+      thumbnail: form.thumbnail,
+      categories: form.categories,
+      language: form.language,
+      provider: form.provider,
+      raw: form.raw,
+      read: form.read,
+      readMotivation: form.readMotivation,
+      physicalCondition: form.physicalCondition,
+      owner: form.owner,
+      notes: form.notes,
+    })
     books.value = [created, ...books.value]
     closeScanner()
   } catch (err) {
@@ -378,6 +447,47 @@ async function saveBook() {
     } else {
       saveError.value = err instanceof Error ? err.message : 'Could not save book'
     }
+  } finally {
+    saving.value = false
+  }
+}
+
+function startEdit(b: LibraryBook) {
+  editing.value = b
+  saveError.value = null
+}
+
+function cancelEdit() {
+  editing.value = null
+  saveError.value = null
+}
+
+async function onUpdateSave(form: EditorForm) {
+  if (!editing.value) return
+  saving.value = true
+  saveError.value = null
+  try {
+    const updates: LibraryBookUpdate = {
+      title: form.title,
+      authors: form.authors,
+      publisher: form.publisher,
+      publishedDate: form.publishedDate,
+      description: form.description,
+      pageCount: form.pageCount,
+      thumbnail: form.thumbnail,
+      categories: form.categories,
+      language: form.language,
+      read: form.read,
+      readMotivation: form.readMotivation,
+      physicalCondition: form.physicalCondition,
+      owner: form.owner,
+      notes: form.notes,
+    }
+    const updated = await libraryApi.update(editing.value.id, updates)
+    books.value = books.value.map(x => x.id === updated.id ? updated : x)
+    editing.value = null
+  } catch (err) {
+    saveError.value = err instanceof Error ? err.message : 'Could not save changes'
   } finally {
     saving.value = false
   }
@@ -396,6 +506,25 @@ async function handleDelete(b: LibraryBook) {
   }
 }
 
+/** Fallback for the JSON modal when raw_metadata is absent — synthesize a
+ *  representative object from the saved columns so the inspector is never
+ *  empty (older rows predate raw_metadata). */
+function jsonFallback(b: LibraryBook | LibraryBookLookup): Record<string, unknown> {
+  return {
+    isbn: b.isbn,
+    title: b.title,
+    authors: b.authors,
+    publisher: b.publisher,
+    publishedDate: b.publishedDate,
+    description: b.description,
+    pageCount: b.pageCount,
+    thumbnail: b.thumbnail,
+    categories: b.categories,
+    language: b.language,
+    provider: b.provider,
+  }
+}
+
 onMounted(load)
 </script>
 
@@ -408,6 +537,18 @@ onMounted(load)
 }
 .library-card:hover {
   transform: translateY(-2px);
+}
+.icon-btn {
+  padding: 0.25rem;
+  color: var(--color-ink-lighter, #a8a29e);
+  transition: color 0.2s;
+}
+.icon-btn:hover {
+  color: var(--color-ink, #1c1917);
+}
+.icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .line-clamp-1 {
   display: -webkit-box;

--- a/server/src/controllers/library.controller.ts
+++ b/server/src/controllers/library.controller.ts
@@ -1,24 +1,32 @@
 import { Request, Response } from 'express'
 import Isbn from '@library-pals/isbn'
-import { libraryRepo } from '../repositories/library.repo.js'
+import { libraryRepo, validateScore } from '../repositories/library.repo.js'
+import { libraryTelemetryRepo } from '../repositories/library-telemetry.repo.js'
 import { UnauthorizedError, ValidationError, NotFoundError } from '../utils/errors.js'
-import type { LibraryBookLookup } from '@shared/LibraryBook'
+import type { LibraryBookLookup, LibraryBookUpdate, LibraryScanEventInput } from '@shared/LibraryBook'
 
 const isbnClient = new Isbn()
-// Try Google Books first (richer descriptions/categories), fall back to
-// Open Library so we still get something for older or self-published titles.
 isbnClient.provider(['google', 'openlibrary'])
 
-/** Strip everything but digits and the trailing X allowed by ISBN-10. */
 function normalizeIsbn(raw: string): string {
   return raw.replace(/[^0-9Xx]/g, '').toUpperCase()
 }
 
-/** Accept ISBN-10 or ISBN-13 by length only — the lookup providers will
- *  reject genuinely malformed values, no need to duplicate the checksum
- *  math here. */
 function isValidIsbn(isbn: string): boolean {
   return isbn.length === 10 || isbn.length === 13
+}
+
+/** Best-effort fire-and-forget telemetry. We never let logging failures
+ *  bubble up — the user-facing operation already succeeded or failed on
+ *  its own terms. */
+function logScanEvent(
+  userId: string,
+  event: LibraryScanEventInput,
+  userAgent: string
+): void {
+  libraryTelemetryRepo.record(userId, event, userAgent).catch(err => {
+    console.error('library telemetry write failed', err)
+  })
 }
 
 export const libraryController = {
@@ -33,13 +41,24 @@ export const libraryController = {
     const userId = (req as any).userId
     if (!userId) throw new UnauthorizedError('Authentication required')
 
+    const userAgent = String(req.headers['user-agent'] || '')
     const isbn = normalizeIsbn(String(req.params.isbn || ''))
     if (!isValidIsbn(isbn)) {
+      logScanEvent(userId, {
+        phase: 'lookup',
+        isbn,
+        succeeded: false,
+        errorCode: 'ISBN_INVALID',
+        errorMessage: 'ISBN must be 10 or 13 digits',
+      }, userAgent)
       throw new ValidationError('ISBN must be 10 or 13 digits')
     }
 
+    const startedAt = Date.now()
     try {
       const book = await isbnClient.resolve(isbn, { timeout: 8000 })
+      const provider = book.bookProvider ?? ''
+      const raw: Record<string, unknown> = { ...(book as unknown as Record<string, unknown>) }
       const lookup: LibraryBookLookup = {
         isbn,
         title: book.title ?? '',
@@ -51,12 +70,30 @@ export const libraryController = {
         thumbnail: book.thumbnail ?? '',
         categories: book.categories ?? [],
         language: book.language ?? '',
+        provider,
+        raw,
       }
+
+      logScanEvent(userId, {
+        phase: 'lookup',
+        isbn,
+        succeeded: true,
+        provider,
+        durationMs: Date.now() - startedAt,
+      }, userAgent)
+
       res.json({ data: lookup })
     } catch (err: any) {
-      throw new NotFoundError(
-        `No book found for ISBN ${isbn}${err?.message ? ` (${err.message})` : ''}`
-      )
+      const message = err?.message ?? 'unknown'
+      logScanEvent(userId, {
+        phase: 'lookup',
+        isbn,
+        succeeded: false,
+        errorCode: err?.code ?? 'PROVIDER_NO_HIT',
+        errorMessage: String(message).slice(0, 1000),
+        durationMs: Date.now() - startedAt,
+      }, userAgent)
+      throw new NotFoundError(`No book found for ISBN ${isbn} (${message})`)
     }
   },
 
@@ -68,6 +105,18 @@ export const libraryController = {
     if (!isValidIsbn(isbn)) {
       throw new ValidationError('ISBN must be 10 or 13 digits')
     }
+
+    const read = Boolean(req.body?.read)
+    const readMotivation = req.body?.readMotivation !== undefined
+      ? validateScore(req.body.readMotivation, 'readMotivation')
+      : 50
+    const physicalCondition = req.body?.physicalCondition !== undefined
+      ? validateScore(req.body.physicalCondition, 'physicalCondition')
+      : 100
+
+    const raw = req.body?.raw && typeof req.body.raw === 'object'
+      ? (req.body.raw as Record<string, unknown>)
+      : null
 
     const book = await libraryRepo.create({
       userId,
@@ -81,16 +130,45 @@ export const libraryController = {
       thumbnail: String(req.body?.thumbnail ?? ''),
       categories: Array.isArray(req.body?.categories) ? req.body.categories.map(String) : [],
       language: String(req.body?.language ?? ''),
+      read,
+      readMotivation,
+      physicalCondition,
+      owner: String(req.body?.owner ?? ''),
       notes: String(req.body?.notes ?? ''),
+      provider: String(req.body?.provider ?? ''),
+      raw,
     })
 
     res.status(201).json({ data: book })
   },
 
-  async updateNotes(req: Request, res: Response) {
+  async update(req: Request, res: Response) {
     const userId = (req as any).userId
     if (!userId) throw new UnauthorizedError('Authentication required')
-    const book = await libraryRepo.updateNotes(req.params.id, userId, String(req.body?.notes ?? ''))
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const updates: LibraryBookUpdate = {}
+    if (typeof body.title === 'string') updates.title = body.title
+    if (Array.isArray(body.authors)) updates.authors = body.authors.map(String)
+    if (typeof body.publisher === 'string') updates.publisher = body.publisher
+    if (typeof body.publishedDate === 'string') updates.publishedDate = body.publishedDate
+    if (typeof body.description === 'string') updates.description = body.description
+    if (body.pageCount === null) updates.pageCount = null
+    else if (typeof body.pageCount === 'number') updates.pageCount = body.pageCount
+    if (typeof body.thumbnail === 'string') updates.thumbnail = body.thumbnail
+    if (Array.isArray(body.categories)) updates.categories = body.categories.map(String)
+    if (typeof body.language === 'string') updates.language = body.language
+    if (typeof body.read === 'boolean') updates.read = body.read
+    if (body.readMotivation !== undefined) {
+      updates.readMotivation = validateScore(body.readMotivation, 'readMotivation')
+    }
+    if (body.physicalCondition !== undefined) {
+      updates.physicalCondition = validateScore(body.physicalCondition, 'physicalCondition')
+    }
+    if (typeof body.owner === 'string') updates.owner = body.owner
+    if (typeof body.notes === 'string') updates.notes = body.notes
+
+    const book = await libraryRepo.update(req.params.id, userId, updates)
     res.json({ data: book })
   },
 
@@ -98,6 +176,31 @@ export const libraryController = {
     const userId = (req as any).userId
     if (!userId) throw new UnauthorizedError('Authentication required')
     await libraryRepo.delete(req.params.id, userId)
+    res.status(204).send()
+  },
+
+  async logTelemetry(req: Request, res: Response) {
+    const userId = (req as any).userId
+    if (!userId) throw new UnauthorizedError('Authentication required')
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const phase = body.phase === 'scan' || body.phase === 'lookup' ? body.phase : null
+    if (!phase) {
+      throw new ValidationError('phase must be "scan" or "lookup"')
+    }
+
+    const event: LibraryScanEventInput = {
+      phase,
+      isbn: typeof body.isbn === 'string' ? body.isbn : undefined,
+      succeeded: Boolean(body.succeeded),
+      provider: typeof body.provider === 'string' ? body.provider : undefined,
+      errorCode: typeof body.errorCode === 'string' ? body.errorCode : undefined,
+      errorMessage: typeof body.errorMessage === 'string' ? body.errorMessage : undefined,
+      durationMs: typeof body.durationMs === 'number' ? body.durationMs : undefined,
+      scanner: typeof body.scanner === 'string' ? body.scanner : undefined,
+    }
+
+    logScanEvent(userId, event, String(req.headers['user-agent'] || ''))
     res.status(204).send()
   },
 }

--- a/server/src/db/migrations/032_library_books_personal_fields.sql
+++ b/server/src/db/migrations/032_library_books_personal_fields.sql
@@ -1,0 +1,32 @@
+-- Migration 032: Per-book personal fields + raw provider metadata
+--
+-- Adds the writer's own appraisal of each library book — whether they've
+-- read it, how much they want to (re-)read it, the physical condition of
+-- their copy, and who currently owns it. Plus a JSONB column that stores
+-- the raw provider response so the UI can show the full record on demand
+-- (and so we can mine richer fields later without re-fetching).
+--
+-- All additive; existing rows get the documented defaults.
+
+ALTER TABLE library_books
+  ADD COLUMN IF NOT EXISTS read               BOOLEAN  NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS read_motivation    INTEGER  NOT NULL DEFAULT 50
+    CHECK (read_motivation BETWEEN 0 AND 100),
+  ADD COLUMN IF NOT EXISTS physical_condition INTEGER  NOT NULL DEFAULT 100
+    CHECK (physical_condition BETWEEN 0 AND 100),
+  ADD COLUMN IF NOT EXISTS owner              VARCHAR(255) NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS provider           VARCHAR(32)  NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS raw_metadata       JSONB;
+
+COMMENT ON COLUMN library_books.read IS
+  'Whether the user has read this book.';
+COMMENT ON COLUMN library_books.read_motivation IS
+  '0 = no interest, 100 = strong want-to-read. Applies to re-reads too.';
+COMMENT ON COLUMN library_books.physical_condition IS
+  '0 = wrecked, 100 = mint condition of the user''s physical copy.';
+COMMENT ON COLUMN library_books.owner IS
+  'Free-text owner — could be a person or a shelf/box identifier.';
+COMMENT ON COLUMN library_books.provider IS
+  'Which @library-pals/isbn provider returned this metadata (google, openlibrary, …).';
+COMMENT ON COLUMN library_books.raw_metadata IS
+  'Full provider response, preserved for the JSON-inspector UI.';

--- a/server/src/db/migrations/033_library_scan_events.sql
+++ b/server/src/db/migrations/033_library_scan_events.sql
@@ -1,0 +1,40 @@
+-- Migration 033: ISBN-scan funnel telemetry
+--
+-- Two-phase funnel: a "scan" row is logged by the client when the camera
+-- (or manual entry) yields an ISBN candidate; a "lookup" row is logged by
+-- the server when /api/library/lookup either resolves a provider hit or
+-- fails. Cross-referenced by isbn so the success rate of each phase can
+-- be measured independently.
+--
+-- We keep the table lean: no PII beyond the user_id FK and a user-agent
+-- string (truncated). No location, no IP. Cascade on user delete.
+
+CREATE TABLE IF NOT EXISTS library_scan_events (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+  phase         VARCHAR(16) NOT NULL,
+  isbn          VARCHAR(20) NOT NULL DEFAULT '',
+  succeeded     BOOLEAN     NOT NULL,
+
+  provider      VARCHAR(32) NOT NULL DEFAULT '',
+  error_code    VARCHAR(64) NOT NULL DEFAULT '',
+  error_message TEXT        NOT NULL DEFAULT '',
+  duration_ms   INTEGER,
+  scanner       VARCHAR(32) NOT NULL DEFAULT '',
+  user_agent    VARCHAR(500) NOT NULL DEFAULT '',
+
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT check_library_scan_events_phase
+    CHECK (phase IN ('scan', 'lookup'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_library_scan_events_user_created
+  ON library_scan_events(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_library_scan_events_phase_succeeded
+  ON library_scan_events(phase, succeeded, created_at DESC);
+
+COMMENT ON TABLE library_scan_events IS
+  'Two-phase funnel for ISBN scan + lookup. Used to measure where scans drop off.';

--- a/server/src/repositories/library-telemetry.repo.ts
+++ b/server/src/repositories/library-telemetry.repo.ts
@@ -1,0 +1,35 @@
+import { pool } from '../config/db.js'
+import type { LibraryScanEventInput } from '@shared/LibraryBook'
+
+/** Truncate a string before insertion so we don't blow past column limits. */
+function clip(value: string | undefined, max: number): string {
+  if (!value) return ''
+  return value.length > max ? value.slice(0, max) : value
+}
+
+export const libraryTelemetryRepo = {
+  async record(
+    userId: string,
+    event: LibraryScanEventInput,
+    userAgent: string
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO library_scan_events
+        (user_id, phase, isbn, succeeded, provider, error_code,
+         error_message, duration_ms, scanner, user_agent)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        userId,
+        event.phase,
+        clip(event.isbn, 20),
+        event.succeeded,
+        clip(event.provider, 32),
+        clip(event.errorCode, 64),
+        clip(event.errorMessage, 2000),
+        typeof event.durationMs === 'number' ? Math.round(event.durationMs) : null,
+        clip(event.scanner, 32),
+        clip(userAgent, 500),
+      ]
+    )
+  },
+}

--- a/server/src/repositories/library.repo.ts
+++ b/server/src/repositories/library.repo.ts
@@ -1,23 +1,47 @@
 import { pool } from '../config/db.js'
-import type { LibraryBook } from '@shared/LibraryBook'
-import { ConflictError, NotFoundError, ForbiddenError } from '../utils/errors.js'
+import type { LibraryBook, LibraryBookUpdate } from '@shared/LibraryBook'
+import { ConflictError, NotFoundError, ForbiddenError, ValidationError } from '../utils/errors.js'
 
 const COLUMNS = `
   id,
-  user_id        AS "userId",
+  user_id            AS "userId",
   isbn,
   title,
   authors,
   publisher,
-  published_date AS "publishedDate",
+  published_date     AS "publishedDate",
   description,
-  page_count     AS "pageCount",
+  page_count         AS "pageCount",
   thumbnail,
   categories,
   language,
+  read,
+  read_motivation    AS "readMotivation",
+  physical_condition AS "physicalCondition",
+  owner,
   notes,
-  created_at     AS "createdAt"
+  provider,
+  raw_metadata       AS "raw",
+  created_at         AS "createdAt"
 `
+
+/** Columns the user can patch via the general update endpoint. */
+const UPDATABLE_COLUMNS: Record<keyof LibraryBookUpdate, string> = {
+  title: 'title',
+  authors: 'authors',
+  publisher: 'publisher',
+  publishedDate: 'published_date',
+  description: 'description',
+  pageCount: 'page_count',
+  thumbnail: 'thumbnail',
+  categories: 'categories',
+  language: 'language',
+  read: 'read',
+  readMotivation: 'read_motivation',
+  physicalCondition: 'physical_condition',
+  owner: 'owner',
+  notes: 'notes',
+}
 
 export const libraryRepo = {
   async listForUser(userId: string): Promise<LibraryBook[]> {
@@ -36,13 +60,18 @@ export const libraryRepo = {
     return result.rows[0] ?? null
   },
 
-  async create(book: Omit<LibraryBook, 'id' | 'createdAt'>): Promise<LibraryBook> {
+  async create(
+    book: Omit<LibraryBook, 'id' | 'createdAt'>
+  ): Promise<LibraryBook> {
     try {
       const result = await pool.query(
         `INSERT INTO library_books
           (user_id, isbn, title, authors, publisher, published_date,
-           description, page_count, thumbnail, categories, language, notes)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+           description, page_count, thumbnail, categories, language,
+           read, read_motivation, physical_condition, owner, notes,
+           provider, raw_metadata)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                 $12, $13, $14, $15, $16, $17, $18)
          RETURNING ${COLUMNS}`,
         [
           book.userId,
@@ -56,13 +85,17 @@ export const libraryRepo = {
           book.thumbnail,
           book.categories,
           book.language,
+          book.read,
+          book.readMotivation,
+          book.physicalCondition,
+          book.owner,
           book.notes,
+          book.provider,
+          book.raw,
         ]
       )
       return result.rows[0]
     } catch (err: any) {
-      // 23505 = unique_violation. Surfaces the friendly "already in your
-      // library" error in the controller without leaking SQL state.
       if (err?.code === '23505') {
         throw new ConflictError('This ISBN is already in your library')
       }
@@ -70,16 +103,39 @@ export const libraryRepo = {
     }
   },
 
-  async updateNotes(id: string, userId: string, notes: string): Promise<LibraryBook> {
+  async update(id: string, userId: string, updates: LibraryBookUpdate): Promise<LibraryBook> {
     const existing = await pool.query('SELECT user_id FROM library_books WHERE id = $1', [id])
     if (existing.rows.length === 0) throw new NotFoundError('Library book not found')
     if (existing.rows[0].user_id !== userId) {
       throw new ForbiddenError('Not authorized to update this library book')
     }
+
+    const fields: string[] = []
+    const values: unknown[] = []
+    let i = 1
+    for (const key of Object.keys(updates) as (keyof LibraryBookUpdate)[]) {
+      if (updates[key] === undefined) continue
+      const column = UPDATABLE_COLUMNS[key]
+      if (!column) continue
+      fields.push(`${column} = $${i++}`)
+      values.push(updates[key])
+    }
+
+    if (fields.length === 0) {
+      // Nothing to update — return current row.
+      const cur = await pool.query(
+        `SELECT ${COLUMNS} FROM library_books WHERE id = $1`,
+        [id]
+      )
+      return cur.rows[0]
+    }
+
+    values.push(id)
     const result = await pool.query(
-      `UPDATE library_books SET notes = $1 WHERE id = $2 RETURNING ${COLUMNS}`,
-      [notes, id]
+      `UPDATE library_books SET ${fields.join(', ')} WHERE id = $${i} RETURNING ${COLUMNS}`,
+      values
     )
+    if (result.rowCount === 0) throw new NotFoundError('Library book not found')
     return result.rows[0]
   },
 
@@ -91,4 +147,12 @@ export const libraryRepo = {
     }
     await pool.query('DELETE FROM library_books WHERE id = $1', [id])
   },
+}
+
+/** Range-validate an integer 0..100. Throws ValidationError on bad input. */
+export function validateScore(value: unknown, fieldName: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 100) {
+    throw new ValidationError(`${fieldName} must be an integer between 0 and 100`)
+  }
+  return value
 }

--- a/server/src/routes/library.routes.ts
+++ b/server/src/routes/library.routes.ts
@@ -10,7 +10,8 @@ router.use(authMiddleware)
 router.get('/', asyncHandler(libraryController.list))
 router.get('/lookup/:isbn', asyncHandler(libraryController.lookup))
 router.post('/', asyncHandler(libraryController.create))
-router.patch('/:id/notes', asyncHandler(libraryController.updateNotes))
+router.post('/telemetry', asyncHandler(libraryController.logTelemetry))
+router.patch('/:id', asyncHandler(libraryController.update))
 router.delete('/:id', asyncHandler(libraryController.delete))
 
 export default router

--- a/shared/LibraryBook.ts
+++ b/shared/LibraryBook.ts
@@ -5,8 +5,12 @@
  * Library, et al.
  *
  * `isbn` is the canonical key the user scanned (ISBN-10 or ISBN-13, digits
- * only). All other fields come from the lookup provider and may be empty
+ * only). The metadata fields come from the lookup provider and may be empty
  * when the provider has nothing for a given record.
+ *
+ * Personal fields (read / readMotivation / physicalCondition / owner /
+ * notes) live alongside the metadata so a writer can keep their own
+ * appraisal of each book — defaults are applied at insertion.
  */
 export interface LibraryBook {
   id: string
@@ -21,12 +25,76 @@ export interface LibraryBook {
   thumbnail: string
   categories: string[]
   language: string
+
+  /** Whether the user has read this book. */
+  read: boolean
+  /** 0 = no interest in (re-)reading, 100 = strong want-to-read. */
+  readMotivation: number
+  /** 0 = wrecked, 100 = mint. */
+  physicalCondition: number
+  /** Who currently owns this copy (free-text — could be a person or a shelf). */
+  owner: string
   notes: string
+
+  /** Provider that returned the metadata, when known (google, openlibrary, …). */
+  provider: string
+  /** Full lookup-provider response, preserved for the JSON inspector. */
+  raw: Record<string, unknown> | null
+
   createdAt: string
 }
 
 /**
- * Shape of what the ISBN-lookup endpoint returns before the book is saved.
- * Same fields as LibraryBook minus the persistence-only ones.
+ * Shape returned by the ISBN-lookup endpoint before the book is saved.
+ * Has the metadata + provider/raw, but no personal fields or persistence
+ * columns — the UI applies personal-field defaults at save time.
  */
-export type LibraryBookLookup = Omit<LibraryBook, 'id' | 'userId' | 'notes' | 'createdAt'>
+export type LibraryBookLookup = Omit<
+  LibraryBook,
+  'id' | 'userId' | 'createdAt' | 'read' | 'readMotivation' | 'physicalCondition' | 'owner' | 'notes'
+>
+
+/** Fields the user can edit after the book is saved. */
+export interface LibraryBookUpdate {
+  title?: string
+  authors?: string[]
+  publisher?: string
+  publishedDate?: string
+  description?: string
+  pageCount?: number | null
+  thumbnail?: string
+  categories?: string[]
+  language?: string
+  read?: boolean
+  readMotivation?: number
+  physicalCondition?: number
+  owner?: string
+  notes?: string
+}
+
+/**
+ * Phase of an ISBN-scan funnel event. `scan` is the camera-side decode;
+ * `lookup` is the server-side metadata fetch.
+ */
+export type LibraryScanPhase = 'scan' | 'lookup'
+
+/**
+ * Client-emitted telemetry for the scan phase. The server attaches user_id
+ * and inserts a row in library_scan_events; the page later POSTs another
+ * event for the lookup phase based on the API response.
+ */
+export interface LibraryScanEventInput {
+  phase: LibraryScanPhase
+  isbn?: string
+  succeeded: boolean
+  /** Provider that returned data (lookup phase). */
+  provider?: string
+  /** Short machine-readable error tag (e.g. "ISBN_INVALID", "PROVIDER_404"). */
+  errorCode?: string
+  /** Human-readable error message (truncated server-side). */
+  errorMessage?: string
+  /** How long the phase took, in milliseconds. */
+  durationMs?: number
+  /** Which scanner produced the read (zxing | barcodedetector | manual). */
+  scanner?: string
+}


### PR DESCRIPTION
## Summary
- **Personal fields per book** — `read` toggle, `read_motivation` 0–100 (covers want-to-read *and* want-to-re-read), `physical_condition` 0–100, and `owner` free-text. Captured at scan-confirm time and editable afterwards.
- **More metadata on display** — cards & list now show authors, published date, publisher, page count, language, owner, plus chips for Read / Want / Cond.
- **Raw-metadata inspector** — an info icon opens a JSON modal showing the full provider response (preserved in a new `raw_metadata` JSONB column, with a synthesised fallback for older rows).
- **Manual edit** — a pencil-icon modal lets the writer fix wrong/missing title/authors/cover/etc. and adjust personal fields. Backed by a new `PATCH /api/library/:id`.
- **Custom range slider** — touch-friendly thumb, native keyboard, scroll-wheel for 1-point nudges with a mouse. Used for both motivation and condition.
- **Scan-funnel telemetry** — `library_scan_events` table records both phases (`scan` from the client, `lookup` from the server) with provider, error code, duration, scanner kind, and user-agent. Lets us measure where the 30%-success drop-off actually lives before reaching for more providers.

## Test plan
- [ ] `npm run migrate` applies `032_library_books_personal_fields.sql` and `033_library_scan_events.sql` cleanly
- [ ] Scan a new book → BookEditor opens prefilled; toggle Read, drag both sliders (touch + mouse + scroll wheel), set Owner, save → row appears with all fields
- [ ] Click info icon on an existing row → JSON modal opens with `bookProvider`, `categories`, etc.; Copy works
- [ ] Click pencil icon on an existing row → edit modal opens, change Title and condition, save → row updates without a re-scan
- [ ] Confirm scan telemetry: open psql and check rows in `library_scan_events` after a scan attempt (both phases recorded)
- [ ] Try an unknown ISBN: lookup fails → editor opens with stub data; user can still hand-key and save; telemetry row records `succeeded = false` with `error_message`
- [ ] `npm run type-check` passes in `client` and `server` (verified locally)

## Follow-up (separate PR)
- Wider provider chain (ISBNdb + LOC + ISBN-10↔13 retry) once we have a week of telemetry showing whether lookup is the bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)