### PR TITLE
Cover preview — scrim on front, fit-to-page blurb on back

### DIFF
--- a/client/src/components/manuscripts/BookPreviewModal.vue
+++ b/client/src/components/manuscripts/BookPreviewModal.vue
@@ -2565,7 +2565,24 @@ const spineEligibility = computed(() => {
   if (n < 250) return 'Standard spine — title + author.'
   return 'Wide spine — title, author, publisher mark.'
 })
-const validation = computed(() => validateConfig(config.value, { estimatedPageCount: estimatedPageCount.value }))
+// True when the back-cover blurb still overflowed at BACK_TEXT_MIN_FONT_PX in
+// at least one of the two preview renderings (wizard spread or book stage).
+// Set by fitBackCoverText() further down; drives a "blurb too long" warning
+// in the validation pill so the author can trim it rather than have print
+// silently clip the bottom.
+const backTextOverflows = ref(false)
+
+const validation = computed(() => {
+  const base = validateConfig(config.value, { estimatedPageCount: estimatedPageCount.value })
+  const warnings = base.warnings.slice()
+  if (backTextOverflows.value && config.value.cover.backText) {
+    warnings.push({
+      field: 'cover.backText',
+      message: 'Back-cover blurb is too long to fit even at the smallest size — trim it or it will be clipped in print.',
+    })
+  }
+  return { errors: base.errors, warnings }
+})
 
 // ---- Quality checks ----
 const qualityChecks = computed<QualityCheckResult[]>(() => {
@@ -2755,29 +2772,31 @@ const backTextWrap = ref<HTMLDivElement | null>(null)
 const backTextElBook = ref<HTMLParagraphElement | null>(null)
 const backTextWrapBook = ref<HTMLDivElement | null>(null)
 const BACK_TEXT_MAX_FONT_PX = 18
-const BACK_TEXT_MIN_FONT_PX = 7
+const BACK_TEXT_MIN_FONT_PX = 6
 
-function fitBackCoverText(textEl: HTMLElement | null, wrap: HTMLElement | null) {
-  if (!textEl || !wrap) return
+function fitBackCoverText(textEl: HTMLElement | null, wrap: HTMLElement | null): boolean {
+  if (!textEl || !wrap) return false
   let size = BACK_TEXT_MAX_FONT_PX
   textEl.style.fontSize = size + 'px'
   void wrap.offsetHeight
   const availW = wrap.clientWidth
   const availH = wrap.clientHeight
-  if (availW <= 0 || availH <= 0) return
+  if (availW <= 0 || availH <= 0) return false
   while (size > BACK_TEXT_MIN_FONT_PX && (textEl.scrollHeight > availH || textEl.scrollWidth > availW)) {
     size -= 0.5
     textEl.style.fontSize = size + 'px'
     void textEl.offsetHeight
   }
+  return textEl.scrollHeight > availH || textEl.scrollWidth > availW
 }
 
 watch(
   [() => config.value.cover.backText, () => config.value.cover.authorName, () => bookState.value, () => previewMode.value, pageWidth, pageHeight],
   async () => {
     await nextTick()
-    fitBackCoverText(backTextEl.value, backTextWrap.value)
-    fitBackCoverText(backTextElBook.value, backTextWrapBook.value)
+    const overflowA = fitBackCoverText(backTextEl.value, backTextWrap.value)
+    const overflowB = fitBackCoverText(backTextElBook.value, backTextWrapBook.value)
+    backTextOverflows.value = overflowA || overflowB
   },
   { flush: 'post' },
 )
@@ -2869,26 +2888,32 @@ function buildPrintCoverHtml(
   const bgFill = `<div style="position:absolute;inset:0;background:${fallbackBg};"></div>`
 
   if (side === 'front') {
+    const scrim = 'background:radial-gradient(ellipse at center,rgba(0,0,0,0.7) 0%,rgba(0,0,0,0.45) 55%,rgba(0,0,0,0) 95%);padding:2mm 6mm;border-radius:1mm;'
     return `
       ${bgFill}
       ${imgEl}
-      <div style="position:absolute;inset:0;text-align:center;padding:8mm;color:#f4ecdd;text-shadow:0 1px 4px rgba(0,0,0,0.55);">
-        <div style="position:absolute;left:50%;top:${cover.titleY}%;transform:translate(-50%,-50%);width:calc(100% - 16mm);text-align:${cover.titleAlign};color:${cover.titleColor};">
+      <div style="position:absolute;inset:0;text-align:center;padding:8mm;color:#f4ecdd;text-shadow:0 1px 5px rgba(0,0,0,0.85),0 0 14px rgba(0,0,0,0.55);">
+        <div style="position:absolute;left:50%;top:${cover.titleY}%;transform:translate(-50%,-50%);width:calc(100% - 16mm);text-align:${cover.titleAlign};color:${cover.titleColor};${scrim}">
           <h2 style="font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-size:${cover.titleSize}pt;font-weight:300;margin:0;letter-spacing:0.04em;line-height:1.15;">${escapeHtml(title)}</h2>
           ${subtitle ? `<p style="font-style:italic;margin:2mm 0 0 0;">${escapeHtml(subtitle)}</p>` : ''}
         </div>
-        ${author ? `<div style="position:absolute;left:50%;top:${cover.authorY}%;transform:translate(-50%,-50%);width:calc(100% - 16mm);font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-style:italic;font-size:${cover.authorSize}pt;color:${cover.authorColor};text-align:${cover.authorAlign};letter-spacing:0.08em;">${escapeHtml(author)}</div>` : ''}
+        ${author ? `<div style="position:absolute;left:50%;top:${cover.authorY}%;transform:translate(-50%,-50%);width:calc(100% - 16mm);font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-style:italic;font-size:${cover.authorSize}pt;color:${cover.authorColor};text-align:${cover.authorAlign};letter-spacing:0.08em;${scrim}">${escapeHtml(author)}</div>` : ''}
       </div>
     `
   }
-  // back
+  // back. The blurb sits in a flex middle slot with min-height:0; overflow:hidden
+  // so a long blurb can't push the title up or the author/barcode off the page.
+  // A fit-to-page script in the print window (see buildNaturalPrintHtml) then
+  // shrinks .pp-cover-back-text from 14pt down to a 6pt floor until it fits.
   return `
     ${bgFill}
     ${imgEl}
-    <div style="position:absolute;inset:0;padding:10mm;color:#f4ecdd;display:flex;flex-direction:column;align-items:center;justify-content:space-between;text-align:center;">
-      <p style="font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-style:italic;font-size:14pt;letter-spacing:0.04em;margin:0;line-height:1.2;">${escapeHtml(title)}</p>
-      <p style="font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-size:11pt;line-height:1.5;color:${cover.backTextColor};max-width:90mm;white-space:pre-wrap;margin:0;">${escapeHtml(cover.backText || '')}</p>
-      <div style="display:flex;flex-direction:column;align-items:center;gap:3mm;">
+    <div style="position:absolute;inset:0;padding:10mm;color:#f4ecdd;display:flex;flex-direction:column;align-items:center;justify-content:space-between;text-align:center;text-shadow:0 1px 4px rgba(0,0,0,0.7);">
+      <p style="font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-style:italic;font-size:14pt;letter-spacing:0.04em;margin:0;line-height:1.2;flex:0 0 auto;">${escapeHtml(title)}</p>
+      <div class="pp-cover-back-text-wrap" style="flex:1 1 auto;min-height:0;width:100%;display:flex;align-items:center;justify-content:center;overflow:hidden;padding:4mm 0;">
+        <p class="pp-cover-back-text" style="font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-size:14pt;line-height:1.45;color:${cover.backTextColor};max-width:110mm;white-space:pre-wrap;margin:0;">${escapeHtml(cover.backText || '')}</p>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:3mm;flex:0 0 auto;">
         ${author ? `<p style="font-family:'${cfg.typography.bodyFont}',Georgia,serif;font-size:9pt;letter-spacing:0.12em;text-transform:uppercase;margin:0;">${escapeHtml(author)}</p>` : ''}
         ${cover.showBarcode && cover.isbn && barcode ? `
           <div style="background:#fff;color:#000;padding:2mm;display:inline-block;">
@@ -3342,11 +3367,14 @@ const NumberField = defineComponent({
 .bp-cover:hover { transform: translateY(-2px); }
 .bp-cover-back { border-radius: 8px 4px 4px 8px; }
 .bp-cover-bg { position: absolute; inset: 0; background: #3a2f24; }
-.bp-cover-content { position: absolute; inset: 0; text-align: center; padding: 2rem; color: #f4ecdd; text-shadow: 0 1px 4px rgba(0,0,0,0.55); }
+.bp-cover-content { position: absolute; inset: 0; text-align: center; padding: 2rem; color: #f4ecdd; text-shadow: 0 1px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55); }
 .bp-cover-title-block, .bp-cover-author-block {
   position: absolute; left: 50%;
   transform: translate(-50%, -50%);
   width: calc(100% - 4rem);
+  padding: 0.6em 1.2em;
+  border-radius: 4px;
+  background: radial-gradient(ellipse at center, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.45) 55%, rgba(0,0,0,0) 95%);
 }
 .bp-cover-title { font-family: ui-serif, Georgia, serif; font-size: 1.6rem; font-weight: 300; letter-spacing: 0.04em; line-height: 1.25; margin: 0; }
 .bp-cover-subtitle { font-style: italic; margin-top: 0.5rem; opacity: 0.9; }

--- a/client/src/components/manuscripts/bookPreview/print.ts
+++ b/client/src/components/manuscripts/bookPreview/print.ts
@@ -457,11 +457,31 @@ export function buildNaturalPrintHtml(args: PrintBuildArgs): string {
         if (typeof img.decode === 'function') return img.decode().catch(function () {});
         return new Promise(function (res) { img.addEventListener('load', res, { once: true }); img.addEventListener('error', res, { once: true }); });
       }));
+    }
+    // Shrink the back-cover blurb until it fits its flex slot. The screen
+    // preview does the same in BookPreviewModal.vue; the print pipeline can't
+    // reuse that because the blurb lives in a fresh window with no Vue.
+    function fitBackBlurb() {
+      var wraps = document.querySelectorAll('.pp-cover-back-text-wrap');
+      for (var i = 0; i < wraps.length; i++) {
+        var wrap = wraps[i];
+        var el = wrap.querySelector('.pp-cover-back-text');
+        if (!el) continue;
+        var availH = wrap.clientHeight;
+        var availW = wrap.clientWidth;
+        if (availH <= 0 || availW <= 0) continue;
+        var sz = 14;
+        el.style.fontSize = sz + 'pt';
+        while (sz > 6 && (el.scrollHeight > availH || el.scrollWidth > availW)) {
+          sz -= 0.25;
+          el.style.fontSize = sz + 'pt';
+        }
+      }
     }${labelFnDef}
     window.addEventListener('load', function () {
       waitForCoverImages().then(function () {
         // Small extra tick for the layout engine to flush after image decode.
-        setTimeout(function () { try { ${labelCall}window.focus(); window.print(); } catch (e) {} }, 100);
+        setTimeout(function () { try { fitBackBlurb(); ${labelCall}window.focus(); window.print(); } catch (e) {} }, 100);
       });
     });
   </script>


### PR DESCRIPTION
## Summary

Manuscript book-preview cover rendering had two issues visible in print/PDF output:

- **Front cover** — the HTML title/author overlays sat directly on top of busy cover artwork with only a faint text-shadow, so they bled into whatever was painted on the cover and became unreadable.
- **Back cover** — a long blurb pushed the author + barcode row past the bottom of the printed A5 page, where it was clipped silently. The on-screen wizard auto-fit the blurb down to a 7px floor; the print HTML did not auto-fit at all.

This PR fixes both, and surfaces a validation warning when the blurb is genuinely too long to fit at the smallest size.

## What changed

**Front cover scrim** — radial dark halo behind `.bp-cover-title-block` and `.bp-cover-author-block` plus a stronger text-shadow on the overlay container, both in the scoped `<style>` and in `buildPrintCoverHtml('front', …)`. Painted-in title type still shows through underneath; the HTML overlay now reads cleanly above it.

**Back cover print fit** — restructured `buildPrintCoverHtml('back', …)` so the blurb sits in a `flex: 1 1 auto; min-height: 0; overflow: hidden` middle slot, so it can no longer push the title up or the author/barcode block off the page. Added `fitBackBlurb()` in the print-window inline script (next to `waitForCoverImages`) that walks each `.pp-cover-back-text-wrap` and shrinks the blurb font from 14pt down to 6pt (0.25pt steps) until `scrollHeight <= clientHeight` and `scrollWidth <= clientWidth`, then calls `window.print()`.

**Smaller floor + "too long" warning** — `BACK_TEXT_MIN_FONT_PX` dropped from 7 → 6. `fitBackCoverText()` now returns a boolean indicating whether it bottomed out; the watcher writes that into a new `backTextOverflows` ref, and the `validation` computed merges in a "Back-cover blurb is too long to fit even at the smallest size — trim it or it will be clipped in print." warning so it shows up in the existing validation pill.

No new config fields, no schema changes, no API changes. The scrim is unconditional (it sits behind the text regardless of whether there's a cover image), which is consistent with the user's choice of "Add a scrim behind text" when asked how to handle the case where the cover artwork already has title type baked in.

## Test plan

- [ ] Open BookPreviewModal on a manuscript with a busy front-cover image and a long back-cover blurb. Confirm the title and author have a soft dark halo behind them and read clearly.
- [ ] Hit "Print A5". In the print preview, confirm the front cover scrim is visible behind the title/author and the back-cover blurb fits inside the page with the author + barcode panel still visible at the bottom.
- [ ] Save the same print preview as PDF; confirm no clipping at the bottom of the back cover.
- [ ] Paste a deliberately oversized blurb (~3000 characters) and confirm: (a) on-screen, the blurb is shrunk to the minimum and the validation pill shows a `1 warning` with the "blurb too long" message; (b) print output still fits author + barcode within the page (text just becomes very small).
- [ ] Confirm `npm run type-check` is clean (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)