### PR TITLE
Clickable library rows, responsive details modal, richer search

### DIFF
--- a/client/src/components/library/BookJsonModal.vue
+++ b/client/src/components/library/BookJsonModal.vue
@@ -1,28 +1,29 @@
 <template>
   <div
-    class="fixed inset-0 z-50 bg-black/60 flex items-start sm:items-center justify-center p-4 overflow-y-auto"
+    class="fixed inset-0 z-50 bg-black/60 flex items-stretch sm:items-center justify-center sm:p-4 overflow-y-auto"
     role="dialog"
     aria-modal="true"
     @click.self="emit('close')"
+    @keydown.esc="emit('close')"
   >
-    <div class="bg-paper border border-line w-full max-w-2xl mt-8 sm:mt-0 max-h-[90vh] flex flex-col">
+    <div class="bg-paper sm:border sm:border-line w-full sm:max-w-2xl h-[100dvh] sm:h-auto sm:max-h-[90vh] flex flex-col">
       <!-- Header -->
-      <div class="flex items-start justify-between gap-3 p-4 sm:p-6 border-b border-line">
+      <div class="flex items-start justify-between gap-3 p-4 sm:p-6 border-b border-line shrink-0">
         <div class="min-w-0">
           <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-1">Book details</p>
-          <h3 class="text-lg font-light tracking-tight text-ink truncate">{{ heading || 'Untitled' }}</h3>
+          <h3 class="text-base sm:text-lg font-light tracking-tight text-ink truncate">{{ heading || 'Untitled' }}</h3>
           <p v-if="subhead" class="text-xs text-ink-light truncate mt-0.5">{{ subhead }}</p>
         </div>
         <div class="flex items-center gap-1 shrink-0">
           <button
             @click="copyRaw"
-            class="text-xs px-2 py-1 border border-line text-ink-light hover:text-ink transition-colors"
+            class="hidden sm:inline-block text-xs px-2 py-1 border border-line text-ink-light hover:text-ink transition-colors"
             :title="copied ? 'Copied' : 'Copy raw JSON to clipboard'"
           >
             {{ copied ? 'Copied' : 'Copy JSON' }}
           </button>
           <button @click="emit('close')" class="text-ink-lighter hover:text-ink p-1" aria-label="Close">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-6 h-6 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -30,23 +31,23 @@
       </div>
 
       <!-- Body -->
-      <div class="overflow-y-auto p-4 sm:p-6 space-y-6">
+      <div class="overflow-y-auto p-4 sm:p-6 space-y-6 grow">
         <!-- Cover + bibliographic grid -->
-        <div class="flex gap-4 items-start">
+        <div class="flex gap-3 sm:gap-4 items-start">
           <img
             v-if="book.thumbnail"
             :src="book.thumbnail"
             :alt="book.title || book.isbn"
-            class="w-24 h-32 sm:w-28 sm:h-36 object-cover border border-line shrink-0"
+            class="w-20 h-28 sm:w-28 sm:h-36 object-cover border border-line shrink-0"
           />
           <div
             v-else
-            class="w-24 h-32 sm:w-28 sm:h-36 bg-surface border border-line shrink-0 flex items-center justify-center text-[10px] tracking-widest uppercase text-ink-lighter text-center px-2"
+            class="w-20 h-28 sm:w-28 sm:h-36 bg-surface border border-line shrink-0 flex items-center justify-center text-[10px] tracking-widest uppercase text-ink-lighter text-center px-2"
           >
             No cover
           </div>
 
-          <dl class="flex-1 min-w-0 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 text-sm">
+          <dl class="flex-1 min-w-0 w-full grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 text-sm">
             <DetailRow label="ISBN" :value="book.isbn" mono />
             <DetailRow label="Provider" :value="book.provider || '—'" />
             <DetailRow label="Title" :value="book.title || '—'" class="sm:col-span-2" />

--- a/client/src/pages/MyLibrary.vue
+++ b/client/src/pages/MyLibrary.vue
@@ -26,12 +26,25 @@
           Scan ISBN
         </button>
 
-        <input
-          v-model="search"
-          type="search"
-          placeholder="Search title, author, ISBN, owner"
-          class="flex-1 min-w-[12rem] px-3 py-2 border border-line bg-paper text-ink text-sm placeholder:text-ink-lighter"
-        />
+        <div class="relative flex-1 min-w-[12rem]">
+          <input
+            v-model="search"
+            type="search"
+            placeholder='Search title, author, description… (try author:tolkien or "central question")'
+            class="w-full px-3 py-2 pr-9 border border-line bg-paper text-ink text-sm placeholder:text-ink-lighter"
+          />
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 px-2 text-ink-lighter hover:text-ink"
+            :title="searchHelpOpen ? 'Hide search tips' : 'Show search tips'"
+            :aria-expanded="searchHelpOpen"
+            @click="searchHelpOpen = !searchHelpOpen"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093M12 17h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </button>
+        </div>
 
         <div class="ml-auto inline-flex border border-line" role="group" aria-label="View toggle">
           <button
@@ -57,6 +70,21 @@
             <span class="hidden sm:inline">List</span>
           </button>
         </div>
+      </div>
+
+      <!-- Search syntax help -->
+      <div
+        v-if="searchHelpOpen"
+        class="max-w-7xl mx-auto mt-3 border border-line bg-surface px-4 py-3 text-xs text-ink-light"
+      >
+        <p class="mb-2 text-ink">Search across every text field — title, authors, ISBN, owner, publisher, description, categories, notes, language, provider, year.</p>
+        <ul class="list-disc list-inside space-y-0.5 marker:text-ink-lighter">
+          <li><code class="bg-paper px-1">tolkien hobbit</code> — both words must appear somewhere</li>
+          <li><code class="bg-paper px-1">"central question"</code> — exact phrase</li>
+          <li><code class="bg-paper px-1">author:le-guin</code> — scope to one field (also <code class="bg-paper px-1">cat:</code>, <code class="bg-paper px-1">desc:</code>, <code class="bg-paper px-1">owner:</code>, <code class="bg-paper px-1">year:</code>, <code class="bg-paper px-1">publisher:</code>)</li>
+          <li><code class="bg-paper px-1">-author:rowling</code> — exclude matches</li>
+          <li><code class="bg-paper px-1">desc:"alchemy"</code> — quoted phrase scoped to one field</li>
+        </ul>
       </div>
     </div>
 
@@ -158,7 +186,13 @@
           <article
             v-for="b in filteredBooks"
             :key="b.id"
-            class="library-card bg-paper border border-line p-4 flex flex-col group"
+            class="library-card bg-paper border border-line p-4 flex flex-col group cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ink"
+            role="button"
+            tabindex="0"
+            :aria-label="`View details for ${b.title || b.isbn}`"
+            @click="jsonViewing = b"
+            @keydown.enter.prevent="jsonViewing = b"
+            @keydown.space.prevent="jsonViewing = b"
           >
             <div class="aspect-[2/3] mb-3 bg-surface flex items-center justify-center overflow-hidden">
               <img
@@ -212,20 +246,15 @@
               ISBN {{ b.isbn }}
             </p>
 
-            <!-- Action bar -->
+            <!-- Action bar (icons are inside a clickable card, so each stops propagation) -->
             <div class="flex items-center justify-end gap-1 mt-2 -mb-1">
-              <button @click="jsonViewing = b" class="icon-btn" :title="'View raw metadata'" aria-label="View raw metadata">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </button>
-              <button @click="startEdit(b)" class="icon-btn" :title="'Edit book'" aria-label="Edit book">
+              <button @click.stop="startEdit(b)" class="icon-btn" :title="'Edit book'" aria-label="Edit book">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                 </svg>
               </button>
               <button
-                @click="handleDelete(b)"
+                @click.stop="handleDelete(b)"
                 :disabled="deleting === b.id"
                 class="icon-btn hover:!text-red-600"
                 :title="'Remove from library'"
@@ -244,7 +273,13 @@
           <li
             v-for="b in filteredBooks"
             :key="b.id"
-            class="flex items-start sm:items-center gap-4 p-3 sm:p-4 hover:bg-surface transition-colors"
+            class="flex items-start sm:items-center gap-4 p-3 sm:p-4 hover:bg-surface transition-colors cursor-pointer focus:outline-none focus-visible:bg-surface"
+            role="button"
+            tabindex="0"
+            :aria-label="`View details for ${b.title || b.isbn}`"
+            @click="jsonViewing = b"
+            @keydown.enter.prevent="jsonViewing = b"
+            @keydown.space.prevent="jsonViewing = b"
           >
             <img
               v-if="b.thumbnail"
@@ -285,18 +320,13 @@
               />
             </div>
             <div class="flex items-center gap-1 shrink-0">
-              <button @click="jsonViewing = b" class="icon-btn" :title="'View raw metadata'" aria-label="View raw metadata">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </button>
-              <button @click="startEdit(b)" class="icon-btn" :title="'Edit book'" aria-label="Edit book">
+              <button @click.stop="startEdit(b)" class="icon-btn" :title="'Edit book'" aria-label="Edit book">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                 </svg>
               </button>
               <button
-                @click="handleDelete(b)"
+                @click.stop="handleDelete(b)"
                 :disabled="deleting === b.id"
                 class="icon-btn hover:!text-red-600"
                 :title="'Remove from library'"
@@ -324,6 +354,7 @@ import BookEditor, { type EditorForm } from '../components/library/BookEditor.vu
 import BookJsonModal from '../components/library/BookJsonModal.vue'
 import CategoryChips from '../components/library/CategoryChips.vue'
 import { playSuccess, playFailure } from '../utils/notificationSound'
+import { parseQuery, matchBook } from '../utils/librarySearch'
 
 type ViewMode = 'cards' | 'list'
 
@@ -333,6 +364,7 @@ const books = ref<LibraryBook[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 const search = ref('')
+const searchHelpOpen = ref(false)
 const viewMode = ref<ViewMode>(((): ViewMode => {
   const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY_VIEW) : null
   return stored === 'list' ? 'list' : 'cards'
@@ -354,15 +386,11 @@ const rapidBusy = ref(false)
 const editing = ref<LibraryBook | null>(null)
 const jsonViewing = ref<LibraryBook | LibraryBookLookup | null>(null)
 
+const searchTerms = computed(() => parseQuery(search.value.trim()))
+
 const filteredBooks = computed(() => {
-  const q = search.value.trim().toLowerCase()
-  if (!q) return books.value
-  return books.value.filter(b =>
-    b.title.toLowerCase().includes(q)
-    || b.authors.some(a => a.toLowerCase().includes(q))
-    || b.isbn.includes(q)
-    || b.owner.toLowerCase().includes(q)
-  )
+  if (searchTerms.value.length === 0) return books.value
+  return books.value.filter(b => matchBook(b, searchTerms.value))
 })
 
 watch(viewMode, v => {

--- a/client/src/utils/librarySearch.ts
+++ b/client/src/utils/librarySearch.ts
@@ -1,0 +1,138 @@
+/**
+ * Tokenised search for the MyLibrary view.
+ *
+ * Supported syntax (all case-insensitive):
+ *
+ *   tolkien                 — substring match across every text field
+ *   tolkien hobbit          — AND across terms (book must contain both)
+ *   "the long road"         — exact phrase
+ *   author:tolkien          — match only the authors field
+ *   cat:fiction             — match only the categories
+ *   desc:"alchemy"          — quoted phrase scoped to one field
+ *   year:2023               — substring of the publishedDate (so "2023" or "20" both work)
+ *   -author:rowling         — negate: book must NOT have rowling in authors
+ *
+ * Field aliases:
+ *   author / authors        → authors
+ *   desc / description      → description
+ *   cat / category /
+ *   categories              → categories
+ *   note / notes            → notes
+ *   lang / language         → language
+ *   year / date / published → publishedDate
+ *   pub / publisher         → publisher
+ *
+ * Anything unknown after the colon is treated as part of the term (so
+ * "9780:" still searches as "9780:" rather than crashing).
+ */
+import type { LibraryBook } from '@shared/LibraryBook'
+
+export type SearchField =
+  | 'title' | 'authors' | 'isbn' | 'owner' | 'description'
+  | 'publisher' | 'publishedDate' | 'categories' | 'notes'
+  | 'language' | 'provider'
+
+export interface SearchTerm {
+  /** Undefined means "match across every text field". */
+  field?: SearchField
+  text: string
+  /** True when the user prefixed with `-` ("not"). */
+  negate: boolean
+}
+
+const FIELD_ALIASES: Record<string, SearchField> = {
+  title: 'title',
+  author: 'authors',
+  authors: 'authors',
+  isbn: 'isbn',
+  owner: 'owner',
+  desc: 'description',
+  description: 'description',
+  publisher: 'publisher',
+  pub: 'publisher',
+  year: 'publishedDate',
+  date: 'publishedDate',
+  published: 'publishedDate',
+  cat: 'categories',
+  category: 'categories',
+  categories: 'categories',
+  note: 'notes',
+  notes: 'notes',
+  lang: 'language',
+  language: 'language',
+  provider: 'provider',
+}
+
+/**
+ * Split the raw query into terms. Handles quoted phrases, field
+ * prefixes, and leading `-` for negation.
+ */
+export function parseQuery(raw: string): SearchTerm[] {
+  const terms: SearchTerm[] = []
+  if (!raw) return terms
+
+  // Capture groups:
+  //   1: leading "-"
+  //   2: optional field prefix
+  //   3: quoted phrase content
+  //   4: bare token
+  const re = /(-)?(?:(\w+):)?(?:"([^"]+)"|(\S+))/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(raw)) !== null) {
+    const negate = !!m[1]
+    const fieldAlias = m[2]?.toLowerCase()
+    const text = (m[3] ?? m[4] ?? '').toLowerCase()
+    if (!text) continue
+
+    // Unknown prefix → fold it back into the term so the user gets a
+    // sane substring search rather than silent dropping.
+    const field = fieldAlias ? FIELD_ALIASES[fieldAlias] : undefined
+    if (fieldAlias && !field) {
+      terms.push({ field: undefined, text: `${fieldAlias}:${text}`, negate })
+    } else {
+      terms.push({ field, text, negate })
+    }
+  }
+  return terms
+}
+
+function fieldValue(b: LibraryBook, field: SearchField): string {
+  switch (field) {
+    case 'title':         return b.title
+    case 'authors':       return b.authors.join(' ')
+    case 'isbn':          return b.isbn
+    case 'owner':         return b.owner
+    case 'description':   return b.description
+    case 'publisher':     return b.publisher
+    case 'publishedDate': return b.publishedDate
+    case 'categories':    return b.categories.join(' ')
+    case 'notes':         return b.notes
+    case 'language':      return b.language
+    case 'provider':      return b.provider
+  }
+}
+
+/** Concatenation of every text field, lower-cased once per book per query. */
+function allFields(b: LibraryBook): string {
+  return [
+    b.title, b.authors.join(' '), b.isbn, b.owner, b.description,
+    b.publisher, b.publishedDate, b.categories.join(' '), b.notes,
+    b.language, b.provider,
+  ].join(' ').toLowerCase()
+}
+
+function termMatches(b: LibraryBook, t: SearchTerm, cachedAll: string): boolean {
+  const haystack = t.field ? fieldValue(b, t.field).toLowerCase() : cachedAll
+  const hit = haystack.includes(t.text)
+  return t.negate ? !hit : hit
+}
+
+/** True when every term in `terms` matches `book`. Empty terms list matches everything. */
+export function matchBook(book: LibraryBook, terms: SearchTerm[]): boolean {
+  if (terms.length === 0) return true
+  const cachedAll = allFields(book)
+  for (const t of terms) {
+    if (!termMatches(book, t, cachedAll)) return false
+  }
+  return true
+}


### PR DESCRIPTION
## Summary
- **Click anywhere on a card or list row** to open the details modal. Keyboard accessible (Enter / Space, focus ring). The pencil + trash icons inside the row use `@click.stop` so they don't trigger the row click. The redundant info icon is removed — the card itself is the affordance.
- **Details modal is now properly responsive**:
  - Phones (< 640px): edge-to-edge, full viewport height using `dvh` (so iOS Safari's collapsing URL bar doesn't push content off-screen), bigger close target, "Copy JSON" button hides (still available inside the collapsible raw JSON pane).
  - Tablet & up: centered, `max-w-2xl`, `max-h-[90vh]`, breathing-room padding.
  - Cover image scales (`w-20` on phones, `w-28` on sm+).
  - `Esc` closes.
- **Search is rebuilt** (`client/src/utils/librarySearch.ts`) as a tokenised parser that covers **every** text field on a book — title, authors, ISBN, owner, publisher, description, categories, notes, language, provider, published date. Supports:
  - Multi-token AND: `tolkien hobbit`
  - Quoted phrases: `"central question"`
  - Field prefixes: `author:le-guin`, `cat:fiction`, `desc:"alchemy"`, `year:2023`, `owner:me`, `note:recommended`, `publisher:`, `lang:`, `provider:` (with aliases)
  - Negation: `-author:rowling`
  - A `?` icon next to the search box toggles a syntax cheat-sheet
- Smoke-tested the parser against 17 representative queries — all pass.

## Test plan
- [ ] Click anywhere on a card → details modal opens; the pencil and trash icons still work and don't open the modal
- [ ] Tab to a card and press Enter / Space → modal opens; focus ring visible
- [ ] Same on a list row
- [ ] Open the modal on a phone (DevTools 375 × 667) — edge-to-edge, scrolls, close X reachable with thumb
- [ ] Open the modal on an iPad portrait (768 × 1024) — centred, max-w-2xl, comfortable padding
- [ ] `Esc` closes the modal
- [ ] Type `author:tolkien` — only books with "tolkien" in the authors field remain
- [ ] Type `desc:"alchemy"` — only books with that phrase in the description remain
- [ ] Type `tolkien -fiction` — books mentioning tolkien but NOT having "fiction" in any field
- [ ] Click the `?` next to the search box — cheat-sheet appears below
- [ ] `npm run type-check` passes in `client/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)