### PR TITLE
Allow custom cover image upload for library books

### DIFF
--- a/client/src/api/library.ts
+++ b/client/src/api/library.ts
@@ -36,6 +36,18 @@ export const libraryApi = {
   delete: (id: string) =>
     api.delete<void>(`/library/${id}`),
 
+  /**
+   * Upload a custom cover image. The server persists the bytes in the
+   * uploaded_files PostgreSQL table (Heroku's filesystem is ephemeral)
+   * and returns the served path the client should store in
+   * library_books.thumbnail.
+   */
+  uploadCover: (file: File) => {
+    const form = new FormData()
+    form.append('file', file)
+    return api.postFormData<{ data: { path: string } }>('/library/upload', form).then(r => r.data.path)
+  },
+
   /** Fire-and-forget client-side telemetry for the scan funnel. */
   logScanEvent: (event: LibraryScanEventInput) =>
     api.post<void>('/library/telemetry', event).catch(err => {

--- a/client/src/components/library/BookEditor.vue
+++ b/client/src/components/library/BookEditor.vue
@@ -11,16 +11,50 @@
 
     <!-- Identity row -->
     <div class="flex gap-4 mb-4">
-      <img
-        v-if="form.thumbnail"
-        :src="form.thumbnail"
-        :alt="form.title"
-        class="w-20 h-28 object-cover border border-line shrink-0"
-      />
+      <div class="shrink-0">
+        <div class="w-20 h-28 sm:w-24 sm:h-32 border border-line bg-surface overflow-hidden flex items-center justify-center">
+          <img
+            v-if="form.thumbnail"
+            :src="form.thumbnail"
+            :alt="form.title"
+            class="w-full h-full object-cover"
+          />
+          <span v-else class="text-[9px] tracking-widest uppercase text-ink-lighter text-center px-2">
+            No cover
+          </span>
+        </div>
+        <div class="flex gap-1 mt-1.5">
+          <button
+            type="button"
+            @click="triggerCoverPicker"
+            :disabled="busy || coverUploading"
+            class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light hover:text-ink hover:bg-surface transition-colors disabled:opacity-50"
+            :title="form.thumbnail ? 'Replace cover image' : 'Upload a custom cover'"
+          >
+            {{ coverUploading ? 'Up…' : (form.thumbnail ? 'Replace' : 'Upload') }}
+          </button>
+          <button
+            v-if="form.thumbnail"
+            type="button"
+            @click="clearCover"
+            :disabled="busy || coverUploading"
+            class="text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-line text-ink-light hover:text-red-600 transition-colors disabled:opacity-50"
+            title="Remove the cover"
+          >Clear</button>
+        </div>
+        <input
+          ref="coverFileInput"
+          type="file"
+          accept="image/jpeg,image/png,image/gif,image/webp"
+          class="hidden"
+          @change="onCoverFilePicked"
+        />
+      </div>
       <div class="flex-1 min-w-0 text-sm">
         <p class="text-[10px] uppercase tracking-widest text-ink-lighter mb-0.5">ISBN</p>
         <p class="font-mono text-ink">{{ form.isbn || '—' }}</p>
         <p v-if="form.provider" class="text-xs text-ink-lighter mt-1">via {{ form.provider }}</p>
+        <p v-if="coverError" class="text-xs text-red-700 mt-2">{{ coverError }}</p>
       </div>
     </div>
 
@@ -57,8 +91,10 @@
       </label>
 
       <label class="block sm:col-span-2">
-        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">Cover URL</span>
-        <input v-model="form.thumbnail" type="url" class="input" />
+        <span class="block text-xs uppercase tracking-widest text-ink-lighter mb-1">
+          Cover URL <span class="text-ink-lighter normal-case tracking-normal">(uploaded covers fill this automatically)</span>
+        </span>
+        <input v-model="form.thumbnail" type="url" class="input" placeholder="https://… or /uploads/cover/…" />
       </label>
 
       <label class="block sm:col-span-2">
@@ -146,9 +182,12 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, computed, watch } from 'vue'
+import { reactive, computed, watch, ref } from 'vue'
 import type { LibraryBook, LibraryBookLookup } from '@shared/LibraryBook'
 import RangeSlider from './RangeSlider.vue'
+import { libraryApi } from '../../api/library'
+
+const MAX_COVER_BYTES = 10 * 1024 * 1024 // matches server's multer limit
 
 export interface EditorForm {
   isbn: string
@@ -259,6 +298,56 @@ watch(() => props.initial, (next) => {
 
 function onSave() {
   emit('save', { ...form, authors: [...form.authors], categories: [...form.categories] })
+}
+
+// --- Custom cover upload --------------------------------------------------
+//
+// User picks an image, we POST it as multipart to /api/library/upload, the
+// server persists the bytes in the uploaded_files PostgreSQL table (so it
+// survives Heroku dyno restarts), and returns the served path which we drop
+// into form.thumbnail. The "Cover URL" text input is still there as the
+// canonical store for the URL — it just gets filled in for the user.
+
+const coverFileInput = ref<HTMLInputElement | null>(null)
+const coverUploading = ref(false)
+const coverError = ref<string | null>(null)
+
+function triggerCoverPicker() {
+  coverError.value = null
+  coverFileInput.value?.click()
+}
+
+function clearCover() {
+  form.thumbnail = ''
+  coverError.value = null
+  if (coverFileInput.value) coverFileInput.value.value = ''
+}
+
+async function onCoverFilePicked(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  // Reset the input so the same filename can be re-selected after a clear.
+  input.value = ''
+
+  if (!/^image\/(jpeg|png|gif|webp)$/.test(file.type)) {
+    coverError.value = 'Use JPEG, PNG, GIF, or WebP.'
+    return
+  }
+  if (file.size > MAX_COVER_BYTES) {
+    coverError.value = `Image is too large (${Math.round(file.size / 1024 / 1024)}MB). Max is 10MB.`
+    return
+  }
+
+  coverUploading.value = true
+  coverError.value = null
+  try {
+    form.thumbnail = await libraryApi.uploadCover(file)
+  } catch (err) {
+    coverError.value = err instanceof Error ? err.message : 'Upload failed'
+  } finally {
+    coverUploading.value = false
+  }
 }
 </script>
 

--- a/server/src/routes/library.routes.ts
+++ b/server/src/routes/library.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { libraryController } from '../controllers/library.controller.js'
+import { uploadsController, uploadSingle } from '../controllers/uploads.controller.js'
 import { authMiddleware } from '../middleware/auth.middleware.js'
 import { asyncHandler } from '../utils/asyncHandler.js'
 
@@ -11,6 +12,11 @@ router.get('/', asyncHandler(libraryController.list))
 router.get('/lookup/:isbn', asyncHandler(libraryController.lookup))
 router.post('/', asyncHandler(libraryController.create))
 router.post('/telemetry', asyncHandler(libraryController.logTelemetry))
+// Custom cover upload. Reuses the shared uploadsController so images
+// land in the same uploaded_files PostgreSQL table (survives Heroku's
+// ephemeral filesystem). Returns { data: { path: "/uploads/cover/<uuid>.jpg" } }
+// which the client stores in library_books.thumbnail.
+router.post('/upload', uploadSingle, asyncHandler(uploadsController.upload))
 router.patch('/:id', asyncHandler(libraryController.update))
 router.delete('/:id', asyncHandler(libraryController.delete))
 


### PR DESCRIPTION
## Summary
When a provider doesn't return a cover image — or the user wants their own photo of the book — they can now upload one from the BookEditor modal. The file is persisted in the existing `uploaded_files` PostgreSQL table (migration 015) so it survives Heroku dyno restarts, unlike the ephemeral filesystem.

## Why use the existing table
Migration 015 already creates `uploaded_files` specifically because the project ran into Heroku's ephemeral-FS problem before; reusing it means no new schema, no new serving code, and covers benefit from the existing `Cache-Control: public, max-age=31536000, immutable` ETag serving.

## Server
- New route `POST /api/library/upload` in `server/src/routes/library.routes.ts`. Reuses the shared `uploadSingle` multer middleware and `uploadsController.upload` — no controller duplication; the new route is just a library-namespaced alias.
- Flow: multer parses multipart → controller reads the temp file → bytes go into `uploaded_files` (BYTEA) → temp file unlinked → response `{ data: { path: '/uploads/cover/<uuid>.jpg' } }`.
- The existing `GET /uploads/cover/:filename` route (in `app.ts:111`) serves bytes back from PostgreSQL with aggressive immutable caching.
- Auth: `authMiddleware` already on the library router. Limits inherited from the shared controller — JPEG / PNG / GIF / WebP, ≤ 10MB.

## Client
- `libraryApi.uploadCover(file)` in `client/src/api/library.ts` — wraps the file in `FormData` and POSTs.
- `BookEditor.vue`'s identity row now hosts a small cover preview frame (80×112 on phones, 96×128 on sm+) showing the current cover or a "No cover" placeholder. Below it: **Upload** / **Replace** / **Clear** chips and a hidden `<input type="file" accept="image/jpeg,image/png,image/gif,image/webp">`. The file picker opens the OS file chooser on desktop and the camera/photos sheet on iPad / Android.
- Client-side validation mirrors the server's (mime whitelist + ≤10MB) so over-limit selections fail fast without a round-trip. Errors render inline next to the ISBN row.
- The existing "Cover URL" text input stays as the canonical store and remains editable for external-URL workflows.

## Test plan
- [ ] Add a new book whose provider returned no cover → tap **Upload** → pick a JPEG → preview updates → Save → list shows the custom cover
- [ ] Edit an existing book → **Replace** → swaps cover; old `/uploads/cover/...` URL is replaced with the new one
- [ ] **Clear** → reverts to the "No cover" placeholder, `thumbnail` field empties
- [ ] Reject a 20MB PNG client-side → red inline error, no upload attempt
- [ ] After a Heroku dyno restart, an uploaded cover still serves (because it's in PostgreSQL, not local FS)
- [ ] `npm run type-check` in `server/` and `client/` (both verified locally — exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)