### PR TITLE
Frag list — gzip, cached column probe, async view log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "writing-platform",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "writing-platform",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "workspaces": [
         "client",
         "server",
@@ -21,7 +21,7 @@
     },
     "client": {
       "name": "@writing-platform/client",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "dependencies": {
         "@zxing/browser": "^0.2.0",
         "@zxing/library": "^0.22.0",
@@ -1030,6 +1030,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
         "@types/node": "*"
       }
     },
@@ -2200,6 +2211,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-stream": {
@@ -3950,6 +4000,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6221,10 +6280,11 @@
     },
     "server": {
       "name": "@writing-platform/server",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "dependencies": {
         "@library-pals/isbn": "^1.6.0",
         "bcrypt": "^6.0.0",
+        "compression": "^1.8.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -6237,6 +6297,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/compression": "^1.8.1",
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
@@ -6252,7 +6313,7 @@
     },
     "shared": {
       "name": "@writing-platform/shared",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "devDependencies": {
         "typescript": "^5.3.0"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@library-pals/isbn": "^1.6.0",
     "bcrypt": "^6.0.0",
+    "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/compression": "^1.8.1",
     "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url'
 import fs from 'fs'
 import cors from 'cors'
 import cookieParser from 'cookie-parser'
+import compression from 'compression'
 import rateLimit from 'express-rate-limit'
 import { errorMiddleware } from './middleware/error.middleware.js'
 import { csrfTokenMiddleware, csrfMiddleware } from './middleware/csrf.middleware.js'
@@ -61,6 +62,10 @@ app.use(cors({
   origin: config.corsOrigin,
   credentials: true
 }))
+// Gzip JSON responses. The frag-list endpoint in particular ships markdown
+// bodies that compress 5-10x. Default threshold (1KB) means tiny payloads
+// stay uncompressed and we don't burn CPU on them.
+app.use(compression())
 app.use(cookieParser())
 // Global JSON body limit. Default is body-parser's 100kb which is too small
 // for a single long-form essay. 2mb comfortably fits any realistic single

--- a/server/src/controllers/writing.controller.ts
+++ b/server/src/controllers/writing.controller.ts
@@ -44,9 +44,10 @@ export const writingController = {
     const limit = parseInt(req.query.limit as string) || 50
     const offset = parseInt(req.query.offset as string) || 0
     const writings = await writingService.getAll(userId, limit, offset, admin, sharedAccess)
-    
-    // Log view activity
-    await activityService.logView(
+
+    // Fire-and-forget the view log so a slow activity-table INSERT doesn't
+    // hold up the response. logActivity already swallows its own errors.
+    void activityService.logView(
       'writing_block',
       null,
       userId,
@@ -54,7 +55,7 @@ export const writingController = {
       getUserAgent(req),
       { action: 'list', limit, offset }
     )
-    
+
     res.json({ data: writings })
   },
 

--- a/server/src/repositories/writing.repo.ts
+++ b/server/src/repositories/writing.repo.ts
@@ -13,6 +13,29 @@ import {
 /** Minutes since the latest revision after which an autosave will checkpoint. */
 const CHECKPOINT_MINUTES = 30
 
+/**
+ * Cached result of "does writing_blocks have a `visibility` column?".
+ * The check exists for backward compatibility with pre-migration-004
+ * environments, but the column is part of the schema everywhere we run
+ * today — caching it turns a per-request probe into a one-time check.
+ * Reset to null only on schema-change error paths if we ever need to.
+ */
+let hasVisibilityColumnCache: boolean | null = null
+async function hasVisibilityColumn(): Promise<boolean> {
+  if (hasVisibilityColumnCache !== null) return hasVisibilityColumnCache
+  try {
+    await pool.query('SELECT visibility FROM writing_blocks LIMIT 1')
+    hasVisibilityColumnCache = true
+  } catch (error: any) {
+    if (error.code === '42703') {
+      hasVisibilityColumnCache = false
+    } else {
+      throw error
+    }
+  }
+  return hasVisibilityColumnCache!
+}
+
 interface HeadRow {
   id: string
   userId: string
@@ -78,20 +101,7 @@ export const writingRepo = {
     let query: string
     let params: unknown[]
 
-    // Check if visibility column exists by trying a simple query first
-    // If it doesn't exist, use a fallback query without visibility filtering
-    let hasVisibilityColumn = true
-    try {
-      await pool.query('SELECT visibility FROM writing_blocks LIMIT 1')
-    } catch (error: any) {
-      if (error.code === '42703') { // column does not exist
-        hasVisibilityColumn = false
-      } else {
-        throw error
-      }
-    }
-
-    if (hasVisibilityColumn) {
+    if (await hasVisibilityColumn()) {
       if (isAdmin) {
         // Admin: see ALL writing blocks regardless of visibility
         query = `
@@ -231,22 +241,10 @@ export const writingRepo = {
     isAdmin: boolean = false,
     userSharedAccess: boolean = false
   ): Promise<WritingBlock> {
-    // Check if visibility column exists
-    let hasVisibilityColumn = true
-    try {
-      await pool.query('SELECT visibility FROM writing_blocks LIMIT 1')
-    } catch (error: any) {
-      if (error.code === '42703') {
-        hasVisibilityColumn = false
-      } else {
-        throw error
-      }
-    }
-
     let query: string
     let params: unknown[]
 
-    if (hasVisibilityColumn) {
+    if (await hasVisibilityColumn()) {
       if (isAdmin) {
         // Admin: access any writing regardless of visibility
         query = `


### PR DESCRIPTION
## Summary

The frag-list endpoint (`GET /api/writing`) was paying three avoidable costs on every request. Fixing all three with no API shape change and no client work.

- **Gzip the API responses** — added Express `compression()` middleware. Markdown bodies (the dominant payload in the frag list) compress 5–10×. Biggest win on slow networks.
- **Cache the visibility-column probe** — `findAll` / `findById` each fired `SELECT visibility FROM writing_blocks LIMIT 1` on every call to handle pre-migration-004 environments. Moved to a module-level cache so the probe runs at most once per process.
- **Fire-and-forget the view-log INSERT** — the controller was `await`ing `activityService.logView(...)` before responding. `logActivity` already swallows its own errors, so the response no longer waits on it.

## Why

User reported the Frag View list sometimes takes a long time to load. These three were the easy levers without touching the API shape or any client code.

## Notes for reviewer

- `compression` + `@types/compression` added to `server/`. Default 1KB threshold leaves tiny payloads alone.
- The cached column probe deliberately doesn't bust on migration; we never down-migrate `visibility` in any environment we run. If we ever need to, restart the process.
- Bigger follow-up (deferred): add `?summary=true` to omit `body` and ship precomputed `bodyPreview` / `wordCount` / `isSpa`. Wasn't done here because `Home.vue` search-filters bodies client-side, so the summary mode needs a paired server-search change to be useful everywhere.

## Test plan

- [ ] Hit `GET /api/writing` and verify `Content-Encoding: gzip` is set for responses > 1KB
- [ ] Verify the frag list renders correctly in Home, Themes, ThemeDetail, Landing
- [ ] Confirm activity_logs still receives `view` rows for list requests (just no longer blocking)
- [ ] `npm run type-check --workspace=server` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)