### PR TITLE
Immersive reader for frags and manuscripts (+ cover-image security hotfix)

### DIFF
--- a/client/src/components/reading/ImmersiveReader.vue
+++ b/client/src/components/reading/ImmersiveReader.vue
@@ -1,0 +1,711 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      ref="rootEl"
+      class="ir-root"
+      :class="[`ir-theme-${prefs.theme}`, `ir-font-${prefs.font}`]"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="`Immersive reader: ${title}`"
+    >
+      <!-- Reading progress -->
+      <div class="ir-progress" aria-hidden="true">
+        <div class="ir-progress-fill" :style="{ width: `${progress * 100}%` }" />
+      </div>
+
+      <!-- Chrome (auto-hides while reading) -->
+      <header class="ir-chrome" :class="{ 'ir-chrome-hidden': !chromeVisible }">
+        <div class="ir-chrome-inner">
+          <button type="button" class="ir-icon-btn" aria-label="Close immersive reader" title="Close (Esc)" @click="$emit('close')">
+            <svg class="ir-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <div class="ir-chrome-title">
+            <span class="ir-chrome-title-text">{{ title }}</span>
+            <span v-if="minutes > 0" class="ir-chrome-meta">{{ minutes }} min · {{ Math.round(progress * 100) }}%</span>
+          </div>
+
+          <div class="ir-chrome-actions">
+            <button
+              v-if="tocEntries.length > 1"
+              type="button"
+              class="ir-icon-btn"
+              :class="{ 'ir-icon-btn-active': tocOpen }"
+              aria-label="Contents"
+              title="Contents"
+              @click="tocOpen = !tocOpen; settingsOpen = false"
+            >
+              <svg class="ir-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 6h16M4 12h10M4 18h16" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="ir-icon-btn"
+              :class="{ 'ir-icon-btn-active': settingsOpen }"
+              aria-label="Reading settings"
+              title="Reading settings"
+              @click="settingsOpen = !settingsOpen; tocOpen = false"
+            >
+              <span class="ir-aa" aria-hidden="true">Aa</span>
+            </button>
+            <button
+              type="button"
+              class="ir-icon-btn"
+              :aria-label="isFullscreen ? 'Exit full screen' : 'Full screen'"
+              :title="isFullscreen ? 'Exit full screen' : 'Full screen'"
+              @click="toggleFullscreen"
+            >
+              <svg v-if="!isFullscreen" class="ir-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M3.75 9V4.5h4.5m7.5 0h4.5V9m0 6v4.5h-4.5m-7.5 0h-4.5V15" />
+              </svg>
+              <svg v-else class="ir-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 3.75V9H3.75M15 3.75V9h5.25M9 20.25V15H3.75M15 20.25V15h5.25" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Settings popover -->
+        <div v-if="settingsOpen" class="ir-panel" @click.stop>
+          <div class="ir-panel-row">
+            <span class="ir-panel-label">Text size</span>
+            <div class="ir-panel-controls">
+              <button type="button" class="ir-chip" :disabled="prefs.sizeIndex <= 0" aria-label="Smaller text" @click="bumpSize(-1)">A−</button>
+              <span class="ir-size-dots" aria-hidden="true">
+                <span v-for="(s, i) in FONT_SIZES" :key="s" class="ir-size-dot" :class="{ 'ir-size-dot-on': i === prefs.sizeIndex }" />
+              </span>
+              <button type="button" class="ir-chip" :disabled="prefs.sizeIndex >= FONT_SIZES.length - 1" aria-label="Larger text" @click="bumpSize(1)">A+</button>
+            </div>
+          </div>
+          <div class="ir-panel-row">
+            <span class="ir-panel-label">Typeface</span>
+            <div class="ir-panel-controls">
+              <button type="button" class="ir-chip" :class="{ 'ir-chip-on': prefs.font === 'serif' }" @click="setPref('font', 'serif')">Serif</button>
+              <button type="button" class="ir-chip" :class="{ 'ir-chip-on': prefs.font === 'sans' }" @click="setPref('font', 'sans')">Sans</button>
+            </div>
+          </div>
+          <div class="ir-panel-row">
+            <span class="ir-panel-label">Line width</span>
+            <div class="ir-panel-controls">
+              <button type="button" class="ir-chip" :class="{ 'ir-chip-on': prefs.measure === 'narrow' }" @click="setPref('measure', 'narrow')">Narrow</button>
+              <button type="button" class="ir-chip" :class="{ 'ir-chip-on': prefs.measure === 'wide' }" @click="setPref('measure', 'wide')">Wide</button>
+            </div>
+          </div>
+          <div class="ir-panel-row">
+            <span class="ir-panel-label">Background</span>
+            <div class="ir-panel-controls">
+              <button
+                v-for="t in THEMES"
+                :key="t.key"
+                type="button"
+                class="ir-swatch"
+                :class="{ 'ir-swatch-on': prefs.theme === t.key }"
+                :style="{ background: t.bg, color: t.fg }"
+                :aria-label="`${t.label} background`"
+                :title="t.label"
+                @click="setPref('theme', t.key)"
+              >Aa</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Table of contents -->
+        <nav v-if="tocOpen" class="ir-panel ir-toc" aria-label="Contents" @click.stop>
+          <button
+            v-for="entry in tocEntries"
+            :key="entry.id"
+            type="button"
+            class="ir-toc-item"
+            :class="{ 'ir-toc-section': entry.kind === 'section' }"
+            @click="jumpTo(entry.id)"
+          >
+            {{ entry.title }}
+          </button>
+        </nav>
+      </header>
+
+      <!-- Content -->
+      <div ref="scrollEl" class="ir-scroll" @scroll.passive="onScroll" @click="onContentClick">
+        <div v-if="loading" class="ir-loading">
+          <p>Preparing your reading&hellip;</p>
+        </div>
+        <article v-else class="ir-article" :class="{ 'ir-measure-wide': prefs.measure === 'wide' }" :style="{ fontSize: `${FONT_SIZES[prefs.sizeIndex]}px` }">
+          <h1 class="ir-doc-title">{{ title }}</h1>
+          <p v-if="subtitle" class="ir-doc-subtitle">{{ subtitle }}</p>
+
+          <template v-for="chapter in chapters" :key="chapter.id">
+            <section v-if="chapter.kind === 'section'" :id="anchorId(chapter.id)" class="ir-section-break">
+              <span class="ir-section-rule" aria-hidden="true" />
+              <h2>{{ chapter.title }}</h2>
+            </section>
+
+            <aside v-else-if="chapter.kind === 'bridge'" :id="anchorId(chapter.id)" class="ir-bridge">
+              <MarkdownRenderer :markdown="chapter.markdown" />
+            </aside>
+
+            <section v-else :id="anchorId(chapter.id)" class="ir-chapter">
+              <h2 v-if="showChapterTitles" class="ir-chapter-title">{{ chapter.title }}</h2>
+              <MarkdownRenderer :markdown="chapter.markdown" />
+            </section>
+          </template>
+
+          <footer class="ir-end">
+            <span class="ir-section-rule" aria-hidden="true" />
+            <p>The end</p>
+          </footer>
+        </article>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onUnmounted } from 'vue'
+import MarkdownRenderer from '../writing/MarkdownRenderer.vue'
+import { countWordsInMarkdown } from '../../utils/markdown'
+import type { ReaderChapter } from '../../utils/immersiveChapters'
+
+interface Props {
+  open: boolean
+  title: string
+  subtitle?: string
+  chapters: ReaderChapter[]
+  loading?: boolean
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ close: [] }>()
+
+/* ---- typography preferences (persisted) ---- */
+
+const FONT_SIZES = [17, 19, 21, 24] as const
+
+const THEMES = [
+  { key: 'paper', label: 'Paper', bg: '#faf8f2', fg: '#2b2620' },
+  { key: 'sepia', label: 'Sepia', bg: '#f3e9d2', fg: '#54432e' },
+  { key: 'night', label: 'Night', bg: '#15161a', fg: '#cfc9bc' },
+] as const
+
+type ThemeKey = (typeof THEMES)[number]['key']
+
+interface ReaderPrefs {
+  sizeIndex: number
+  font: 'serif' | 'sans'
+  measure: 'narrow' | 'wide'
+  theme: ThemeKey
+}
+
+const PREFS_KEY = 'immersive-reader-prefs'
+
+function loadPrefs(): ReaderPrefs {
+  const defaults: ReaderPrefs = { sizeIndex: 1, font: 'serif', measure: 'narrow', theme: 'paper' }
+  try {
+    const raw = localStorage.getItem(PREFS_KEY)
+    if (!raw) return defaults
+    const parsed = JSON.parse(raw) as Partial<ReaderPrefs>
+    return {
+      sizeIndex: typeof parsed.sizeIndex === 'number'
+        ? Math.min(Math.max(Math.round(parsed.sizeIndex), 0), FONT_SIZES.length - 1)
+        : defaults.sizeIndex,
+      font: parsed.font === 'sans' ? 'sans' : 'serif',
+      measure: parsed.measure === 'wide' ? 'wide' : 'narrow',
+      theme: THEMES.some(t => t.key === parsed.theme) ? (parsed.theme as ThemeKey) : defaults.theme,
+    }
+  } catch {
+    return defaults
+  }
+}
+
+const prefs = ref<ReaderPrefs>(loadPrefs())
+
+function persistPrefs() {
+  try {
+    localStorage.setItem(PREFS_KEY, JSON.stringify(prefs.value))
+  } catch {
+    /* private mode etc. — reading still works, prefs just won't stick */
+  }
+}
+
+function setPref<K extends keyof ReaderPrefs>(key: K, value: ReaderPrefs[K]) {
+  prefs.value = { ...prefs.value, [key]: value }
+  persistPrefs()
+}
+
+function bumpSize(delta: number) {
+  setPref('sizeIndex', Math.min(Math.max(prefs.value.sizeIndex + delta, 0), FONT_SIZES.length - 1))
+}
+
+/* ---- chrome visibility, progress, panels ---- */
+
+const rootEl = ref<HTMLElement | null>(null)
+const scrollEl = ref<HTMLElement | null>(null)
+const chromeVisible = ref(true)
+const settingsOpen = ref(false)
+const tocOpen = ref(false)
+const progress = ref(0)
+let lastScrollTop = 0
+
+function onScroll() {
+  const el = scrollEl.value
+  if (!el) return
+  const max = el.scrollHeight - el.clientHeight
+  progress.value = max > 0 ? Math.min(el.scrollTop / max, 1) : 0
+
+  // Hide the chrome when reading down, reveal on any upward scroll.
+  // Keep it while a panel is open or near the very top.
+  if (settingsOpen.value || tocOpen.value) return
+  const delta = el.scrollTop - lastScrollTop
+  if (el.scrollTop < 80 || delta < -4) chromeVisible.value = true
+  else if (delta > 4) chromeVisible.value = false
+  lastScrollTop = el.scrollTop
+}
+
+// Tap/click on the prose toggles the chrome back (mobile-friendly),
+// but never when the user is selecting text or clicking a link.
+function onContentClick(e: MouseEvent) {
+  if (settingsOpen.value || tocOpen.value) {
+    settingsOpen.value = false
+    tocOpen.value = false
+    return
+  }
+  const sel = window.getSelection()
+  if (sel && !sel.isCollapsed) return
+  if ((e.target as HTMLElement).closest('a')) return
+  chromeVisible.value = !chromeVisible.value
+}
+
+/* ---- contents ---- */
+
+const tocEntries = computed(() => props.chapters.filter(c => c.kind !== 'bridge'))
+
+// A lone chapter would just repeat the document title above it.
+const showChapterTitles = computed(() => props.chapters.filter(c => c.kind === 'chapter').length > 1)
+
+const anchorId = (id: string) => `ir-anchor-${id}`
+
+// Instant jump (not smooth): a chapter can be thousands of pixels away, and
+// smooth scrolling stalls entirely in rAF-throttled (backgrounded) tabs.
+function jumpTo(id: string) {
+  tocOpen.value = false
+  document.getElementById(anchorId(id))?.scrollIntoView({ behavior: 'auto', block: 'start' })
+}
+
+const minutes = computed(() => {
+  const words = props.chapters.reduce((sum, c) => sum + countWordsInMarkdown(c.markdown), 0)
+  return words > 0 ? Math.max(1, Math.round(words / 280)) : 0
+})
+
+/* ---- fullscreen ---- */
+
+const isFullscreen = ref(false)
+
+function toggleFullscreen() {
+  if (document.fullscreenElement) {
+    document.exitFullscreen().catch(() => {})
+  } else {
+    rootEl.value?.requestFullscreen?.().catch(() => {})
+  }
+}
+
+function onFullscreenChange() {
+  isFullscreen.value = !!document.fullscreenElement
+}
+
+/* ---- open/close lifecycle ---- */
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Escape') return
+  if (settingsOpen.value || tocOpen.value) {
+    settingsOpen.value = false
+    tocOpen.value = false
+  } else if (!document.fullscreenElement) {
+    // In fullscreen the browser maps Esc to exiting fullscreen; a second
+    // Esc (now windowed) closes the reader.
+    emit('close')
+  }
+}
+
+let savedBodyOverflow = ''
+
+watch(
+  () => props.open,
+  (open) => {
+    if (open) {
+      savedBodyOverflow = document.body.style.overflow
+      document.body.style.overflow = 'hidden'
+      document.addEventListener('keydown', onKeydown)
+      document.addEventListener('fullscreenchange', onFullscreenChange)
+      chromeVisible.value = true
+      settingsOpen.value = false
+      tocOpen.value = false
+      progress.value = 0
+      lastScrollTop = 0
+    } else {
+      document.body.style.overflow = savedBodyOverflow
+      document.removeEventListener('keydown', onKeydown)
+      document.removeEventListener('fullscreenchange', onFullscreenChange)
+      if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
+    }
+  },
+)
+
+onUnmounted(() => {
+  if (props.open) {
+    document.body.style.overflow = savedBodyOverflow
+    document.removeEventListener('keydown', onKeydown)
+    document.removeEventListener('fullscreenchange', onFullscreenChange)
+  }
+})
+</script>
+
+<style scoped>
+.ir-root {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  background: var(--ir-bg);
+  color: var(--ir-fg);
+}
+
+/* Reading themes — self-contained, deliberately independent of the app
+   light/dark mode so "Night" reading works from a light app and vice versa. */
+.ir-theme-paper { --ir-bg: #faf8f2; --ir-fg: #2b2620; --ir-muted: #8a8272; --ir-line: rgba(43, 38, 32, 0.14); --ir-chrome: rgba(250, 248, 242, 0.94); }
+.ir-theme-sepia { --ir-bg: #f3e9d2; --ir-fg: #54432e; --ir-muted: #9c8a6c; --ir-line: rgba(84, 67, 46, 0.16); --ir-chrome: rgba(243, 233, 210, 0.94); }
+.ir-theme-night { --ir-bg: #15161a; --ir-fg: #cfc9bc; --ir-muted: #7d786d; --ir-line: rgba(207, 201, 188, 0.14); --ir-chrome: rgba(21, 22, 26, 0.94); }
+
+.ir-font-serif .ir-article { font-family: 'Crimson Pro', Georgia, serif; }
+.ir-font-sans .ir-article { font-family: 'Inter', system-ui, sans-serif; }
+
+/* ---- progress ---- */
+.ir-progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 30;
+  background: transparent;
+}
+.ir-progress-fill {
+  height: 100%;
+  background: var(--ir-muted);
+  transition: width 120ms linear;
+}
+
+/* ---- chrome ---- */
+.ir-chrome {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  background: var(--ir-chrome);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--ir-line);
+  transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1), opacity 300ms;
+}
+.ir-chrome-hidden {
+  transform: translateY(-100%);
+  opacity: 0;
+  pointer-events: none;
+}
+.ir-chrome-inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 10px 16px;
+}
+.ir-chrome-title {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.ir-chrome-title-text {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ir-chrome-meta {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 11px;
+  color: var(--ir-muted);
+}
+.ir-chrome-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.ir-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  color: var(--ir-muted);
+  transition: color 200ms, background 200ms;
+}
+.ir-icon-btn:hover, .ir-icon-btn-active {
+  color: var(--ir-fg);
+  background: var(--ir-line);
+}
+.ir-icon { width: 20px; height: 20px; }
+.ir-aa {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 17px;
+  line-height: 1;
+}
+
+/* ---- popovers ---- */
+.ir-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 16px;
+  width: min(320px, calc(100vw - 32px));
+  background: var(--ir-bg);
+  border: 1px solid var(--ir-line);
+  border-radius: 10px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.18);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.ir-panel-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.ir-panel-label {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ir-muted);
+}
+.ir-panel-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ir-chip {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  padding: 5px 10px;
+  border: 1px solid var(--ir-line);
+  border-radius: 999px;
+  color: var(--ir-muted);
+  transition: color 200ms, border-color 200ms;
+}
+.ir-chip:hover:not(:disabled) { color: var(--ir-fg); }
+.ir-chip:disabled { opacity: 0.4; }
+.ir-chip-on {
+  color: var(--ir-fg);
+  border-color: var(--ir-fg);
+}
+.ir-size-dots { display: inline-flex; gap: 4px; margin: 0 2px; }
+.ir-size-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--ir-line);
+}
+.ir-size-dot-on { background: var(--ir-fg); }
+.ir-swatch {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--ir-line);
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.ir-swatch-on { box-shadow: 0 0 0 2px var(--ir-bg), 0 0 0 4px var(--ir-fg); }
+
+.ir-toc {
+  max-height: min(60vh, 480px);
+  overflow-y: auto;
+  gap: 0;
+  padding: 8px;
+}
+.ir-toc-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 13px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  color: var(--ir-fg);
+}
+.ir-toc-item:hover { background: var(--ir-line); }
+.ir-toc-section {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 11px;
+  color: var(--ir-muted);
+  margin-top: 6px;
+}
+.ir-toc-section:first-child { margin-top: 0; }
+
+/* ---- content ---- */
+.ir-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+.ir-loading {
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-style: italic;
+  color: var(--ir-muted);
+}
+.ir-article {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 96px 24px 64px;
+  line-height: 1.85;
+  cursor: default;
+}
+.ir-measure-wide { max-width: 56rem; }
+
+.ir-doc-title {
+  font-size: 2em;
+  font-weight: 300;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  margin-bottom: 0.4em;
+}
+.ir-doc-subtitle {
+  font-style: italic;
+  color: var(--ir-muted);
+  margin-bottom: 2em;
+}
+.ir-doc-title + .ir-chapter, .ir-doc-title + .ir-section-break { margin-top: 2.5em; }
+
+.ir-section-break {
+  text-align: center;
+  margin: 4em 0 3em;
+}
+.ir-section-break h2 {
+  font-size: 1.05em;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ir-muted);
+}
+.ir-section-rule {
+  display: block;
+  width: 48px;
+  height: 1px;
+  background: var(--ir-line);
+  margin: 0 auto 1.4em;
+}
+
+.ir-chapter { margin: 2.5em 0; }
+.ir-chapter-title {
+  font-size: 1.4em;
+  font-weight: 300;
+  line-height: 1.3;
+  margin-bottom: 1em;
+}
+
+.ir-bridge {
+  margin: 3em auto;
+  max-width: 34rem;
+  text-align: center;
+  font-style: italic;
+  color: var(--ir-muted);
+}
+
+.ir-end {
+  text-align: center;
+  margin-top: 5em;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ir-muted);
+}
+
+/* Rendered markdown inside chapters/bridges — MarkdownRenderer emits raw
+   elements (there is no typography plugin), so the reader styles them here. */
+.ir-article :deep(p) { margin: 0 0 1.25em; }
+.ir-article :deep(p:last-child) { margin-bottom: 0; }
+.ir-article :deep(h1), .ir-article :deep(h2), .ir-article :deep(h3), .ir-article :deep(h4) {
+  font-weight: 400;
+  line-height: 1.3;
+  margin: 1.8em 0 0.7em;
+}
+.ir-article :deep(h1) { font-size: 1.5em; }
+.ir-article :deep(h2) { font-size: 1.3em; }
+.ir-article :deep(h3) { font-size: 1.15em; }
+.ir-article :deep(blockquote) {
+  border-left: 2px solid var(--ir-line);
+  padding-left: 1.2em;
+  margin: 1.5em 0;
+  font-style: italic;
+  color: var(--ir-muted);
+}
+.ir-article :deep(ul), .ir-article :deep(ol) { margin: 0 0 1.25em 1.4em; }
+.ir-article :deep(ul) { list-style: disc; }
+.ir-article :deep(ol) { list-style: decimal; }
+.ir-article :deep(li) { margin-bottom: 0.4em; }
+.ir-article :deep(a) {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--ir-muted);
+  text-underline-offset: 3px;
+}
+.ir-article :deep(hr) {
+  border: 0;
+  height: 1px;
+  background: var(--ir-line);
+  margin: 2.5em auto;
+  width: 48px;
+}
+.ir-article :deep(img) {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin: 1.5em auto;
+}
+.ir-article :deep(code) {
+  font-family: 'Courier Prime', ui-monospace, monospace;
+  font-size: 0.85em;
+  background: var(--ir-line);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+.ir-article :deep(pre) {
+  background: var(--ir-line);
+  padding: 1em 1.2em;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 1.5em 0;
+}
+.ir-article :deep(pre code) { background: none; padding: 0; }
+
+@media (max-width: 640px) {
+  .ir-article { padding: 84px 20px 48px; }
+}
+</style>

--- a/client/src/pages/ManuscriptDetail.vue
+++ b/client/src/pages/ManuscriptDetail.vue
@@ -57,6 +57,14 @@
               </span>
               <button
                 type="button"
+                @click="openImmersiveReader"
+                class="px-4 py-2 text-sm tracking-wide font-sans border border-line text-ink-light hover:text-ink hover:border-ink-lighter transition-colors duration-300"
+                title="Read the whole manuscript in a distraction-free, full-screen view"
+              >
+                Read
+              </button>
+              <button
+                type="button"
                 @click="showPreview = true"
                 class="px-4 py-2 text-sm tracking-wide font-sans border border-line text-ink-light hover:text-ink hover:border-ink-lighter transition-colors duration-300"
               >
@@ -670,6 +678,17 @@
       </div>
     </div>
 
+    <!-- Immersive reading overlay: the whole spine as one continuous text -->
+    <ImmersiveReader
+      v-if="manuscript"
+      :open="immersiveOpen"
+      :title="manuscript.title"
+      :subtitle="manuscript.workingSubtitle ?? undefined"
+      :chapters="immersiveChapters"
+      :loading="immersiveLoading"
+      @close="immersiveOpen = false"
+    />
+
     <!-- Book preview -->
     <BookPreviewModal
       v-if="manuscript"
@@ -730,6 +749,8 @@ import ManuscriptSubNav from '../components/storycraft/ManuscriptSubNav.vue'
 import ChatDrawer from '../components/manuscripts/ChatDrawer.vue'
 import SpineSection from '../components/manuscripts/SpineSection.vue'
 import LayerConfigModal from '../components/manuscripts/LayerConfigModal.vue'
+import ImmersiveReader from '../components/reading/ImmersiveReader.vue'
+import { buildManuscriptChapters, type ReaderChapter } from '../utils/immersiveChapters'
 import { useSpineDepthFlag } from '../composables/useSpineDepthFlag'
 import type { ApiResponse } from '@shared/ApiResponses'
 import type { Theme } from '../domain/Theme'
@@ -783,6 +804,49 @@ const dragOverItemId = ref<string | null>(null)
 
 // ---- preview ----
 const showPreview = ref(false)
+
+// ---- immersive reading ----
+// Frag bodies aren't part of the spine payload, so opening the reader lazily
+// fetches each linked WritingBlock once and caches it for re-opens.
+const immersiveOpen = ref(false)
+const immersiveLoading = ref(false)
+const immersiveBodyById = ref<Map<string, string>>(new Map())
+
+const immersiveChapters = computed<ReaderChapter[]>(() =>
+  buildManuscriptChapters(
+    sortedSections.value,
+    itemsBySection.value,
+    unassignedItems.value,
+    immersiveBodyById.value,
+  )
+)
+
+async function openImmersiveReader() {
+  immersiveOpen.value = true
+  const missing = [...new Set(
+    items.value
+      .filter(it => it.itemType === 'essay' && it.writingBlockId)
+      .map(it => it.writingBlockId!)
+      .filter(id => !immersiveBodyById.value.has(id))
+  )]
+  if (missing.length === 0) return
+  immersiveLoading.value = true
+  try {
+    const fetched = await Promise.all(
+      missing.map(id =>
+        api
+          .get<ApiResponse<WritingBlock>>(`/writing/${id}`)
+          .then(r => ({ id, body: r.data?.body || '' }))
+          .catch(() => ({ id, body: '' })),
+      ),
+    )
+    const next = new Map(immersiveBodyById.value)
+    for (const { id, body } of fetched) next.set(id, body)
+    immersiveBodyById.value = next
+  } finally {
+    immersiveLoading.value = false
+  }
+}
 
 // ---- briefing (structured AI handoff) ----
 const showBriefing = ref(false)

--- a/client/src/pages/Read.vue
+++ b/client/src/pages/Read.vue
@@ -103,6 +103,29 @@
                 v-if="!isSpa"
                 type="button"
                 class="inline-flex items-center justify-center w-10 h-10 rounded text-ink-lighter hover:text-ink hover:bg-line transition-colors"
+                :aria-label="`Read ${writing.title} in immersive mode`"
+                title="Immersive reading"
+                @click="immersiveOpen = true"
+              >
+                <svg
+                  class="w-5 h-5"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <!-- Heroicons "book-open" -->
+                  <path d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+                </svg>
+              </button>
+              <button
+                v-if="!isSpa"
+                type="button"
+                class="inline-flex items-center justify-center w-10 h-10 rounded text-ink-lighter hover:text-ink hover:bg-line transition-colors"
                 :aria-label="`Print ${writing.title}`"
                 title="Print essay"
                 @click="printEssay"
@@ -228,6 +251,14 @@
           <CommentSection :writing-id="writing.id" />
         </div>
       </div>
+
+      <!-- Distraction-free reading overlay -->
+      <ImmersiveReader
+        :open="immersiveOpen"
+        :title="writing.title"
+        :chapters="immersiveChapters"
+        @close="immersiveOpen = false"
+      />
     </div>
   </ReadingLayout>
 </template>
@@ -245,6 +276,8 @@ import MarkdownRenderer from '../components/writing/MarkdownRenderer.vue'
 import ThemeTag from '../components/writing/ThemeTag.vue'
 import AppreciationButton from '../components/writing/AppreciationButton.vue'
 import CommentSection from '../components/writing/CommentSection.vue'
+import ImmersiveReader from '../components/reading/ImmersiveReader.vue'
+import type { ReaderChapter } from '../utils/immersiveChapters'
 import type { WritingBlock } from '../domain/WritingBlock'
 import type { Theme } from '../domain/Theme'
 import type { Appreciation } from '../domain/Appreciation'
@@ -278,6 +311,19 @@ const error = ref<string | null>(null)
 // True when the author pasted a complete HTML document (`<!DOCTYPE …` / `<html …`).
 // Drives a separate render path: sandboxed iframe instead of markdown paragraphs.
 const isSpa = computed(() => isStandaloneHtmlDoc(writing.value?.body))
+
+// Immersive (distraction-free) reading overlay. A single frag reads as one
+// chapter; the reader shows the title itself, so no chapter heading repeats it.
+const immersiveOpen = ref(false)
+const immersiveChapters = computed<ReaderChapter[]>(() => {
+  if (!writing.value || isSpa.value) return []
+  return [{
+    id: writing.value.id,
+    kind: 'chapter',
+    title: writing.value.title,
+    markdown: writing.value.body,
+  }]
+})
 
 // Split content into paragraphs for progressive reveal (body only — excerpt covers the opening)
 const paragraphs = computed(() => {

--- a/client/src/pages/Read.vue
+++ b/client/src/pages/Read.vue
@@ -36,11 +36,12 @@
                 <span class="text-xs font-sans text-ink-lighter">{{ formattedDate }}</span>
               </div>
               <img
-                v-if="writing.coverImageUrl"
+                v-if="writing.coverImageUrl && !coverImageError"
                 :src="writing.coverImageUrl"
                 :alt="`Cover for ${writing.title}`"
                 class="w-32 h-32 rounded overflow-hidden object-cover flex-shrink-0 border border-line ml-auto"
                 :style="{ objectPosition: writing.coverImagePosition || '50% 50%' }"
+                @error="coverImageError = true"
               />
             </div>
           </div>
@@ -266,6 +267,9 @@ const readingStore = useReadingStore()
 const { origin: navOrigin, originLabel } = useNavigationOrigin('/home')
 
 const writing = ref<WritingBlock | null>(null)
+// Cover images are admin-only (security hotfix); non-admin/anon loads 403 —
+// hide the broken image gracefully instead of showing a broken-image icon.
+const coverImageError = ref(false)
 const themes = ref<Theme[]>([])
 const appreciations = ref<Appreciation[]>([])
 const loading = ref(true)

--- a/client/src/utils/immersiveChapters.spec.ts
+++ b/client/src/utils/immersiveChapters.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { buildManuscriptChapters } from './immersiveChapters'
+import type { ManuscriptSection, ManuscriptItem, ManuscriptItemType } from '@shared/Manuscript'
+
+const section = (id: string, title: string, orderIndex: number): ManuscriptSection =>
+  ({ id, title, orderIndex } as unknown as ManuscriptSection)
+
+const item = (
+  id: string,
+  itemType: ManuscriptItemType,
+  title: string,
+  opts: { writingBlockId?: string | null; summary?: string | null } = {},
+): ManuscriptItem =>
+  ({
+    id,
+    itemType,
+    title,
+    writingBlockId: opts.writingBlockId ?? null,
+    summary: opts.summary ?? null,
+  } as unknown as ManuscriptItem)
+
+describe('buildManuscriptChapters', () => {
+  it('walks sections in order and emits a divider before each section with readable items', () => {
+    const sections = [section('s1', 'Part One', 0), section('s2', 'Part Two', 1)]
+    const itemsBySection = new Map([
+      ['s1', [item('i1', 'essay', 'First frag', { writingBlockId: 'w1' })]],
+      ['s2', [item('i2', 'essay', 'Second frag', { writingBlockId: 'w2' })]],
+    ])
+    const bodies = new Map([
+      ['w1', 'Body one.'],
+      ['w2', 'Body two.'],
+    ])
+
+    const chapters = buildManuscriptChapters(sections, itemsBySection, [], bodies)
+
+    expect(chapters.map(c => [c.kind, c.title])).toEqual([
+      ['section', 'Part One'],
+      ['chapter', 'First frag'],
+      ['section', 'Part Two'],
+      ['chapter', 'Second frag'],
+    ])
+    expect(chapters[1].markdown).toBe('Body one.')
+  })
+
+  it('skips notes, fragments and placeholders, and omits dividers for sections left empty', () => {
+    const sections = [section('s1', 'Scaffolding only', 0), section('s2', 'Real part', 1)]
+    const itemsBySection = new Map([
+      ['s1', [
+        item('i1', 'note', 'A working note'),
+        item('i2', 'fragment', 'A fragment'),
+        item('i3', 'placeholder', 'Not yet written'),
+      ]],
+      ['s2', [item('i4', 'essay', 'The frag', { writingBlockId: 'w1' })]],
+    ])
+    const chapters = buildManuscriptChapters(sections, itemsBySection, [], new Map([['w1', 'Text.']]))
+
+    expect(chapters.map(c => c.title)).toEqual(['Real part', 'The frag'])
+  })
+
+  it('renders bridges from their summary, falling back to the title', () => {
+    const itemsBySection = new Map([
+      ['s1', [
+        item('i1', 'bridge', 'Bridge label', { summary: 'Connective tissue.' }),
+        item('i2', 'bridge', 'Bare bridge'),
+      ]],
+    ])
+    const chapters = buildManuscriptChapters([section('s1', 'Part', 0)], itemsBySection, [], new Map())
+
+    expect(chapters.filter(c => c.kind === 'bridge').map(c => c.markdown)).toEqual([
+      'Connective tissue.',
+      'Bare bridge',
+    ])
+  })
+
+  it('appends unassigned readable items after all sections, without a divider', () => {
+    const chapters = buildManuscriptChapters(
+      [],
+      new Map(),
+      [item('i1', 'essay', 'Loose frag', { writingBlockId: 'w1' }), item('i2', 'note', 'Skip me')],
+      new Map([['w1', 'Loose body.']]),
+    )
+    expect(chapters).toEqual([
+      { id: 'item-i1', kind: 'chapter', title: 'Loose frag', markdown: 'Loose body.' },
+    ])
+  })
+
+  it('stubs interactive (standalone HTML) frags and missing bodies instead of dumping raw HTML', () => {
+    const itemsBySection = new Map([
+      ['s1', [
+        item('i1', 'essay', 'Interactive piece', { writingBlockId: 'w1' }),
+        item('i2', 'essay', 'Unloaded piece', { writingBlockId: 'w2' }),
+      ]],
+    ])
+    const bodies = new Map([['w1', '<!DOCTYPE html><html><body>app</body></html>']])
+    const chapters = buildManuscriptChapters([section('s1', 'Part', 0)], itemsBySection, [], bodies)
+
+    expect(chapters[1].markdown).toMatch(/interactive frag/i)
+    expect(chapters[1].markdown).not.toContain('<!DOCTYPE')
+    expect(chapters[2].markdown).toMatch(/unavailable/i)
+  })
+})

--- a/client/src/utils/immersiveChapters.ts
+++ b/client/src/utils/immersiveChapters.ts
@@ -1,0 +1,87 @@
+import type { ManuscriptSection, ManuscriptItem } from '@shared/Manuscript'
+import { isStandaloneHtmlDoc } from './markdown'
+
+/**
+ * One entry in the immersive reader's flow.
+ *
+ * - `section`  — a part/section divider (title only, rendered as a break)
+ * - `chapter`  — a full prose chapter (frag body)
+ * - `bridge`   — short connective tissue rendered as a centred interstitial
+ */
+export interface ReaderChapter {
+  id: string
+  kind: 'section' | 'chapter' | 'bridge'
+  title: string
+  markdown: string
+}
+
+/**
+ * Flatten a manuscript spine into the immersive reader's chapter list,
+ * mirroring the Book Room's reading order: sections by orderIndex, each
+ * section's items by orderIndex, then unassigned items.
+ *
+ * Working artefacts (notes, fragments) and unwritten placeholders are the
+ * writer's scaffolding, not the reader's text, so they are skipped. Frags
+ * whose body is a standalone HTML document (interactive SPAs) can't be read
+ * as prose and get an explanatory stub instead. Section dividers are only
+ * emitted when the section actually contributed something readable.
+ */
+export function buildManuscriptChapters(
+  sortedSections: ManuscriptSection[],
+  itemsBySection: Map<string, ManuscriptItem[]>,
+  unassignedItems: ManuscriptItem[],
+  bodyByWritingBlockId: Map<string, string>,
+): ReaderChapter[] {
+  const out: ReaderChapter[] = []
+
+  const pushItems = (items: ManuscriptItem[]) => {
+    let pushed = 0
+    for (const item of items) {
+      const chapter = itemToChapter(item, bodyByWritingBlockId)
+      if (chapter) {
+        out.push(chapter)
+        pushed++
+      }
+    }
+    return pushed
+  }
+
+  for (const section of sortedSections) {
+    const items = itemsBySection.get(section.id) ?? []
+    const dividerAt = out.length
+    if (pushItems(items) > 0) {
+      out.splice(dividerAt, 0, {
+        id: `section-${section.id}`,
+        kind: 'section',
+        title: section.title,
+        markdown: '',
+      })
+    }
+  }
+
+  pushItems(unassignedItems)
+  return out
+}
+
+function itemToChapter(
+  item: ManuscriptItem,
+  bodyByWritingBlockId: Map<string, string>,
+): ReaderChapter | null {
+  if (item.itemType === 'essay' && item.writingBlockId) {
+    const body = bodyByWritingBlockId.get(item.writingBlockId) ?? ''
+    return {
+      id: `item-${item.id}`,
+      kind: 'chapter',
+      title: item.title,
+      markdown: isStandaloneHtmlDoc(body)
+        ? '*This is an interactive frag — open it from the library to experience it.*'
+        : body || '*(Body unavailable.)*',
+    }
+  }
+  if (item.itemType === 'bridge') {
+    const text = (item.summary ?? '').trim() || item.title
+    if (!text) return null
+    return { id: `item-${item.id}`, kind: 'bridge', title: item.title, markdown: text }
+  }
+  return null
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,6 +8,8 @@ import compression from 'compression'
 import rateLimit from 'express-rate-limit'
 import { errorMiddleware } from './middleware/error.middleware.js'
 import { csrfTokenMiddleware, csrfMiddleware } from './middleware/csrf.middleware.js'
+import { authMiddleware } from './middleware/auth.middleware.js'
+import { requireAdmin } from './middleware/authorize.middleware.js'
 import authRoutes from './routes/auth.routes.js'
 import writingRoutes from './routes/writing.routes.js'
 import themeRoutes from './routes/theme.routes.js'
@@ -112,8 +114,14 @@ app.use('/api', (_req, res, next) => {
   next()
 })
 
-// Serve uploaded images from PostgreSQL (filesystem is ephemeral on Heroku)
-app.get('/uploads/cover/:filename', asyncHandler(uploadsController.serve))
+// Serve uploaded images from PostgreSQL (filesystem is ephemeral on Heroku).
+// SECURITY HOTFIX: cover images are restricted to signed-in admin users only.
+// authMiddleware reads the httpOnly `token` cookie (same-origin <img> tags send
+// it automatically), so admin browsers still load covers; everyone else (anon or
+// non-admin) gets 401/403 and the frontend degrades gracefully. Responses are
+// marked private/no-store in the controller so Cloudflare never caches and
+// re-serves a protected image to an unauthenticated visitor.
+app.get('/uploads/cover/:filename', authMiddleware, requireAdmin, asyncHandler(uploadsController.serve))
 
 // CSRF token generation (must be before CSRF protection)
 // Skip CSRF for auth endpoints - they use their own protection

--- a/server/src/controllers/uploads.controller.ts
+++ b/server/src/controllers/uploads.controller.ts
@@ -114,7 +114,10 @@ export const uploadsController = {
 
   /**
    * GET /uploads/cover/:filename - serve an image from PostgreSQL.
-   * Aggressive caching (immutable filenames with UUID) avoids repeated DB reads.
+   * SECURITY: route is gated by authMiddleware + requireAdmin (see app.ts), so
+   * only signed-in admins reach here. Responses are marked private/no-store so
+   * no shared cache (Cloudflare) or browser retains a copy that could be served
+   * to an unauthenticated visitor.
    */
   async serve(req: Request, res: Response) {
     const { filename } = req.params
@@ -133,8 +136,11 @@ export const uploadsController = {
     res.set({
       'Content-Type': contentType,
       'Content-Length': String(file.size_bytes),
-      'Cache-Control': 'public, max-age=31536000, immutable',
-      'ETag': `"${file.id}"`,
+      // Private/no-store: admin-only content must never be cached by a shared
+      // proxy (Cloudflare) or persisted by the browser for later anonymous use.
+      'Cache-Control': 'private, no-store, must-revalidate',
+      'Pragma': 'no-cache',
+      'Expires': '0',
     })
     res.send(file.data)
   }


### PR DESCRIPTION
## What

Two commits ride on this branch:

**1. Security hotfix (42d47b0)** — restricts cover images to signed-in admin users. This was already on the branch before the feature work.

**2. Immersive reader (3a9f136)** — a full-screen, distraction-free reading mode for individual frags and whole manuscripts.

### The reader (`ImmersiveReader.vue`)

- Typography controls in an "Aa" panel: four text sizes, serif/sans typeface, narrow/wide measure, and paper/sepia/night backgrounds. Preferences persist in localStorage, independent of the app's light/dark mode.
- Thin progress bar plus a header (title, est. read time, percent read) that auto-hides while reading down and returns on upward scroll or a tap.
- Contents panel for multi-chapter reads with section groupings and instant jumps, a browser fullscreen toggle, and Esc to close. Body scroll locks while open.

### Entry points

- **Frags** (`Read.vue`): a book-open icon beside print opens the frag as a single-chapter read. Hidden for interactive/SPA frags, which keep their own fullscreen path.
- **Manuscripts** (`ManuscriptDetail.vue`): a **Read** button before "Preview book" flattens the spine into one continuous text. Frag bodies are fetched lazily on first open and cached for re-opens.

### Spine flattening (`immersiveChapters.ts`)

Pure helper mirroring the Book Room's reading order: sections become part dividers (only when they contribute readable content), frag bodies become chapters, bridges render as centred interstitials from their summary. Notes, fragments and placeholders are excluded as writer-only scaffolding; standalone-HTML frag bodies get an explanatory stub instead of raw markup.

## Reviewer notes

- 5 unit tests cover the spine flattening; `vue-tsc` is clean.
- Verified live in the browser (frag + a sectioned manuscript with bridge and note): themes, sizing, progress, auto-hide, prefs persistence, TOC jumps, Esc/scroll-lock restore.
- TOC jumps are deliberately instant, not smooth — smooth `scrollIntoView` stalls in rAF-throttled tabs, and instant jumps are standard e-reader behavior.
- Pre-existing test failures on this branch (Write.spec + BookPreviewModal snapshots, 20 tests) also fail on a clean checkout of the hotfix commit — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)