### PR TITLE
Polish MyLibrary details modal and add rapid-scan mode (0.5.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the Rambulations writing platform are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.15] - 2026-05-18
+
+### Added
+- **MyLibrary** — new `/library` view backed by a per-user `library_books` table. Books are added by scanning a back-cover barcode (ZXing via `@zxing/browser`, works on iPad iOS Safari, Android Chrome, and MacBook) and enriched server-side via Google Books → Open Library fallback.
+- **Personal fields per book** — `read` toggle, two 0–100 sliders for `read_motivation` (covers re-reads too) and `physical_condition`, and free-text `owner`. New `RangeSlider` component is touch-friendly with mouse scroll-wheel for 1-point nudges.
+- **Card / list toggle** — view-mode choice persists in `localStorage`; search across title, authors, ISBN, owner.
+- **Manual edit** of any book via a pencil-icon modal (`PATCH /api/library/:id`).
+- **Book details modal** — UI-consistent structured view with cover, bibliographic grid, categories, description, personal appraisal, preview link (when the provider returns one), and a collapsible raw JSON pane with Copy button.
+- **Rapid scan mode** — toggle in the scanner; auto-saves each scan with personal-field defaults, plays a positive Web Audio chime on hit and a negative bonk on miss/duplicate, keeps the camera live for the next book.
+- **Categories chips** — cards and list show first 2 categories with a `+N` touch-tap expand.
+- **Scan-funnel telemetry** — new `library_scan_events` table records one row per provider attempt (phase, provider, error code, duration, scanner, user-agent) so we can measure where scans drop off.
+
+### Changed
+- **ISBN lookup chain** — bypassed `@library-pals/isbn`'s unauthenticated Google call (was 429-throttled on Heroku egress IPs, contributing 0% in production). New `isbn-lookup.service.ts` calls Google Books directly with `GOOGLE_BOOKS_API_KEY`, falls back to Open Library, then retries the whole chain with the alternate ISBN form (ISBN-10 ↔ ISBN-13). Each provider call is wrapped — a JS parser crash in one source no longer kills the chain.
+- Version bump 0.5.14 → 0.5.15.
+
+### Database
+- Migration 031: `library_books`.
+- Migration 032: per-book personal fields + `provider` + `raw_metadata` JSONB.
+- Migration 033: `library_scan_events`.
+
+### Deploy notes
+- Set `GOOGLE_BOOKS_API_KEY` on Heroku before deploying — without it, lookups fall back to unauthenticated Google quota and 429 quickly.
+
+---
+
 ## [0.5.10] - 2026-05-06
 
 ### Changed

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/client",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/components/library/BookJsonModal.vue
+++ b/client/src/components/library/BookJsonModal.vue
@@ -5,19 +5,21 @@
     aria-modal="true"
     @click.self="emit('close')"
   >
-    <div class="bg-paper border border-line p-4 sm:p-6 w-full max-w-2xl mt-8 sm:mt-0">
-      <div class="flex items-start justify-between mb-3 gap-3">
+    <div class="bg-paper border border-line w-full max-w-2xl mt-8 sm:mt-0 max-h-[90vh] flex flex-col">
+      <!-- Header -->
+      <div class="flex items-start justify-between gap-3 p-4 sm:p-6 border-b border-line">
         <div class="min-w-0">
-          <h3 class="text-lg font-light tracking-tight truncate">{{ heading }}</h3>
-          <p v-if="subhead" class="text-xs text-ink-lighter truncate">{{ subhead }}</p>
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-1">Book details</p>
+          <h3 class="text-lg font-light tracking-tight text-ink truncate">{{ heading || 'Untitled' }}</h3>
+          <p v-if="subhead" class="text-xs text-ink-light truncate mt-0.5">{{ subhead }}</p>
         </div>
         <div class="flex items-center gap-1 shrink-0">
           <button
-            @click="copy"
-            class="text-xs px-2 py-1 border border-line text-ink-light hover:text-ink"
-            :title="copied ? 'Copied' : 'Copy JSON'"
+            @click="copyRaw"
+            class="text-xs px-2 py-1 border border-line text-ink-light hover:text-ink transition-colors"
+            :title="copied ? 'Copied' : 'Copy raw JSON to clipboard'"
           >
-            {{ copied ? 'Copied' : 'Copy' }}
+            {{ copied ? 'Copied' : 'Copy JSON' }}
           </button>
           <button @click="emit('close')" class="text-ink-lighter hover:text-ink p-1" aria-label="Close">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -27,32 +29,171 @@
         </div>
       </div>
 
-      <pre class="json-pre">{{ pretty }}</pre>
+      <!-- Body -->
+      <div class="overflow-y-auto p-4 sm:p-6 space-y-6">
+        <!-- Cover + bibliographic grid -->
+        <div class="flex gap-4 items-start">
+          <img
+            v-if="book.thumbnail"
+            :src="book.thumbnail"
+            :alt="book.title || book.isbn"
+            class="w-24 h-32 sm:w-28 sm:h-36 object-cover border border-line shrink-0"
+          />
+          <div
+            v-else
+            class="w-24 h-32 sm:w-28 sm:h-36 bg-surface border border-line shrink-0 flex items-center justify-center text-[10px] tracking-widest uppercase text-ink-lighter text-center px-2"
+          >
+            No cover
+          </div>
+
+          <dl class="flex-1 min-w-0 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 text-sm">
+            <DetailRow label="ISBN" :value="book.isbn" mono />
+            <DetailRow label="Provider" :value="book.provider || '—'" />
+            <DetailRow label="Title" :value="book.title || '—'" class="sm:col-span-2" />
+            <DetailRow label="Authors" :value="book.authors.length ? book.authors.join(', ') : '—'" class="sm:col-span-2" />
+            <DetailRow label="Publisher" :value="book.publisher || '—'" />
+            <DetailRow label="Published" :value="book.publishedDate || '—'" />
+            <DetailRow label="Pages" :value="book.pageCount != null ? String(book.pageCount) : '—'" />
+            <DetailRow label="Language" :value="book.language || '—'" />
+          </dl>
+        </div>
+
+        <!-- Preview link (when the provider gave us one) -->
+        <section v-if="previewUrl">
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-2">Preview</p>
+          <a
+            :href="previewUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 text-sm text-ink hover:text-ink-light underline-offset-2 hover:underline"
+          >
+            <span>Open on {{ previewHost || 'provider' }}</span>
+            <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5h5v5M19 5l-9 9M5 9v10h10" />
+            </svg>
+          </a>
+        </section>
+
+        <!-- Categories -->
+        <section v-if="book.categories.length">
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-2">Categories</p>
+          <CategoryChips :categories="book.categories" />
+        </section>
+
+        <!-- Description -->
+        <section>
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-2">Description</p>
+          <p
+            v-if="book.description"
+            class="text-sm font-light leading-relaxed text-ink-light whitespace-pre-line"
+          >
+            {{ book.description }}
+          </p>
+          <p v-else class="text-sm font-light italic text-ink-lighter leading-relaxed">
+            No description was returned for this ISBN{{ book.provider ? ` by ${book.provider}` : '' }}.
+            You can paste your own via the edit pencil on the book row.
+          </p>
+        </section>
+
+        <!-- Personal fields (only when present — saved books) -->
+        <section v-if="hasPersonal">
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-2">Your appraisal</p>
+          <dl class="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-3 text-sm">
+            <DetailRow label="Read" :value="bookAsSaved.read ? 'Yes' : 'No'" />
+            <DetailRow label="Want" :value="`${bookAsSaved.readMotivation} / 100`" />
+            <DetailRow label="Condition" :value="`${bookAsSaved.physicalCondition} / 100`" />
+            <DetailRow label="Owner" :value="bookAsSaved.owner || '—'" />
+            <DetailRow v-if="bookAsSaved.notes" label="Notes" :value="bookAsSaved.notes" class="sm:col-span-4" />
+          </dl>
+        </section>
+
+        <!-- Collapsible raw provider response -->
+        <details class="border border-line">
+          <summary class="cursor-pointer px-3 py-2 text-[10px] uppercase tracking-widest text-ink-lighter hover:text-ink select-none">
+            Raw provider response
+          </summary>
+          <pre class="json-pre">{{ pretty }}</pre>
+        </details>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import type { LibraryBook, LibraryBookLookup } from '@shared/LibraryBook'
+import DetailRow from './DetailRow.vue'
+import CategoryChips from './CategoryChips.vue'
 
 const props = defineProps<{
-  data: unknown
+  /** Saved book or fresh lookup result. */
+  book: LibraryBook | LibraryBookLookup
   heading: string
   subhead?: string
 }>()
 
 const emit = defineEmits<{ close: [] }>()
 
-const pretty = computed(() => {
-  try {
-    return JSON.stringify(props.data, null, 2)
-  } catch {
-    return String(props.data)
+const bookAsSaved = computed(() => props.book as LibraryBook)
+const hasPersonal = computed(() => {
+  const b = props.book as Partial<LibraryBook>
+  return typeof b.readMotivation === 'number'
+})
+
+/**
+ * Pull a "read more / preview" URL out of the raw provider payload.
+ * Google Books exposes `volumeInfo.previewLink` (preview, may say "no
+ * preview available" but still a useful landing page) and `infoLink`;
+ * @library-pals/isbn exposes a flat `link`. Returns null when none of
+ * those are present.
+ */
+const previewUrl = computed<string | null>(() => {
+  const raw = props.book.raw
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, any>
+  const volume = r.volumeInfo as Record<string, unknown> | undefined
+  const access = r.accessInfo as Record<string, unknown> | undefined
+  const candidates = [
+    typeof volume?.previewLink === 'string' ? volume.previewLink : '',
+    typeof volume?.infoLink === 'string' ? volume.infoLink : '',
+    typeof volume?.canonicalVolumeLink === 'string' ? volume.canonicalVolumeLink : '',
+    typeof access?.webReaderLink === 'string' ? access.webReaderLink : '',
+    typeof r.link === 'string' ? r.link : '',
+  ]
+  for (const c of candidates) {
+    if (c && /^https?:\/\//i.test(c)) return c
   }
+  return null
+})
+
+/** Hostname for the link label, so the user can see where they're going. */
+const previewHost = computed<string>(() => {
+  if (!previewUrl.value) return ''
+  try { return new URL(previewUrl.value).hostname.replace(/^www\./, '') }
+  catch { return '' }
+})
+
+const rawForJson = computed(() => props.book.raw ?? {
+  isbn: props.book.isbn,
+  title: props.book.title,
+  authors: props.book.authors,
+  publisher: props.book.publisher,
+  publishedDate: props.book.publishedDate,
+  description: props.book.description,
+  pageCount: props.book.pageCount,
+  thumbnail: props.book.thumbnail,
+  categories: props.book.categories,
+  language: props.book.language,
+  provider: props.book.provider,
+})
+
+const pretty = computed(() => {
+  try { return JSON.stringify(rawForJson.value, null, 2) }
+  catch { return String(rawForJson.value) }
 })
 
 const copied = ref(false)
-async function copy() {
+async function copyRaw() {
   try {
     await navigator.clipboard.writeText(pretty.value)
     copied.value = true
@@ -65,15 +206,16 @@ async function copy() {
 
 <style scoped>
 .json-pre {
-  max-height: 60vh;
+  margin: 0;
+  max-height: 40vh;
   overflow: auto;
-  padding: 0.75rem;
+  padding: 0.75rem 1rem;
   background: var(--color-surface, #f5f5f4);
-  border: 1px solid var(--color-line, #d6d3d1);
+  border-top: 1px solid var(--color-line, #d6d3d1);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   line-height: 1.4;
-  color: var(--color-ink, #1c1917);
+  color: var(--color-ink-light, #57534e);
   white-space: pre;
 }
 </style>

--- a/client/src/components/library/CategoryChips.vue
+++ b/client/src/components/library/CategoryChips.vue
@@ -1,0 +1,66 @@
+<template>
+  <div v-if="categories.length" class="flex flex-wrap gap-1 items-center">
+    <span
+      v-for="c in shown"
+      :key="c"
+      class="chip"
+    >{{ c }}</span>
+
+    <button
+      v-if="hidden > 0"
+      type="button"
+      :aria-expanded="expanded"
+      :aria-label="expanded ? 'Show fewer categories' : `Show ${hidden} more categories`"
+      @click.stop="expanded = !expanded"
+      class="chip chip-toggle"
+    >{{ expanded ? '− less' : `+${hidden}` }}</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = withDefaults(defineProps<{
+  categories: string[]
+  initialLimit?: number
+}>(), {
+  initialLimit: 2,
+})
+
+const expanded = ref(false)
+
+const shown = computed(() =>
+  expanded.value ? props.categories : props.categories.slice(0, props.initialLimit)
+)
+
+const hidden = computed(() =>
+  Math.max(0, props.categories.length - props.initialLimit)
+)
+</script>
+
+<style scoped>
+.chip {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--color-line, #d6d3d1);
+  color: var(--color-ink-light, #57534e);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.chip-toggle {
+  cursor: pointer;
+  color: var(--color-ink-lighter, #a8a29e);
+  background: transparent;
+  transition: color 0.2s, background-color 0.2s;
+}
+.chip-toggle:hover {
+  color: var(--color-ink, #1c1917);
+  background: var(--color-surface, #f5f5f4);
+}
+.chip-toggle:focus-visible {
+  outline: 2px solid var(--color-ink, #1c1917);
+  outline-offset: 1px;
+}
+</style>

--- a/client/src/components/library/DetailRow.vue
+++ b/client/src/components/library/DetailRow.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <dt class="text-[10px] uppercase tracking-widest text-ink-lighter mb-0.5">{{ label }}</dt>
+    <dd
+      :class="[
+        'text-ink break-words',
+        mono ? 'font-mono text-xs' : 'text-sm font-light',
+      ]"
+    >{{ value }}</dd>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+  value: string
+  mono?: boolean
+}>()
+</script>

--- a/client/src/components/library/IsbnScanner.vue
+++ b/client/src/components/library/IsbnScanner.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="isbn-scanner">
     <div class="bg-paper border border-line p-4 sm:p-6">
-      <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center justify-between mb-3">
         <h3 class="text-lg font-light tracking-tight">Scan an ISBN</h3>
         <button
           @click="emit('close')"
@@ -14,10 +14,30 @@
         </button>
       </div>
 
-      <p class="text-sm text-ink-light mb-4">
-        Point the back cover&rsquo;s barcode at the camera. We&rsquo;ll catch
-        the ISBN and pull in the rest from Google Books / Open Library.
-      </p>
+      <!-- Mode line -->
+      <div class="flex items-center justify-between gap-3 mb-3">
+        <p class="text-sm text-ink-light leading-snug">
+          <template v-if="rapidMode">
+            Point the camera at a barcode &mdash; we&rsquo;ll add each book straight to your library.
+          </template>
+          <template v-else>
+            Point the back cover&rsquo;s barcode at the camera. We&rsquo;ll catch the ISBN and pull in the rest.
+          </template>
+        </p>
+        <label class="flex items-center gap-2 cursor-pointer shrink-0 select-none">
+          <span class="text-[10px] uppercase tracking-widest text-ink-lighter">Rapid</span>
+          <button
+            type="button"
+            role="switch"
+            :aria-checked="rapidMode"
+            @click="rapidMode = !rapidMode"
+            class="toggle"
+            :class="rapidMode ? 'toggle-on' : ''"
+          >
+            <span class="toggle-knob" />
+          </button>
+        </label>
+      </div>
 
       <!-- Live camera viewport -->
       <div
@@ -33,11 +53,39 @@
         ></video>
         <!-- Reticle to help the user line up the barcode -->
         <div class="scanner-reticle" aria-hidden="true"></div>
+
+        <!-- Per-scan result overlay (rapid mode) -->
+        <transition name="fade">
+          <div
+            v-if="lastResult"
+            class="absolute top-2 left-2 right-2 mx-auto max-w-md px-3 py-2 text-sm font-sans tracking-wide flex items-center gap-2"
+            :class="lastResult.ok
+              ? 'bg-emerald-600/90 text-white'
+              : 'bg-red-600/90 text-white'"
+          >
+            <svg v-if="lastResult.ok" class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
+            </svg>
+            <svg v-else class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 9v3m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span class="truncate">{{ lastResult.label }}</span>
+          </div>
+        </transition>
+
         <div
-          v-if="scanning && !lastCode"
+          v-if="scanning && !lastCode && !lastResult"
           class="absolute bottom-2 left-2 right-2 text-center text-xs text-white/80 font-sans tracking-wide"
         >
           Looking for a barcode&hellip;
+        </div>
+
+        <!-- Mini tally for rapid runs -->
+        <div
+          v-if="rapidMode && (tally.added > 0 || tally.failed > 0)"
+          class="absolute bottom-2 left-2 text-[10px] uppercase tracking-widest text-white/90 bg-black/40 px-2 py-1"
+        >
+          Added {{ tally.added }} &middot; Skipped {{ tally.failed }}
         </div>
       </div>
 
@@ -83,20 +131,38 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, reactive, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { BrowserMultiFormatReader, IScannerControls } from '@zxing/browser'
 import { BarcodeFormat, DecodeHintType } from '@zxing/library'
+import { primeAudio } from '../../utils/notificationSound'
 
 export interface ScanDetectedPayload {
   isbn: string
   durationMs: number
   scanner: 'zxing' | 'manual'
   format?: string
+  /** True when the user opted into auto-save-and-continue. */
+  rapid: boolean
 }
+
+export interface ScanResult {
+  ok: boolean
+  /** Short message shown in the in-camera overlay. */
+  label: string
+}
+
+const props = withDefaults(defineProps<{
+  /** v-model. When true, parent auto-saves and calls `acceptNextScan(result)`
+   *  after each scan so we keep the camera running. */
+  rapidMode?: boolean
+}>(), {
+  rapidMode: false,
+})
 
 const emit = defineEmits<{
   detected: [payload: ScanDetectedPayload]
   close: []
+  'update:rapidMode': [value: boolean]
 }>()
 
 const startedAt = Date.now()
@@ -109,8 +175,39 @@ const scanning = ref(false)
 const lastCode = ref<string | null>(null)
 const manualIsbn = ref('')
 
+const lastResult = ref<ScanResult | null>(null)
+const tally = reactive({ added: 0, failed: 0 })
+
+const rapidMode = computed<boolean>({
+  get: () => props.rapidMode,
+  set: (v: boolean) => emit('update:rapidMode', v),
+})
+
 let reader: BrowserMultiFormatReader | null = null
 let controls: IScannerControls | null = null
+let resultClearTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Parent calls this via `defineExpose` after each rapid-scan attempt
+ * resolves, so the next different barcode can fire. We deliberately do
+ * NOT clear if the same code is still in view — the user must move the
+ * book away to scan it again.
+ */
+function acceptNextScan(result: ScanResult): void {
+  lastResult.value = result
+  if (result.ok) tally.added++
+  else tally.failed++
+
+  // Free the "same-code debounce" so a different book can fire next.
+  lastCode.value = null
+
+  if (resultClearTimer) clearTimeout(resultClearTimer)
+  resultClearTimer = setTimeout(() => {
+    lastResult.value = null
+  }, 2200)
+}
+
+defineExpose({ acceptNextScan })
 
 function buildReader(): BrowserMultiFormatReader {
   // Constrain decoding to the 1D book/product formats. Cuts CPU
@@ -148,10 +245,10 @@ async function start() {
   lastCode.value = null
   reader = buildReader()
 
+  // Prime the audio context off the user gesture that opened the scanner.
+  primeAudio()
+
   try {
-    // Prefer the chosen device. If we don't have one (permission not yet
-    // granted), fall back to a constraint that asks the browser for the
-    // back-facing camera — works on iOS Safari and Android Chrome.
     const constraints: MediaStreamConstraints = selectedDeviceId.value
       ? { video: { deviceId: { exact: selectedDeviceId.value } } }
       : { video: { facingMode: { ideal: 'environment' } } }
@@ -162,8 +259,6 @@ async function start() {
       (result, err) => {
         if (result) {
           const text = result.getText().replace(/[^0-9Xx]/g, '')
-          // ISBN-13 barcodes are EAN-13 starting with 978 or 979. ISBN-10
-          // is uncommon on modern back covers but we accept anyway.
           if (text.length === 13 || text.length === 10) {
             if (text !== lastCode.value) {
               lastCode.value = text
@@ -172,6 +267,7 @@ async function start() {
                 durationMs: Date.now() - startedAt,
                 scanner: 'zxing',
                 format: result.getBarcodeFormat ? String(result.getBarcodeFormat()) : undefined,
+                rapid: rapidMode.value,
               })
             }
           }
@@ -208,6 +304,10 @@ function stop() {
   }
   controls = null
   reader = null
+  if (resultClearTimer) {
+    clearTimeout(resultClearTimer)
+    resultClearTimer = null
+  }
 }
 
 async function restart() {
@@ -226,7 +326,9 @@ function submitManual() {
     isbn: digits,
     durationMs: Date.now() - startedAt,
     scanner: 'manual',
+    rapid: rapidMode.value,
   })
+  manualIsbn.value = ''
 }
 
 onMounted(async () => {
@@ -251,5 +353,38 @@ onBeforeUnmount(() => {
   border-radius: 4px;
   box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.25);
   pointer-events: none;
+}
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  background: #d6d3d1;
+  transition: background-color 0.2s;
+}
+.toggle-on {
+  background: var(--color-ink, #1c1917);
+}
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s;
+}
+.toggle-on .toggle-knob {
+  transform: translateX(16px);
+}
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.18s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/client/src/config/version.ts
+++ b/client/src/config/version.ts
@@ -1,3 +1,3 @@
 // Version is injected at build time via Vite
 // This file is replaced during build with the actual version from package.json
-export const APP_VERSION = '0.5.23'
+export const APP_VERSION = '0.5.15'

--- a/client/src/pages/MyLibrary.vue
+++ b/client/src/pages/MyLibrary.vue
@@ -69,8 +69,13 @@
       @click.self="closeScanner"
     >
       <div class="w-full max-w-2xl mt-8 sm:mt-0">
+        <!-- Scanner is always mounted while open in rapid mode (so the camera
+             keeps running between scans). In confirm mode it yields to the
+             lookup spinner / BookEditor. -->
         <IsbnScanner
-          v-if="!lookupBusy && !pendingLookup"
+          v-if="rapidMode || (!lookupBusy && !pendingLookup)"
+          ref="scannerRef"
+          v-model:rapid-mode="rapidMode"
           @detected="handleDetected"
           @close="closeScanner"
         />
@@ -111,10 +116,10 @@
       />
     </div>
 
-    <!-- JSON modal -->
+    <!-- Book details modal -->
     <BookJsonModal
       v-if="jsonViewing"
-      :data="jsonViewing.raw ?? jsonFallback(jsonViewing)"
+      :book="jsonViewing"
       :heading="jsonViewing.title || jsonViewing.isbn"
       :subhead="jsonViewing.provider ? `ISBN ${jsonViewing.isbn} · via ${jsonViewing.provider}` : `ISBN ${jsonViewing.isbn}`"
       @close="jsonViewing = null"
@@ -197,6 +202,12 @@
               </span>
             </div>
 
+            <CategoryChips
+              v-if="b.categories.length"
+              :categories="b.categories"
+              class="mt-2"
+            />
+
             <p class="text-[10px] tracking-widest uppercase text-ink-lighter mt-2">
               ISBN {{ b.isbn }}
             </p>
@@ -267,6 +278,11 @@
                 <span class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light">Want {{ b.readMotivation }}</span>
                 <span class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light">Cond {{ b.physicalCondition }}</span>
               </div>
+              <CategoryChips
+                v-if="b.categories.length"
+                :categories="b.categories"
+                class="mt-1.5"
+              />
             </div>
             <div class="flex items-center gap-1 shrink-0">
               <button @click="jsonViewing = b" class="icon-btn" :title="'View raw metadata'" aria-label="View raw metadata">
@@ -306,6 +322,8 @@ import type { LibraryBook, LibraryBookLookup, LibraryBookUpdate } from '@shared/
 import IsbnScanner, { type ScanDetectedPayload } from '../components/library/IsbnScanner.vue'
 import BookEditor, { type EditorForm } from '../components/library/BookEditor.vue'
 import BookJsonModal from '../components/library/BookJsonModal.vue'
+import CategoryChips from '../components/library/CategoryChips.vue'
+import { playSuccess, playFailure } from '../utils/notificationSound'
 
 type ViewMode = 'cards' | 'list'
 
@@ -328,6 +346,9 @@ const pendingLookup = ref<LibraryBookLookup | null>(null)
 const saving = ref(false)
 const saveError = ref<string | null>(null)
 const deleting = ref<string | null>(null)
+const rapidMode = ref(false)
+const scannerRef = ref<InstanceType<typeof IsbnScanner> | null>(null)
+const rapidBusy = ref(false)
 
 // Edit / view state
 const editing = ref<LibraryBook | null>(null)
@@ -374,13 +395,13 @@ function closeScanner() {
   pendingIsbn.value = null
   pendingLookup.value = null
   saveError.value = null
+  rapidBusy.value = false
 }
 
 async function handleDetected(payload: ScanDetectedPayload) {
-  if (lookupBusy.value || pendingLookup.value) return
-  pendingIsbn.value = payload.isbn
+  if (lookupBusy.value || pendingLookup.value || rapidBusy.value) return
 
-  // Log the scan-phase event (camera/manual reach).
+  // Log the scan-phase event regardless of mode.
   libraryApi.logScanEvent({
     phase: 'scan',
     isbn: payload.isbn,
@@ -390,6 +411,13 @@ async function handleDetected(payload: ScanDetectedPayload) {
     provider: payload.format,
   })
 
+  if (payload.rapid) {
+    await handleRapidScan(payload.isbn)
+    return
+  }
+
+  // Confirm flow: open the BookEditor with the lookup data.
+  pendingIsbn.value = payload.isbn
   lookupBusy.value = true
   saveError.value = null
   try {
@@ -413,6 +441,69 @@ async function handleDetected(payload: ScanDetectedPayload) {
     }
   } finally {
     lookupBusy.value = false
+  }
+}
+
+/**
+ * Rapid-mode scan: look up, auto-save with personal-field defaults, then
+ * tell the scanner to listen for the next book. Audio cues distinguish
+ * the outcome so a user scanning a stack of books can keep working
+ * without looking at the screen.
+ */
+async function handleRapidScan(isbn: string) {
+  rapidBusy.value = true
+  try {
+    let lookup: LibraryBookLookup
+    try {
+      lookup = await libraryApi.lookup(isbn)
+    } catch (err) {
+      playFailure()
+      scannerRef.value?.acceptNextScan({
+        ok: false,
+        label: `Not found: ${isbn}`,
+      })
+      return
+    }
+
+    try {
+      const created = await libraryApi.create({
+        isbn: lookup.isbn,
+        title: lookup.title,
+        authors: lookup.authors,
+        publisher: lookup.publisher,
+        publishedDate: lookup.publishedDate,
+        description: lookup.description,
+        pageCount: lookup.pageCount,
+        thumbnail: lookup.thumbnail,
+        categories: lookup.categories,
+        language: lookup.language,
+        provider: lookup.provider,
+        raw: lookup.raw,
+        // Personal-field defaults; user can refine via the pencil icon later.
+        read: false,
+        readMotivation: 50,
+        physicalCondition: 100,
+        owner: '',
+        notes: '',
+      })
+      books.value = [created, ...books.value]
+      playSuccess()
+      scannerRef.value?.acceptNextScan({
+        ok: true,
+        label: created.title ? `Added: ${created.title}` : `Added: ${created.isbn}`,
+      })
+    } catch (err) {
+      const duplicate = err instanceof ApiError && err.status === 409
+      playFailure()
+      scannerRef.value?.acceptNextScan({
+        ok: false,
+        label: duplicate
+          ? `Already in library: ${lookup.title || isbn}`
+          : `Save failed: ${lookup.title || isbn}`,
+      })
+    }
+  } finally {
+    rapidBusy.value = false
   }
 }
 
@@ -503,25 +594,6 @@ async function handleDelete(b: LibraryBook) {
     alert(err instanceof Error ? err.message : 'Failed to remove book')
   } finally {
     deleting.value = null
-  }
-}
-
-/** Fallback for the JSON modal when raw_metadata is absent — synthesize a
- *  representative object from the saved columns so the inspector is never
- *  empty (older rows predate raw_metadata). */
-function jsonFallback(b: LibraryBook | LibraryBookLookup): Record<string, unknown> {
-  return {
-    isbn: b.isbn,
-    title: b.title,
-    authors: b.authors,
-    publisher: b.publisher,
-    publishedDate: b.publishedDate,
-    description: b.description,
-    pageCount: b.pageCount,
-    thumbnail: b.thumbnail,
-    categories: b.categories,
-    language: b.language,
-    provider: b.provider,
   }
 }
 

--- a/client/src/utils/notificationSound.ts
+++ b/client/src/utils/notificationSound.ts
@@ -1,0 +1,95 @@
+/**
+ * Tiny audio-feedback helper for the rapid-scan flow.
+ *
+ * Sounds are synthesised inline with the Web Audio API so we don't ship
+ * an audio asset and don't pay a network round-trip on the first beep.
+ *
+ * The browser blocks AudioContext creation until a user gesture has
+ * happened on the page, so we lazily create it inside the play
+ * functions — they will only ever be called from inside an event
+ * handler triggered by a user action (scanner button, scan event).
+ */
+
+let ctx: AudioContext | null = null
+
+function getContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null
+  if (ctx) {
+    // Some browsers suspend the context if it sits idle; resume on demand.
+    if (ctx.state === 'suspended') void ctx.resume()
+    return ctx
+  }
+  const Ctor = window.AudioContext ?? (window as any).webkitAudioContext
+  if (!Ctor) return null
+  try {
+    ctx = new Ctor()
+    return ctx
+  } catch {
+    return null
+  }
+}
+
+interface ToneStep {
+  /** Frequency in Hz. */
+  freq: number
+  /** Duration in seconds. */
+  dur: number
+  /** Peak gain (0..1). Defaults to 0.18 — comfortable on speakers and headphones. */
+  gain?: number
+}
+
+/**
+ * Play a sequence of pure-sine tones with a short attack/release envelope
+ * so they don't click. Steps run back-to-back.
+ */
+function playTones(steps: ToneStep[]): void {
+  const c = getContext()
+  if (!c) return
+
+  let t = c.currentTime
+  for (const step of steps) {
+    const osc = c.createOscillator()
+    const gain = c.createGain()
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(step.freq, t)
+
+    const peak = step.gain ?? 0.18
+    const attack = Math.min(0.012, step.dur / 4)
+    const release = Math.min(0.04, step.dur / 2)
+
+    gain.gain.setValueAtTime(0, t)
+    gain.gain.linearRampToValueAtTime(peak, t + attack)
+    gain.gain.setValueAtTime(peak, t + step.dur - release)
+    gain.gain.linearRampToValueAtTime(0, t + step.dur)
+
+    osc.connect(gain).connect(c.destination)
+    osc.start(t)
+    osc.stop(t + step.dur)
+
+    t += step.dur
+  }
+}
+
+/** Ascending two-tone "ding" — book found and added. */
+export function playSuccess(): void {
+  playTones([
+    { freq: 659.25, dur: 0.09 }, // E5
+    { freq: 987.77, dur: 0.14 }, // B5
+  ])
+}
+
+/** Descending two-tone "bonk" — book not found or duplicate. */
+export function playFailure(): void {
+  playTones([
+    { freq: 246.94, dur: 0.10, gain: 0.22 }, // B3
+    { freq: 174.61, dur: 0.16, gain: 0.22 }, // F3
+  ])
+}
+
+/**
+ * Touch the audio context so the first real beep doesn't carry the
+ * one-off cost of creating it. Safe to call from any user gesture.
+ */
+export function primeAudio(): void {
+  getContext()
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writing-platform",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "Personal Writing Platform (Vendor-Neutral, Self-Hosted)",
   "private": true,
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/server",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "type": "module",
   "scripts": {
     "dev": "nodemon",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@writing-platform/shared",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "Shared types and contracts for writing platform",
   "main": "index.ts",
   "types": "index.ts",


### PR DESCRIPTION
## Summary
- **Book details modal** rebuilt to match the rest of the UI: cover, bibliographic grid via the new `DetailRow` component, categories chips, description (with a graceful fallback message when the provider returned no blurb), personal-appraisal section for saved books, **Preview** link when the provider's raw payload carries one (Google Books `volumeInfo.previewLink` / `infoLink` / `canonicalVolumeLink` / `accessInfo.webReaderLink`, or `@library-pals/isbn`'s top-level `link`), and a collapsible raw-JSON pane with Copy.
- **Rapid scan mode** — toggle in the scanner header. When on, every detected ISBN looks up + auto-saves with personal-field defaults, plays a positive Web Audio chime on hit / a negative bonk on miss/duplicate, and keeps the camera live for the next book. An in-camera result banner shows the last outcome; a small Added/Skipped tally sits in the corner.
- **Categories on cards and list rows** — first 2 chips with a touch-friendly `+N` expand. Same `CategoryChips` component slotted into the details modal so all three places behave identically.
- **Version bump 0.5.14 → 0.5.15** in all four `package.json` files plus `client/src/config/version.ts` so the Build Nbr in the footer updates immediately.

## Screenshots / behaviour
- Rapid mode: ZXing detection → server lookup → auto-create → ding → ready for next scan, ~1.5–2s end-to-end.
- Modal fallback when no description: italic muted line "No description was returned for this ISBN by &lt;provider&gt;. You can paste your own via the edit pencil on the book row."
- Categories: tap `+N` to expand to all chips with a `− less` chip to collapse; works on touch and keyboard.

## Test plan
- [ ] Open a book's details modal — verify structured layout matches the rest of the UI (no raw JSON dump unless the user opens the `<details>`)
- [ ] On a book with a known preview link (e.g. Google Books title), verify the "Open on books.google.com" link opens in a new tab
- [ ] On a book with no description, verify the italic fallback line is shown
- [ ] On a book with 4+ categories, verify only first 2 chips show with `+2`, tap expands, then `− less` collapses
- [ ] Enable rapid mode, scan three books in a row — verify each ding, each appears at the top of the list; scan a duplicate → bonk + "Already in library" banner
- [ ] Scan an unknown ISBN in rapid mode → bonk + "Not found" banner; camera stays live
- [ ] Confirm-mode (rapid off) still opens BookEditor as before
- [ ] Verify footer shows `Build 0.5.15`
- [ ] `npm run type-check` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)