### PR TITLE
Gap-fill ISBN lookups + library filter panel

### DIFF
--- a/client/src/pages/MyLibrary.vue
+++ b/client/src/pages/MyLibrary.vue
@@ -26,6 +26,24 @@
           Scan ISBN
         </button>
 
+        <button
+          @click="filtersOpen = !filtersOpen"
+          :aria-expanded="filtersOpen"
+          class="inline-flex items-center gap-2 px-3 py-2 border text-sm tracking-wide font-sans transition-colors"
+          :class="activeFilterCount > 0
+            ? 'border-ink bg-ink text-paper hover:bg-ink-light'
+            : 'border-line bg-paper text-ink-light hover:text-ink'"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h18M6 10h12M10 16h4" />
+          </svg>
+          <span>Filters</span>
+          <span
+            v-if="activeFilterCount > 0"
+            class="text-[10px] tracking-widest px-1.5 py-0.5 bg-paper text-ink"
+          >{{ activeFilterCount }}</span>
+        </button>
+
         <div class="relative flex-1 min-w-[12rem]">
           <input
             v-model="search"
@@ -69,6 +87,91 @@
             </svg>
             <span class="hidden sm:inline">List</span>
           </button>
+        </div>
+      </div>
+
+      <!-- Filters panel -->
+      <div
+        v-if="filtersOpen"
+        class="max-w-7xl mx-auto mt-3 border border-line bg-surface px-4 py-4 text-sm"
+      >
+        <div class="flex items-center justify-between mb-3">
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter">Filters</p>
+          <button
+            v-if="activeFilterCount > 0"
+            @click="clearFilters"
+            class="text-xs text-ink-light hover:text-ink underline-offset-2 hover:underline"
+          >Clear all</button>
+        </div>
+
+        <!-- Read state -->
+        <div class="mb-4">
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-1.5">Read state</p>
+          <div class="inline-flex border border-line" role="group" aria-label="Read filter">
+            <button
+              v-for="opt in [
+                { val: 'all',    label: 'All'    },
+                { val: 'read',   label: 'Read'   },
+                { val: 'unread', label: 'Unread' },
+              ]"
+              :key="opt.val"
+              @click="filters.readState = opt.val as ReadFilter"
+              :aria-pressed="filters.readState === opt.val"
+              class="px-3 py-1.5 text-xs tracking-wide font-sans transition-colors"
+              :class="[
+                filters.readState === opt.val ? 'bg-ink text-paper' : 'bg-paper text-ink-light hover:text-ink',
+                opt.val !== 'all' ? 'border-l border-line' : ''
+              ]"
+            >{{ opt.label }}</button>
+          </div>
+        </div>
+
+        <!-- Owners -->
+        <div v-if="availableOwners.length" class="mb-4">
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-1.5">Owner</p>
+          <div class="flex flex-wrap gap-1.5">
+            <button
+              v-for="o in availableOwners"
+              :key="o"
+              @click="toggleOwnerFilter(o)"
+              :aria-pressed="filters.owners.includes(o)"
+              class="text-xs px-2 py-0.5 border transition-colors"
+              :class="filters.owners.includes(o)
+                ? 'border-ink bg-ink text-paper'
+                : 'border-line text-ink-light hover:text-ink hover:bg-paper'"
+            >{{ o }}</button>
+          </div>
+        </div>
+
+        <!-- Categories -->
+        <div v-if="availableCategories.length" class="mb-4">
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-1.5">
+            Categories <span class="text-ink-lighter normal-case tracking-normal">(top {{ availableCategories.length }})</span>
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <button
+              v-for="c in availableCategories"
+              :key="c"
+              @click="toggleCategoryFilter(c)"
+              :aria-pressed="filters.categories.includes(c)"
+              class="text-xs px-2 py-0.5 border transition-colors"
+              :class="filters.categories.includes(c)
+                ? 'border-ink bg-ink text-paper'
+                : 'border-line text-ink-light hover:text-ink hover:bg-paper'"
+            >{{ c }}</button>
+          </div>
+        </div>
+
+        <!-- Want-to-read range -->
+        <div>
+          <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-1.5">Want-to-read score</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-xl">
+            <RangeSlider v-model="filters.minMotivation" label="From" low-label="0" high-label="100" />
+            <RangeSlider v-model="filters.maxMotivation" label="To"   low-label="0" high-label="100" />
+          </div>
+          <p v-if="filters.minMotivation > filters.maxMotivation" class="text-xs text-red-700 mt-2">
+            From is higher than To — no books will match.
+          </p>
         </div>
       </div>
 
@@ -167,7 +270,7 @@
         <div v-else-if="filteredBooks.length === 0" class="text-center py-16">
           <p class="text-lg font-light text-ink-light mb-4">
             <span v-if="books.length === 0">Your library is empty. Scan an ISBN to start.</span>
-            <span v-else>Nothing matches your search.</span>
+            <span v-else>Nothing matches the current {{ activeFilterCount > 0 && searchTerms.length > 0 ? 'search and filters' : activeFilterCount > 0 ? 'filters' : 'search' }}.</span>
           </p>
           <button
             v-if="books.length === 0"
@@ -353,8 +456,23 @@ import IsbnScanner, { type ScanDetectedPayload } from '../components/library/Isb
 import BookEditor, { type EditorForm } from '../components/library/BookEditor.vue'
 import BookJsonModal from '../components/library/BookJsonModal.vue'
 import CategoryChips from '../components/library/CategoryChips.vue'
+import RangeSlider from '../components/library/RangeSlider.vue'
 import { playSuccess, playFailure } from '../utils/notificationSound'
 import { parseQuery, matchBook } from '../utils/librarySearch'
+
+type ReadFilter = 'all' | 'read' | 'unread'
+
+interface LibraryFilters {
+  readState: ReadFilter
+  owners: string[]
+  categories: string[]
+  minMotivation: number
+  maxMotivation: number
+}
+
+function defaultFilters(): LibraryFilters {
+  return { readState: 'all', owners: [], categories: [], minMotivation: 0, maxMotivation: 100 }
+}
 
 type ViewMode = 'cards' | 'list'
 
@@ -365,6 +483,8 @@ const loading = ref(true)
 const error = ref<string | null>(null)
 const search = ref('')
 const searchHelpOpen = ref(false)
+const filtersOpen = ref(false)
+const filters = ref<LibraryFilters>(defaultFilters())
 const viewMode = ref<ViewMode>(((): ViewMode => {
   const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY_VIEW) : null
   return stored === 'list' ? 'list' : 'cards'
@@ -388,10 +508,88 @@ const jsonViewing = ref<LibraryBook | LibraryBookLookup | null>(null)
 
 const searchTerms = computed(() => parseQuery(search.value.trim()))
 
-const filteredBooks = computed(() => {
-  if (searchTerms.value.length === 0) return books.value
-  return books.value.filter(b => matchBook(b, searchTerms.value))
+/**
+ * Owners present in the library, sorted alphabetically. Empty owners
+ * are excluded since they wouldn't make a useful filter chip.
+ */
+const availableOwners = computed<string[]>(() => {
+  const set = new Set<string>()
+  for (const b of books.value) {
+    if (b.owner.trim()) set.add(b.owner.trim())
+  }
+  return [...set].sort((a, b) => a.localeCompare(b))
 })
+
+/**
+ * Categories present in the library, sorted by frequency descending.
+ * The 20 most common are surfaced as chips — anything beyond that is
+ * better reached via the `cat:` search prefix.
+ */
+const availableCategories = computed<string[]>(() => {
+  const counts = new Map<string, number>()
+  for (const b of books.value) {
+    for (const c of b.categories) {
+      const key = c.trim()
+      if (!key) continue
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 20)
+    .map(([c]) => c)
+})
+
+const activeFilterCount = computed(() => {
+  const f = filters.value
+  let n = 0
+  if (f.readState !== 'all') n++
+  if (f.owners.length) n++
+  if (f.categories.length) n++
+  if (f.minMotivation > 0 || f.maxMotivation < 100) n++
+  return n
+})
+
+/** True when `book` satisfies every active filter. */
+function bookPassesFilters(b: LibraryBook): boolean {
+  const f = filters.value
+  if (f.readState === 'read' && !b.read) return false
+  if (f.readState === 'unread' && b.read) return false
+  if (f.owners.length && !f.owners.includes(b.owner.trim())) return false
+  if (f.categories.length && !b.categories.some(c => f.categories.includes(c))) return false
+  if (b.readMotivation < f.minMotivation || b.readMotivation > f.maxMotivation) return false
+  return true
+}
+
+const filteredBooks = computed(() => {
+  const terms = searchTerms.value
+  const hasSearch = terms.length > 0
+  const hasFilters = activeFilterCount.value > 0
+  if (!hasSearch && !hasFilters) return books.value
+  return books.value.filter(b => {
+    if (hasFilters && !bookPassesFilters(b)) return false
+    if (hasSearch && !matchBook(b, terms)) return false
+    return true
+  })
+})
+
+function clearFilters() {
+  filters.value = defaultFilters()
+}
+
+function toggleOwnerFilter(o: string) {
+  const list = filters.value.owners
+  const i = list.indexOf(o)
+  if (i >= 0) list.splice(i, 1)
+  else list.push(o)
+}
+
+function toggleCategoryFilter(c: string) {
+  const list = filters.value.categories
+  const i = list.indexOf(c)
+  if (i >= 0) list.splice(i, 1)
+  else list.push(c)
+}
 
 watch(viewMode, v => {
   try { localStorage.setItem(STORAGE_KEY_VIEW, v) } catch { /* ignore */ }

--- a/server/src/services/isbn-lookup.service.ts
+++ b/server/src/services/isbn-lookup.service.ts
@@ -22,8 +22,10 @@ import { config } from '../config/env.js'
 
 const PROVIDER_GOOGLE = 'google'
 const PROVIDER_OPENLIBRARY = 'openlibrary'
+const PROVIDER_OPENLIBRARY_GAPFILL = 'openlibrary-gapfill'
 
 const GOOGLE_BOOKS_URL = 'https://www.googleapis.com/books/v1/volumes'
+const OPENLIBRARY_DATA_URL = 'https://openlibrary.org/api/books'
 
 const fallbackClient = new Isbn()
 fallbackClient.provider([PROVIDER_OPENLIBRARY])
@@ -149,6 +151,89 @@ function pickThumbnail(info: Record<string, unknown>): string {
   return ''
 }
 
+/**
+ * Direct Open Library `?jscmd=data` lookup. Exposes richer subjects /
+ * number_of_pages / cover URLs than @library-pals/isbn's parser pulls
+ * out today, which is why we keep both paths.
+ *
+ * Used in two places: (a) as a fallback inside `tryChain` would be
+ * overkill — we already have @library-pals for that; (b) as the
+ * **gap-fill** source after a successful Google hit that came back
+ * missing fields. The shape returned matches `LibraryBookLookup`, with
+ * the categories/page fields populated when available so `mergeGaps`
+ * can lift them onto the primary record.
+ */
+async function fetchOpenLibraryDirect(isbn: string): Promise<LibraryBookLookup> {
+  const url = new URL(OPENLIBRARY_DATA_URL)
+  url.searchParams.set('bibkeys', `ISBN:${isbn}`)
+  url.searchParams.set('jscmd', 'data')
+  url.searchParams.set('format', 'json')
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 6000)
+  let res: Response
+  try {
+    res = await fetch(url, { signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+
+  if (!res.ok) {
+    const err = new Error(`Open Library responded ${res.status}`) as Error & { status: number }
+    err.status = res.status
+    throw err
+  }
+
+  const json = (await res.json()) as Record<string, unknown>
+  const key = `ISBN:${isbn}`
+  const record = json[key] as Record<string, unknown> | undefined
+  if (!record) {
+    const err = new Error('Open Library has no record for this ISBN') as Error & { status: number }
+    err.status = 404
+    throw err
+  }
+
+  const authors = Array.isArray(record.authors)
+    ? (record.authors as Array<Record<string, unknown>>)
+        .map(a => (typeof a.name === 'string' ? a.name : ''))
+        .filter(Boolean)
+    : []
+  const publishers = Array.isArray(record.publishers)
+    ? (record.publishers as Array<Record<string, unknown>>)
+        .map(p => (typeof p.name === 'string' ? p.name : ''))
+        .filter(Boolean)
+    : []
+  const subjects = Array.isArray(record.subjects)
+    ? (record.subjects as Array<Record<string, unknown>>)
+        .map(s => (typeof s.name === 'string' ? s.name : ''))
+        // Filter out LCSH subdivisions ("X -- Y -- Z") that aren't useful
+        // as user-facing genre labels.
+        .filter(s => s && !s.includes(' -- '))
+        .slice(0, 10)
+    : []
+  const cover = (record.cover as Record<string, unknown> | undefined) ?? {}
+  const thumbnail = [cover.medium, cover.large, cover.small]
+    .find((v): v is string => typeof v === 'string' && v.length > 0) ?? ''
+  const description = typeof record.description === 'string'
+    ? record.description
+    : (record.description as Record<string, unknown> | undefined)?.value as string ?? ''
+
+  return {
+    isbn,
+    title: typeof record.title === 'string' ? record.title : '',
+    authors,
+    publisher: publishers[0] ?? '',
+    publishedDate: typeof record.publish_date === 'string' ? record.publish_date : '',
+    description,
+    pageCount: typeof record.number_of_pages === 'number' ? record.number_of_pages : null,
+    thumbnail,
+    categories: subjects,
+    language: '',
+    provider: PROVIDER_OPENLIBRARY_GAPFILL,
+    raw: record,
+  }
+}
+
 async function tryOpenLibrary(isbn: string): Promise<LibraryBookLookup> {
   const book = await fallbackClient.resolve(isbn, { timeout: 8000 }) as PalsBook
   return {
@@ -199,6 +284,58 @@ async function runAttempt(
   }
 }
 
+/** True when the record is missing at least one field that gap-fill can plug. */
+function hasGaps(b: LibraryBookLookup): boolean {
+  return (
+    b.categories.length === 0
+    || b.pageCount === null
+    || b.description.trim() === ''
+    || b.thumbnail.trim() === ''
+  )
+}
+
+/**
+ * Fill the empty fields of `primary` with values from `supplement`.
+ * Non-empty primary fields always win. The provider attribution stays
+ * on `primary` (it's the canonical source); the `raw` payload picks up
+ * a `_gapFilled` annotation so the JSON inspector shows what was added
+ * and where it came from.
+ */
+function mergeGaps(primary: LibraryBookLookup, supplement: LibraryBookLookup): LibraryBookLookup {
+  const filledFields: string[] = []
+  const pickString = (a: string, b: string, name: string) => {
+    if (!a && b) { filledFields.push(name); return b }
+    return a
+  }
+  const pickArray = (a: string[], b: string[], name: string) => {
+    if (a.length === 0 && b.length > 0) { filledFields.push(name); return b }
+    return a
+  }
+
+  const merged: LibraryBookLookup = {
+    isbn: primary.isbn,
+    title: pickString(primary.title, supplement.title, 'title'),
+    authors: pickArray(primary.authors, supplement.authors, 'authors'),
+    publisher: pickString(primary.publisher, supplement.publisher, 'publisher'),
+    publishedDate: pickString(primary.publishedDate, supplement.publishedDate, 'publishedDate'),
+    description: pickString(primary.description, supplement.description, 'description'),
+    pageCount: primary.pageCount !== null
+      ? primary.pageCount
+      : (supplement.pageCount !== null ? (filledFields.push('pageCount'), supplement.pageCount) : null),
+    thumbnail: pickString(primary.thumbnail, supplement.thumbnail, 'thumbnail'),
+    categories: pickArray(primary.categories, supplement.categories, 'categories'),
+    language: pickString(primary.language, supplement.language, 'language'),
+    provider: primary.provider,
+    raw: {
+      ...((primary.raw as Record<string, unknown>) ?? {}),
+      _gapFilled: filledFields.length
+        ? { from: supplement.provider, fields: filledFields, raw: supplement.raw }
+        : undefined,
+    },
+  }
+  return merged
+}
+
 /** Run Google → Open Library against one ISBN form. */
 async function tryChain(isbn: string): Promise<{ data?: LibraryBookLookup; attempts: ProviderAttempt[] }> {
   const attempts: ProviderAttempt[] = []
@@ -215,6 +352,35 @@ async function tryChain(isbn: string): Promise<{ data?: LibraryBookLookup; attem
 }
 
 /**
+ * If the winning record is missing fields that Open Library typically
+ * carries (categories, page count, description, cover), call the OL
+ * data API for the same ISBN and merge in only the empty slots.
+ *
+ * Skipped when the primary record is itself already Open Library —
+ * re-querying the same source rarely helps. The OL provider id from
+ * @library-pals/isbn is "Open Library" (with space), so we detect both
+ * forms.
+ */
+async function gapFillIfNeeded(
+  primary: LibraryBookLookup,
+  isbnForLookup: string,
+  attempts: ProviderAttempt[]
+): Promise<LibraryBookLookup> {
+  if (!hasGaps(primary)) return primary
+  const p = primary.provider.toLowerCase()
+  if (p.includes('openlibrary') || p.includes('open library')) return primary
+
+  const fill = await runAttempt(
+    PROVIDER_OPENLIBRARY_GAPFILL,
+    isbnForLookup,
+    () => fetchOpenLibraryDirect(isbnForLookup)
+  )
+  attempts.push(fill.attempt)
+  if (!fill.ok) return primary
+  return mergeGaps(primary, fill.data)
+}
+
+/**
  * Main entry. Throws an Error with `.attempts` attached if nothing matches.
  * `userIsbn` is what the user originally scanned — that form is preserved on
  * the returned data even when a conversion was needed.
@@ -224,14 +390,20 @@ export async function lookupIsbn(userIsbn: string): Promise<IsbnLookupResult> {
 
   const first = await tryChain(userIsbn)
   allAttempts.push(...first.attempts)
-  if (first.data) return { data: { ...first.data, isbn: userIsbn }, attempts: allAttempts }
+  if (first.data) {
+    const filled = await gapFillIfNeeded(first.data, userIsbn, allAttempts)
+    return { data: { ...filled, isbn: userIsbn }, attempts: allAttempts }
+  }
 
   // Convert and try again with the alternate form.
   const alt = userIsbn.length === 13 ? isbn13to10(userIsbn) : userIsbn.length === 10 ? isbn10to13(userIsbn) : null
   if (alt && alt !== userIsbn) {
     const second = await tryChain(alt)
     allAttempts.push(...second.attempts)
-    if (second.data) return { data: { ...second.data, isbn: userIsbn }, attempts: allAttempts }
+    if (second.data) {
+      const filled = await gapFillIfNeeded(second.data, alt, allAttempts)
+      return { data: { ...filled, isbn: userIsbn }, attempts: allAttempts }
+    }
   }
 
   const error = new Error('No provider returned a record for this ISBN') as Error & { attempts: ProviderAttempt[] }


### PR DESCRIPTION
## Summary
Two related improvements driven by what production telemetry has been showing.

### Server: gap-fill from Open Library's data API
Many Google Books records come back with empty `categories`, `pageCount`, `description`, or `thumbnail`. The lookup service now does a second pass against Open Library's `https://openlibrary.org/api/books?bibkeys=ISBN:&jscmd=data&format=json` endpoint to fill those gaps **only** before returning to the client.

- The primary provider's values always win; gap-fill only plugs empty slots.
- Subjects from OL are filtered to skip LCSH subdivisions (`"X -- Y -- Z"`) and capped at 10 so the UI doesn't get spammed with cataloguer-style headings.
- The merge step is recorded as its own `openlibrary-gapfill` telemetry row, so the per-provider dashboard now shows how often it contributes.
- The raw payload picks up a `_gapFilled: { from, fields, raw }` annotation, visible in the JSON-details modal — full transparency about where each field came from.
- Skipped when the primary record was itself already Open Library (avoids the wasteful same-source second call). Detects both `openlibrary` and `Open Library` (the @library-pals/isbn variant).

Latency: unchanged on complete Google hits; ~300–800ms added on incomplete records (the population that needed help anyway).

### Client: filter panel on MyLibrary
A new **Filters** button (with active-count badge) opens a collapsible panel below the toolbar:

- **Read state** — three-way All / Read / Unread pill toggle.
- **Owner** — chips of every owner present in the library, sorted alphabetically; multi-select OR.
- **Categories** — chips of the **top 20 most-frequent** categories in the library, sorted by count; multi-select OR. Anything beyond the top 20 remains reachable via the search `cat:` prefix.
- **Want-to-read score** — two `RangeSlider`s (From / To, 0–100) with an inline warning if From > To.
- **Clear all** appears when anything is active.

Composes cleanly with the existing tokenised search. Empty-state copy adapts to which combination (search / filters / both) is active.

## Telemetry to expect once deployed
```sql
SELECT provider, COUNT(*) FILTER (WHERE succeeded) AS hits
FROM library_scan_events
WHERE phase='lookup' AND created_at > NOW() - INTERVAL '1 day'
GROUP BY provider ORDER BY hits DESC;
```
You should now see an `openlibrary-gapfill` row whenever Google's response was incomplete.

## Test plan
- [ ] Scan a book Google has but with no categories — verify the saved record now carries OL's subjects
- [ ] Scan a book Google fully covers — verify no `openlibrary-gapfill` telemetry row is logged (no gaps → no call)
- [ ] Open the JSON-details modal on a gap-filled book — verify the `_gapFilled` annotation in the raw payload
- [ ] Open Filters → toggle Read / Unread; verify list narrows
- [ ] Toggle a few category chips; verify OR semantics
- [ ] Slide From above To — verify the red inline warning appears and the list empties
- [ ] Combine filters + search (`author:` prefix); verify both narrow
- [ ] Clear all → list returns to full
- [ ] `npm run type-check` passes in `server/` and `client/` (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)