### PR TITLE
Frag page breaks — [[pb]] marker forces a new page in print/PDF

### DIFF
--- a/client/src/components/manuscripts/BookPreviewModal.vue
+++ b/client/src/components/manuscripts/BookPreviewModal.vue
@@ -1333,7 +1333,7 @@
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount, h, defineComponent, type PropType } from 'vue'
 import { api } from '../../api/client'
 import { bookPrintingApi } from '../../api/bookPrinting'
-import { renderMarkdown } from '../../utils/markdown'
+import { renderMarkdownForPrint } from '../../utils/markdown'
 import type { ApiResponse } from '@shared/ApiResponses'
 import type {
   ManuscriptProject,
@@ -1873,15 +1873,20 @@ const loadingBodies = ref(false)
 const loadError = ref<string | null>(null)
 const bodyById = ref<Map<string, string>>(new Map())
 
-// Cache rendered markdown by writingBlockId. renderMarkdown can be slow for
-// long essays, and bookFlowHtml depends on enough fields that even unrelated
-// settings (chapter title style, scene break symbol, author name keystrokes)
-// would otherwise re-run renderMarkdown for every essay each time. Caching
-// here means renderMarkdown only runs when the underlying body changes.
+// Cache rendered markdown by writingBlockId. renderMarkdownForPrint can be
+// slow for long essays, and bookFlowHtml depends on enough fields that even
+// unrelated settings (chapter title style, scene break symbol, author name
+// keystrokes) would otherwise re-render every essay each time. Caching here
+// means we only re-render when the underlying body changes.
+//
+// We use the *ForPrint variant so author-inserted `[[pb]]` page-break markers
+// produce real page breaks in the printed PDF (and on-screen column breaks in
+// the preview); the screen-only paths use plain renderMarkdown, which strips
+// the marker so it never leaks as literal text.
 const renderedHtmlById = computed<Map<string, string>>(() => {
   const map = new Map<string, string>()
   for (const [id, body] of bodyById.value) {
-    map.set(id, body ? renderMarkdown(body) : '<p><em>(Body not loaded.)</em></p>')
+    map.set(id, body ? renderMarkdownForPrint(body) : '<p><em>(Body not loaded.)</em></p>')
   }
   return map
 })

--- a/client/src/components/manuscripts/__snapshots__/BookPreviewModal.snapshot.spec.ts.snap
+++ b/client/src/components/manuscripts/__snapshots__/BookPreviewModal.snapshot.spec.ts.snap
@@ -111,6 +111,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     color: #1f1a14;
   }
 
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
+
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
   .bp-item > p:first-child,
@@ -381,6 +391,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     color: #1f1a14;
   }
 
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
+
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
   .bp-item > p:first-child,
@@ -644,6 +664,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     -webkit-hyphens: auto;
     color: #1f1a14;
   }
+
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
 
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
@@ -943,6 +973,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     color: #1f1a14;
   }
 
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
+
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
   .bp-item > p:first-child,
@@ -1224,6 +1264,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     color: #1f1a14;
   }
 
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
+
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
   .bp-item > p:first-child,
@@ -1458,6 +1508,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     color: #1f1a14;
   }
 
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
+
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
   .bp-item > p:first-child,
@@ -1685,6 +1745,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     -webkit-hyphens: auto;
     color: #1f1a14;
   }
+
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
 
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
@@ -1937,6 +2007,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     -webkit-hyphens: auto;
     color: #1f1a14;
   }
+
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
 
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
@@ -2233,6 +2313,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     -webkit-hyphens: auto;
     color: #1f1a14;
   }
+
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
 
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
@@ -2534,6 +2624,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     color: #1f1a14;
   }
 
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
+
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
   .bp-item > p:first-child,
@@ -2827,6 +2927,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     -webkit-hyphens: auto;
     color: #1f1a14;
   }
+
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
 
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }
@@ -3155,6 +3265,16 @@ exports[`BookPreviewModal — depth-1 regression snapshots (Phase 1 baseline) > 
     -webkit-hyphens: auto;
     color: #1f1a14;
   }
+
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
 
   /* ===== Body type ===== */
   p { margin: 0; text-indent: 0.25in; padding-bottom: 0pt; }

--- a/client/src/components/manuscripts/bookPreview/print.ts
+++ b/client/src/components/manuscripts/bookPreview/print.ts
@@ -324,6 +324,16 @@ export function buildNaturalPrintHtml(args: PrintBuildArgs): string {
     color: #1f1a14;
   }
 
+  /* ===== Author-inserted page breaks =====
+     [[pb]] markers in a frag body are rendered as a div with class
+     bp-page-break-after (see renderMarkdownForPrint). The screen preview
+     handles these as column breaks; the print stylesheet needs the
+     equivalent paged-media rule so the marker pushes the next paragraph
+     onto a new physical page. The div carries no content, so it must not
+     introduce vertical space. */
+  .bp-page-break-after  { break-after: page; height: 0; margin: 0; padding: 0; }
+  .bp-page-break-before { break-before: page; height: 0; margin: 0; padding: 0; }
+
   /* ===== Body type ===== */
   p { margin: 0; text-indent: ${indent}; padding-bottom: ${paraSpacing}; }
   .bp-item > p:first-child,

--- a/client/src/pages/Read.vue
+++ b/client/src/pages/Read.vue
@@ -253,7 +253,8 @@ import {
   bodyMarkdownAfterExcerptPrefix,
   excerptPlainCutLength,
   isStandaloneHtmlDoc,
-  renderMarkdown
+  renderMarkdownForPrint,
+  stripPageBreakMarkers
 } from '../utils/markdown'
 import { buildNaturalPrintHtml, openPrintWindow } from '../components/manuscripts/bookPreview/print'
 import { defaultPaperbackProfile } from '../components/manuscripts/bookPreview/defaults'
@@ -278,7 +279,7 @@ const isSpa = computed(() => isStandaloneHtmlDoc(writing.value?.body))
 const paragraphs = computed(() => {
   if (!writing.value) return []
   if (isSpa.value) return []
-  const afterExcerpt = bodyMarkdownAfterExcerptPrefix(writing.value.body)
+  const afterExcerpt = stripPageBreakMarkers(bodyMarkdownAfterExcerptPrefix(writing.value.body))
   return afterExcerpt.split(/\n\n+/).filter(p => p.trim().length > 0)
 })
 
@@ -346,7 +347,7 @@ const printEssay = () => {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-  const bodyHtml = renderMarkdown(w.body || '')
+  const bodyHtml = renderMarkdownForPrint(w.body || '')
   const flow =
     `<section class="bp-chapter bp-chapter-opening bp-page-break-before">
        <div class="bp-chapter-heading">${titleEscaped}</div>

--- a/client/src/utils/markdown.spec.ts
+++ b/client/src/utils/markdown.spec.ts
@@ -10,7 +10,10 @@ import {
   excerptPlainCutLength,
   readingExcerptPlainCutLength,
   READING_EXCERPT_PLAIN_LENGTH,
-  isStandaloneHtmlDoc
+  isStandaloneHtmlDoc,
+  stripPageBreakMarkers,
+  renderMarkdown,
+  renderMarkdownForPrint
 } from './markdown'
 
 describe('isStandaloneHtmlDoc', () => {
@@ -143,5 +146,57 @@ describe('bodyMarkdownAfterExcerptPrefix', () => {
     const cut = excerptPlainCutLength(full)
     const after = bodyMarkdownAfterExcerptPrefix(md)
     expect(full.substring(cut).trimStart()).toBe(markdownToText(after).trimStart())
+  })
+})
+
+describe('[[pb]] page-break markers', () => {
+  it('stripPageBreakMarkers removes marker-only lines', () => {
+    const md = 'one\n\n[[pb]]\n\ntwo'
+    expect(stripPageBreakMarkers(md)).toBe('one\n\ntwo')
+  })
+
+  it('stripPageBreakMarkers tolerates surrounding whitespace on the marker line', () => {
+    expect(stripPageBreakMarkers('a\n  [[pb]]  \nb')).toBe('a\n\nb')
+  })
+
+  it('stripPageBreakMarkers leaves inline [[pb]] alone', () => {
+    expect(stripPageBreakMarkers('he typed [[pb]] in the middle')).toBe('he typed [[pb]] in the middle')
+  })
+
+  it('renderMarkdown strips the marker (does not appear in HTML)', () => {
+    const html = renderMarkdown('para one\n\n[[pb]]\n\npara two')
+    expect(html).not.toContain('[[pb]]')
+    expect(html).not.toContain('bp-page-break-after')
+    expect(html).toContain('para one')
+    expect(html).toContain('para two')
+  })
+
+  it('renderMarkdownForPrint emits a page-break div between chunks', () => {
+    const html = renderMarkdownForPrint('para one\n\n[[pb]]\n\npara two')
+    expect(html).not.toContain('[[pb]]')
+    expect(html).toContain('class="bp-page-break-after"')
+    expect(html.indexOf('para one')).toBeLessThan(html.indexOf('bp-page-break-after'))
+    expect(html.indexOf('bp-page-break-after')).toBeLessThan(html.indexOf('para two'))
+  })
+
+  it('renderMarkdownForPrint handles multiple markers', () => {
+    const html = renderMarkdownForPrint('a\n\n[[pb]]\n\nb\n\n[[pb]]\n\nc')
+    const breaks = html.match(/bp-page-break-after/g) ?? []
+    expect(breaks.length).toBe(2)
+  })
+
+  it('renderMarkdownForPrint is a no-op when no markers are present', () => {
+    const html = renderMarkdownForPrint('just a paragraph')
+    expect(html).not.toContain('bp-page-break-after')
+    expect(html).toContain('just a paragraph')
+  })
+
+  it('markdownToText omits the marker', () => {
+    expect(markdownToText('hi\n\n[[pb]]\n\nbye')).not.toContain('[[pb]]')
+    expect(markdownToText('hi\n\n[[pb]]\n\nbye')).not.toContain('pb')
+  })
+
+  it('countWordsInMarkdown does not count the marker', () => {
+    expect(countWordsInMarkdown('one two three\n\n[[pb]]\n\nfour five')).toBe(5)
   })
 })

--- a/client/src/utils/markdown.ts
+++ b/client/src/utils/markdown.ts
@@ -17,21 +17,58 @@ export function isStandaloneHtmlDoc(s: string | undefined | null): boolean {
 }
 
 /**
- * Render markdown to HTML
+ * Page-break marker. A line containing only `[[pb]]` (whitespace allowed
+ * around it) means "start a new page here in print/PDF output". The marker
+ * is honoured by {@link renderMarkdownForPrint}; everywhere else it is
+ * stripped so it never appears as literal text in the reader view or AI
+ * assist panel.
+ */
+const PAGE_BREAK_LINE_RE = /^[ \t]*\[\[pb\]\][ \t]*$/gm
+
+/** Remove `[[pb]]` marker lines from text. The marker only counts when it
+ *  is the sole content of a line — `[[pb]]` typed mid-sentence is left
+ *  alone, so it can still appear as prose if the author quotes it. Adjacent
+ *  blank lines collapse to a single paragraph break. */
+export function stripPageBreakMarkers(s: string): string {
+  if (!s) return s
+  return s.replace(PAGE_BREAK_LINE_RE, '').replace(/\n{3,}/g, '\n\n')
+}
+
+function marked_(s: string): string {
+  const result = marked(s, { breaks: true, gfm: true })
+  return typeof result === 'string' ? result : String(result)
+}
+
+/**
+ * Render markdown to HTML. `[[pb]]` page-break markers are stripped — use
+ * {@link renderMarkdownForPrint} when you want them to produce actual page
+ * breaks.
  */
 export function renderMarkdown(markdown: string): string {
-  const result = marked(markdown, {
-    breaks: true,
-    gfm: true
-  })
-  return typeof result === 'string' ? result : String(result)
+  return marked_(stripPageBreakMarkers(markdown))
+}
+
+/**
+ * Render markdown to HTML, honouring `[[pb]]` page-break markers by emitting
+ * a `<div class="bp-page-break-after">` between the surrounding chunks. Used
+ * by the book-preview print path and the single-frag print path; both feed
+ * the result into a print stylesheet that maps the class onto
+ * `break-after: page`.
+ */
+export function renderMarkdownForPrint(markdown: string): string {
+  if (!markdown) return ''
+  const chunks = markdown.split(PAGE_BREAK_LINE_RE)
+  if (chunks.length === 1) return marked_(markdown)
+  return chunks
+    .map(c => marked_(c))
+    .join('<div class="bp-page-break-after" aria-hidden="true"></div>')
 }
 
 /**
  * Extract plain text from markdown
  */
 export function markdownToText(markdown: string): string {
-  return markdown
+  return stripPageBreakMarkers(markdown)
     .replace(/#{1,6}\s+/g, '') // Remove headers
     .replace(/\*\*(.*?)\*\*/g, '$1') // Remove bold
     .replace(/\*(.*?)\*/g, '$1') // Remove italic
@@ -151,7 +188,7 @@ export function bodyMarkdownAfterExcerptPrefix(markdown: string, excerptPlainLen
  * (P3-uix-07 / cni-07)
  */
 export function stripMarkdownForWordCount(markdown: string): string {
-  return markdown
+  return stripPageBreakMarkers(markdown)
     .replace(/```[\s\S]*?```/g, '') // Fenced code blocks (before inline code)
     .replace(/#{1,6}\s+/g, '') // Headers
     .replace(/\*\*(.*?)\*\*/g, '$1') // Bold


### PR DESCRIPTION
## Summary

- Writers can put `[[pb]]` on its own line in a frag body to force a page break in the printed PDF.
- Honoured in both print paths: book-preview print (`BookPreviewModal`) and single-frag print (`Read.vue` → `printEssay`).
- Marker is silently stripped from the reader view, AI assist panel, generic markdown renderer, excerpts, and word counts so it never appears as literal text.
- Inline `[[pb]]` mid-sentence is preserved as prose; only marker-only lines are treated as page breaks.

## How it works

- `renderMarkdownForPrint(body)` splits the markdown on marker-only lines and rejoins with `<div class="bp-page-break-after" aria-hidden="true"></div>`.
- New print CSS rule `.bp-page-break-after { break-after: page; height: 0; ... }` makes the class trigger a real paged-media break (previously only the on-screen column preview honoured the class).
- Default `renderMarkdown`, `markdownToText`, and `stripMarkdownForWordCount` all strip the marker so non-print contexts stay clean.

## Files changed

- `client/src/utils/markdown.ts` — new helpers, marker stripped from default renderers.
- `client/src/utils/markdown.spec.ts` — 9 new tests pinning down marker behaviour (strip, render-for-print, multiple markers, no-op, word count, inline-prose preservation).
- `client/src/components/manuscripts/BookPreviewModal.vue` — body cache uses `renderMarkdownForPrint`.
- `client/src/components/manuscripts/bookPreview/print.ts` — print CSS for `.bp-page-break-after` / `.bp-page-break-before`.
- `client/src/pages/Read.vue` — `printEssay` uses `renderMarkdownForPrint`; reader paragraph split strips the marker so it doesn't leave empty `<p>` blocks.
- `client/src/components/manuscripts/__snapshots__/BookPreviewModal.snapshot.spec.ts.snap` — additive update (+120 lines, -0) reflecting the new CSS section in 12 snapshots.

## Test plan

- [x] `npm run type-check` passes
- [x] `npx vitest run src/utils/markdown.spec.ts` — 31 tests pass (22 prior + 9 new)
- [x] `npx vitest run src/components/manuscripts/BookPreviewModal.snapshot.spec.ts` — 12 snapshots pass after additive update
- [x] Full client suite: 60 pass / 8 fail (8 failures are pre-existing on `main`, all in `src/pages/Write.spec.ts` for `Metadata`-button/word-count assertions — unrelated to this change)
- [ ] Manual: type `[[pb]]` on its own line in a frag, open book preview → Print, confirm a page break appears at the marker
- [ ] Manual: same frag in the reader view shows no literal `[[pb]]` text and no empty paragraph at the marker location
- [ ] Manual: open the single-frag print (printer icon on Read view), confirm page break is honoured there too

## Notes for reviewer

- No UI affordance (toolbar button, in-editor hint) — the writer just types `[[pb]]`. Discoverability can be a follow-up if desired.
- The marker is line-anchored: `[[pb]]` mid-sentence stays as prose. The strip regex (`PAGE_BREAK_LINE_RE`) and the split regex are the same, so semantics are consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)