### PR TITLE
Lock library to admin-only + fix uploaded_files ON CONFLICT

### DIFF
--- a/client/src/layouts/DefaultLayout.vue
+++ b/client/src/layouts/DefaultLayout.vue
@@ -37,6 +37,7 @@
                 Manuscripts
               </router-link>
               <router-link
+                v-if="isAdmin"
                 to="/library"
                 class="pb-0.5 hover:text-ink transition-colors duration-300"
                 :class="route.name === 'MyLibrary' ? 'text-ink border-b border-ink' : 'text-ink-lighter'"
@@ -268,7 +269,7 @@
             Manuscripts
           </router-link>
           <router-link
-            v-if="isAuthenticated"
+            v-if="isAuthenticated && isAdmin"
             to="/library"
             @click="menuOpen = false"
             class="block text-sm tracking-wide font-sans hover:text-ink transition-colors duration-300"

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -129,7 +129,7 @@ const router = createRouter({
       path: '/library',
       name: 'MyLibrary',
       component: MyLibrary,
-      meta: { requiresAuth: true }
+      meta: { requiresAuth: true, requiresAdmin: true }
     },
     {
       path: '/profile',

--- a/server/src/db/migrations/034_uploaded_files_filename_unique.sql
+++ b/server/src/db/migrations/034_uploaded_files_filename_unique.sql
@@ -1,0 +1,25 @@
+-- Migration 034: Ensure uploaded_files.filename has a UNIQUE index
+--
+-- Migration 015 declared `filename VARCHAR(255) NOT NULL UNIQUE`, but the
+-- migration uses CREATE TABLE IF NOT EXISTS — any production database
+-- whose `uploaded_files` table predates that wording silently skipped
+-- the create and never picked up the UNIQUE constraint.
+--
+-- uploadsRepo.save() relies on `ON CONFLICT (filename) DO UPDATE`, which
+-- in PostgreSQL requires a matching unique constraint or unique index.
+-- Without it the query 500s with
+--   "there is no unique or exclusion constraint matching the ON CONFLICT
+--    specification"
+-- as soon as anyone tries to upload a file (covers, library covers,
+-- anywhere else uploadsRepo is reused).
+--
+-- This migration adds a unique index idempotently. The pre-existing
+-- non-unique idx_uploaded_files_filename stays in place — harmless,
+-- and removing it would risk a brief window with no index between the
+-- DROP and CREATE on a busy DB.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uploaded_files_filename_uniq
+  ON uploaded_files (filename);
+
+COMMENT ON INDEX uploaded_files_filename_uniq IS
+  'Backfills the UNIQUE that migration 015 declared inline but never applied to pre-existing tables. Required for ON CONFLICT (filename) upserts.';

--- a/server/src/routes/library.routes.ts
+++ b/server/src/routes/library.routes.ts
@@ -2,11 +2,18 @@ import { Router } from 'express'
 import { libraryController } from '../controllers/library.controller.js'
 import { uploadsController, uploadSingle } from '../controllers/uploads.controller.js'
 import { authMiddleware } from '../middleware/auth.middleware.js'
+import { requireAdmin } from '../middleware/authorize.middleware.js'
 import { asyncHandler } from '../utils/asyncHandler.js'
 
 const router = Router()
 
+// MyLibrary is currently an admin-only feature. authMiddleware first to
+// attach userId/userRole; requireAdmin then forbids anyone whose role
+// isn't 'admin'. Belt-and-braces: every route inherits both, including
+// the lookup, telemetry, and upload endpoints, so there's no way to
+// reach any library API as a non-admin.
 router.use(authMiddleware)
+router.use(requireAdmin)
 
 router.get('/', asyncHandler(libraryController.list))
 router.get('/lookup/:isbn', asyncHandler(libraryController.lookup))


### PR DESCRIPTION
## Summary
Two related changes shipped together to land the admin-only MyLibrary feature properly.

### Permissions lock — library is now admin-only
- **Server** ([library.routes.ts](server/src/routes/library.routes.ts)): every `/api/library/*` route runs `authMiddleware` then `requireAdmin` at the router level, so **list / lookup / create / telemetry / update / delete / upload** all 403 (`ForbiddenError: 'Admin access required'`) for non-admins.
- **Client router** ([router/index.ts](client/src/router/index.ts)): `/library` gains `requiresAdmin` in its meta. The existing route guard already redirects non-admins to `/home`.
- **Navigation** ([DefaultLayout.vue](client/src/layouts/DefaultLayout.vue)): the "Library" link in the desktop top nav and the mobile menu is now gated on `isAdmin`, so non-admins never see it.

Mirrors how the existing `/admin/*` routes are gated in the codebase — same `requireAdmin` middleware, same `meta.requiresAdmin` pattern.

### Migration 034 — `uploaded_files.filename` UNIQUE backfill
Heroku app logs showed every `POST /api/library/upload` 500'ing with:
```
DatabaseError: there is no unique or exclusion constraint matching the ON CONFLICT specification
  at Object.save (uploads.repo.js)
  at upload (uploads.controller.js)
```

**Root cause**: migration 015 declares `filename VARCHAR(255) NOT NULL UNIQUE` inline, but it uses `CREATE TABLE IF NOT EXISTS`. On this production DB the `uploaded_files` table predates that wording, so the create was a silent no-op and the UNIQUE constraint never landed. `uploadsRepo.save`'s `ON CONFLICT (filename) DO UPDATE` needs a matching unique constraint/index to function.

Verified directly against production:
```
\d uploaded_files
Indexes:
  "uploaded_files_pkey" PRIMARY KEY, btree (id)
  "idx_uploaded_files_filename" btree (filename)   ← non-unique
```

**Fix**: idempotent `CREATE UNIQUE INDEX IF NOT EXISTS uploaded_files_filename_uniq ON uploaded_files (filename)`. Fresh DBs that already have the constraint from migration 015 skip cleanly because the index name is new (and `IF NOT EXISTS` covers the case where this migration has run already).

**Scope**: this isn't specific to library covers — `uploadsRepo.save` is also used by the writing-cover upload and admin-uploads paths. Anything that ever uploads a file is fixed by this migration.

## Test plan
After deploy (heroku.yml release phase will apply migration 034 automatically):
- [ ] Non-admin user: no "Library" link in nav; `/library` URL redirects to `/home`; direct `/api/library/*` requests return 403
- [ ] Admin user: nav still shows the link; `/library` renders; existing flows work
- [ ] Admin uploads a cover from BookEditor → file persists in `uploaded_files`, served via `/uploads/cover/<uuid>.jpg`
- [ ] Admin uploads a cover from the preview modal — same outcome
- [ ] After dyno restart, uploaded covers still served (PostgreSQL, not local FS)
- [ ] `npm run type-check` in `server/` and `client/` (verified locally — exit 0)

## Verification of the fix
On Heroku post-deploy:
```bash
heroku run --app befly -- psql \$DATABASE_URL -c "\\d uploaded_files"
```
Expect to see the new `uploaded_files_filename_uniq` UNIQUE index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)