### PR TITLE
Bypass unauthenticated Google Books for ISBN lookups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ CORS_ORIGIN=http://localhost:5178
 JWT_SECRET=change-me-in-production-use-strong-random-secret
 JWT_EXPIRES_IN=7d
 APP_NAME=Befly
+# Optional. Without it, MyLibrary ISBN lookups hit Google Books unauthenticated
+# and get rate-limited (HTTP 429) within a handful of requests on shared
+# hosting IPs. Get one at https://console.cloud.google.com/apis/credentials.
+GOOGLE_BOOKS_API_KEY=

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -18,5 +18,14 @@ export const config = {
   },
   get appName() {
     return getEnv('APP_NAME', 'Rambulations')
+  },
+  /**
+   * Google Books API key. Optional — when set, ISBN lookups authenticate
+   * with the key, lifting the strict unauthenticated quota that otherwise
+   * 429s most production traffic. Empty string means "unauthenticated,
+   * accept the lower quota".
+   */
+  get googleBooksApiKey() {
+    return getEnv('GOOGLE_BOOKS_API_KEY', '')
   }
 }

--- a/server/src/controllers/library.controller.ts
+++ b/server/src/controllers/library.controller.ts
@@ -1,12 +1,9 @@
 import { Request, Response } from 'express'
-import Isbn from '@library-pals/isbn'
 import { libraryRepo, validateScore } from '../repositories/library.repo.js'
 import { libraryTelemetryRepo } from '../repositories/library-telemetry.repo.js'
+import { lookupIsbn, type ProviderAttempt } from '../services/isbn-lookup.service.js'
 import { UnauthorizedError, ValidationError, NotFoundError } from '../utils/errors.js'
-import type { LibraryBookLookup, LibraryBookUpdate, LibraryScanEventInput } from '@shared/LibraryBook'
-
-const isbnClient = new Isbn()
-isbnClient.provider(['google', 'openlibrary'])
+import type { LibraryBookUpdate, LibraryScanEventInput } from '@shared/LibraryBook'
 
 function normalizeIsbn(raw: string): string {
   return raw.replace(/[^0-9Xx]/g, '').toUpperCase()
@@ -27,6 +24,22 @@ function logScanEvent(
   libraryTelemetryRepo.record(userId, event, userAgent).catch(err => {
     console.error('library telemetry write failed', err)
   })
+}
+
+/** Record one telemetry row per provider attempt — gives us the breakdown
+ *  needed to see which provider is actually carrying the load. */
+function logAttempts(userId: string, attempts: ProviderAttempt[], userAgent: string): void {
+  for (const a of attempts) {
+    logScanEvent(userId, {
+      phase: 'lookup',
+      isbn: a.isbn,
+      succeeded: a.succeeded,
+      provider: a.provider,
+      errorCode: a.errorCode,
+      errorMessage: a.errorMessage,
+      durationMs: a.durationMs,
+    }, userAgent)
+  }
 }
 
 export const libraryController = {
@@ -54,46 +67,17 @@ export const libraryController = {
       throw new ValidationError('ISBN must be 10 or 13 digits')
     }
 
-    const startedAt = Date.now()
     try {
-      const book = await isbnClient.resolve(isbn, { timeout: 8000 })
-      const provider = book.bookProvider ?? ''
-      const raw: Record<string, unknown> = { ...(book as unknown as Record<string, unknown>) }
-      const lookup: LibraryBookLookup = {
-        isbn,
-        title: book.title ?? '',
-        authors: book.authors ?? [],
-        publisher: book.publisher ?? '',
-        publishedDate: book.publishedDate ?? '',
-        description: book.description ?? '',
-        pageCount: typeof book.pageCount === 'number' ? book.pageCount : null,
-        thumbnail: book.thumbnail ?? '',
-        categories: book.categories ?? [],
-        language: book.language ?? '',
-        provider,
-        raw,
-      }
-
-      logScanEvent(userId, {
-        phase: 'lookup',
-        isbn,
-        succeeded: true,
-        provider,
-        durationMs: Date.now() - startedAt,
-      }, userAgent)
-
-      res.json({ data: lookup })
+      const { data, attempts } = await lookupIsbn(isbn)
+      logAttempts(userId, attempts, userAgent)
+      res.json({ data })
     } catch (err: any) {
-      const message = err?.message ?? 'unknown'
-      logScanEvent(userId, {
-        phase: 'lookup',
-        isbn,
-        succeeded: false,
-        errorCode: err?.code ?? 'PROVIDER_NO_HIT',
-        errorMessage: String(message).slice(0, 1000),
-        durationMs: Date.now() - startedAt,
-      }, userAgent)
-      throw new NotFoundError(`No book found for ISBN ${isbn} (${message})`)
+      const attempts: ProviderAttempt[] = Array.isArray(err?.attempts) ? err.attempts : []
+      logAttempts(userId, attempts, userAgent)
+      const summary = attempts.length
+        ? attempts.map(a => `${a.provider}:${a.errorCode ?? 'ok'}`).join(', ')
+        : (err?.message ?? 'unknown')
+      throw new NotFoundError(`No book found for ISBN ${isbn} (${summary})`)
     }
   },
 

--- a/server/src/services/isbn-lookup.service.ts
+++ b/server/src/services/isbn-lookup.service.ts
@@ -1,0 +1,240 @@
+/**
+ * ISBN lookup with a small fallback chain:
+ *
+ *   1. Google Books, called directly with an API key (when configured).
+ *      `@library-pals/isbn` calls Google unauthenticated, which 429s
+ *      almost immediately on shared egress IPs (Heroku, etc.) — telemetry
+ *      showed 0% Google success in production. Authenticating lifts the
+ *      quota to 1000 req/day per key.
+ *   2. Open Library via @library-pals/isbn (its parser is the strongest
+ *      and we already depend on the package).
+ *   3. If both miss and the ISBN can be converted between 10 and 13
+ *      digits, repeat the chain with the alternate form. Some providers
+ *      only index one form.
+ *
+ * Every provider call is wrapped — a JS crash inside one parser must NOT
+ * end the chain. Each attempt returns a structured outcome so the
+ * controller can log per-provider telemetry rows.
+ */
+import Isbn, { type Book as PalsBook } from '@library-pals/isbn'
+import type { LibraryBookLookup } from '@shared/LibraryBook'
+import { config } from '../config/env.js'
+
+const PROVIDER_GOOGLE = 'google'
+const PROVIDER_OPENLIBRARY = 'openlibrary'
+
+const GOOGLE_BOOKS_URL = 'https://www.googleapis.com/books/v1/volumes'
+
+const fallbackClient = new Isbn()
+fallbackClient.provider([PROVIDER_OPENLIBRARY])
+
+export interface ProviderAttempt {
+  provider: string
+  /** ISBN form actually queried (may differ from the user-supplied form). */
+  isbn: string
+  succeeded: boolean
+  errorCode?: string
+  errorMessage?: string
+  durationMs: number
+}
+
+export interface IsbnLookupResult {
+  data: LibraryBookLookup
+  attempts: ProviderAttempt[]
+}
+
+/**
+ * Convert an ISBN-13 with the 978 prefix to its ISBN-10 equivalent. ISBN-13
+ * with 979 prefix has no ISBN-10. Returns null for any non-convertible form.
+ */
+export function isbn13to10(isbn13: string): string | null {
+  if (isbn13.length !== 13 || !isbn13.startsWith('978')) return null
+  const core = isbn13.slice(3, 12)
+  let sum = 0
+  for (let i = 0; i < 9; i++) {
+    const d = parseInt(core[i]!, 10)
+    if (Number.isNaN(d)) return null
+    sum += d * (10 - i)
+  }
+  const check = (11 - (sum % 11)) % 11
+  return core + (check === 10 ? 'X' : String(check))
+}
+
+/** Convert any ISBN-10 to its canonical 978-prefixed ISBN-13. */
+export function isbn10to13(isbn10: string): string | null {
+  if (isbn10.length !== 10) return null
+  const core = '978' + isbn10.slice(0, 9)
+  let sum = 0
+  for (let i = 0; i < 12; i++) {
+    const d = parseInt(core[i]!, 10)
+    if (Number.isNaN(d)) return null
+    sum += d * (i % 2 === 0 ? 1 : 3)
+  }
+  const check = (10 - (sum % 10)) % 10
+  return core + String(check)
+}
+
+/** Best-effort short error code from a thrown error or HTTP status. */
+function classifyError(err: unknown, status?: number): string {
+  if (status === 429) return 'RATE_LIMITED'
+  if (status === 404) return 'NOT_FOUND'
+  if (status && status >= 500) return 'PROVIDER_5XX'
+  if (status && status >= 400) return `PROVIDER_${status}`
+  const msg = (err as any)?.message ?? String(err)
+  if (/timeout/i.test(msg)) return 'TIMEOUT'
+  if (/Cannot read properties of undefined/i.test(msg)) return 'PARSER_CRASH'
+  if (/ENOTFOUND|ECONNREFUSED|ECONNRESET|EAI_AGAIN/i.test(msg)) return 'NETWORK'
+  return 'PROVIDER_ERROR'
+}
+
+async function tryGoogleBooks(isbn: string): Promise<LibraryBookLookup> {
+  const url = new URL(GOOGLE_BOOKS_URL)
+  url.searchParams.set('q', `isbn:${isbn}`)
+  url.searchParams.set('maxResults', '1')
+  const key = config.googleBooksApiKey
+  if (key) url.searchParams.set('key', key)
+
+  // 8s ceiling per provider — three providers in a chain shouldn't keep a
+  // user waiting longer than the request timeout.
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 8000)
+  let res: Response
+  try {
+    res = await fetch(url, { signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+
+  if (!res.ok) {
+    const err = new Error(`Google Books responded ${res.status}`) as Error & { status: number }
+    err.status = res.status
+    throw err
+  }
+
+  const json = (await res.json()) as {
+    items?: Array<{ volumeInfo?: Record<string, unknown> }>
+  }
+  if (!json.items || json.items.length === 0) {
+    const err = new Error('Google Books returned no items') as Error & { status: number }
+    err.status = 404
+    throw err
+  }
+
+  const volume = json.items[0]
+  const info = (volume?.volumeInfo ?? {}) as Record<string, unknown>
+  return {
+    isbn,
+    title: typeof info.title === 'string' ? info.title : '',
+    authors: Array.isArray(info.authors) ? (info.authors as string[]) : [],
+    publisher: typeof info.publisher === 'string' ? info.publisher : '',
+    publishedDate: typeof info.publishedDate === 'string' ? info.publishedDate : '',
+    description: typeof info.description === 'string' ? info.description : '',
+    pageCount: typeof info.pageCount === 'number' ? info.pageCount : null,
+    thumbnail: pickThumbnail(info),
+    categories: Array.isArray(info.categories) ? (info.categories as string[]) : [],
+    language: typeof info.language === 'string' ? info.language : '',
+    provider: PROVIDER_GOOGLE,
+    raw: volume as Record<string, unknown>,
+  }
+}
+
+function pickThumbnail(info: Record<string, unknown>): string {
+  const links = info.imageLinks as Record<string, unknown> | undefined
+  if (!links) return ''
+  const order = ['thumbnail', 'smallThumbnail', 'small', 'medium', 'large']
+  for (const k of order) {
+    const v = links[k]
+    if (typeof v === 'string') return v.replace(/^http:/, 'https:')
+  }
+  return ''
+}
+
+async function tryOpenLibrary(isbn: string): Promise<LibraryBookLookup> {
+  const book = await fallbackClient.resolve(isbn, { timeout: 8000 }) as PalsBook
+  return {
+    isbn,
+    title: book.title ?? '',
+    authors: book.authors ?? [],
+    publisher: book.publisher ?? '',
+    publishedDate: book.publishedDate ?? '',
+    description: book.description ?? '',
+    pageCount: typeof book.pageCount === 'number' ? book.pageCount : null,
+    thumbnail: book.thumbnail ?? '',
+    categories: book.categories ?? [],
+    language: book.language ?? '',
+    provider: book.bookProvider || PROVIDER_OPENLIBRARY,
+    raw: book as unknown as Record<string, unknown>,
+  }
+}
+
+/**
+ * Run one provider attempt with a try/catch + timer. A crash never bubbles
+ * out — the caller gets a structured outcome and decides what to do.
+ */
+async function runAttempt(
+  provider: string,
+  isbn: string,
+  fn: () => Promise<LibraryBookLookup>
+): Promise<{ ok: true; data: LibraryBookLookup; attempt: ProviderAttempt } | { ok: false; attempt: ProviderAttempt }> {
+  const startedAt = Date.now()
+  try {
+    const data = await fn()
+    return {
+      ok: true,
+      data,
+      attempt: { provider, isbn, succeeded: true, durationMs: Date.now() - startedAt },
+    }
+  } catch (err: any) {
+    return {
+      ok: false,
+      attempt: {
+        provider,
+        isbn,
+        succeeded: false,
+        errorCode: classifyError(err, err?.status),
+        errorMessage: String(err?.message ?? err).slice(0, 400),
+        durationMs: Date.now() - startedAt,
+      },
+    }
+  }
+}
+
+/** Run Google → Open Library against one ISBN form. */
+async function tryChain(isbn: string): Promise<{ data?: LibraryBookLookup; attempts: ProviderAttempt[] }> {
+  const attempts: ProviderAttempt[] = []
+
+  const g = await runAttempt(PROVIDER_GOOGLE, isbn, () => tryGoogleBooks(isbn))
+  attempts.push(g.attempt)
+  if (g.ok) return { data: g.data, attempts }
+
+  const o = await runAttempt(PROVIDER_OPENLIBRARY, isbn, () => tryOpenLibrary(isbn))
+  attempts.push(o.attempt)
+  if (o.ok) return { data: o.data, attempts }
+
+  return { attempts }
+}
+
+/**
+ * Main entry. Throws an Error with `.attempts` attached if nothing matches.
+ * `userIsbn` is what the user originally scanned — that form is preserved on
+ * the returned data even when a conversion was needed.
+ */
+export async function lookupIsbn(userIsbn: string): Promise<IsbnLookupResult> {
+  const allAttempts: ProviderAttempt[] = []
+
+  const first = await tryChain(userIsbn)
+  allAttempts.push(...first.attempts)
+  if (first.data) return { data: { ...first.data, isbn: userIsbn }, attempts: allAttempts }
+
+  // Convert and try again with the alternate form.
+  const alt = userIsbn.length === 13 ? isbn13to10(userIsbn) : userIsbn.length === 10 ? isbn10to13(userIsbn) : null
+  if (alt && alt !== userIsbn) {
+    const second = await tryChain(alt)
+    allAttempts.push(...second.attempts)
+    if (second.data) return { data: { ...second.data, isbn: userIsbn }, attempts: allAttempts }
+  }
+
+  const error = new Error('No provider returned a record for this ISBN') as Error & { attempts: ProviderAttempt[] }
+  error.attempts = allAttempts
+  throw error
+}


### PR DESCRIPTION
## Summary
- New `isbn-lookup.service.ts` that calls **Google Books directly** with `GOOGLE_BOOKS_API_KEY` — bypasses `@library-pals/isbn`'s unauthenticated path which was hitting HTTP 429 on every production lookup.
- **Open Library** still serves as fallback via `@library-pals/isbn`.
- **ISBN-10 ↔ ISBN-13 retry**: if both providers miss the supplied form, convert (978-prefixed ISBN-13 ↔ ISBN-10) and retry the chain with the alternate form. Verified the conversion math against a known pair and all six failing ISBNs from prod telemetry; all round-trip cleanly, including the `X` check-digit case.
- **Per-provider guards**: each call runs in its own try/catch + timer; a parser crash in one source (e.g. the `Cannot read properties of undefined` Open Library was throwing) becomes a structured `PARSER_CRASH` error code instead of taking down the whole chain.
- **Richer telemetry**: each provider attempt now logs its own `library_scan_events` row (previously one row per request), so future dashboards can show `google` vs `openlibrary` success independently. Classified error codes — `RATE_LIMITED`, `NOT_FOUND`, `PARSER_CRASH`, `TIMEOUT`, `NETWORK`, `PROVIDER_5XX`, etc.

## Baseline (production telemetry, 14 lookups before this change)
| Phase | Hits | Misses | % |
|---|---|---|---|
| scan | 14 | 0 | **100%** |
| lookup | 4 | 10 | **28.6%** |

All 10 lookup failures were `google: 429 + openlibrary: 404/parser crash`. With the key set, Google's quota goes from ~5 unauthenticated/IP/day to **1000/day per key**.

## Deploy steps
```bash
heroku config:set GOOGLE_BOOKS_API_KEY=<your-key> --app befly
```
Key already provisioned per chat.

## Test plan
- [ ] After deploy, scan a book that previously failed; expect `success` row with `provider = google`
- [ ] Verify telemetry shows per-attempt rows:
  ```sql
  SELECT phase, provider,
         COUNT(*) FILTER (WHERE succeeded) AS hits,
         COUNT(*) FILTER (WHERE NOT succeeded) AS misses
  FROM library_scan_events
  WHERE created_at > NOW() - INTERVAL '1 day'
  GROUP BY phase, provider
  ORDER BY phase, hits DESC;
  ```
- [ ] Force a deliberate miss (random 13-digit number) → 404 returned to client, lookup events show both providers tried for both ISBN forms
- [ ] `npm run type-check` in `server/` (verified locally — exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)