### PR TITLE
Refactor WRITE view: remove typewriter UI, mobile-first toolbar with consolidated AI menu

### DIFF
--- a/client/src/components/writing/WritingToolsCluster.vue
+++ b/client/src/components/writing/WritingToolsCluster.vue
@@ -1,49 +1,11 @@
 <template>
   <div
-    ref="clusterRootRef"
-    class="writing-tools-cluster"
+    ref="toolbarRootRef"
+    class="writing-toolbar print:hidden"
     role="toolbar"
     aria-label="Writing tools"
-    aria-orientation="vertical"
-    :class="[
-      {
-        'is-active': hasActiveMode || isHovering,
-        'is-floating': !isFixed,
-        'is-dragging': isDragging,
-        'is-pinned': userPosition !== null,
-        'is-horizontal': orientation === 'horizontal',
-      },
-    ]"
-    :style="clusterStyle"
-    @pointerdown="onPointerDown"
-    @click.capture="onClickCapture"
-    @mouseenter="isHovering = true"
-    @mouseleave="isHovering = false"
-    @focusin="isHovering = true"
-    @focusout="isHovering = false"
   >
-    <!-- Rotation handles — small dots on the top and bottom of the
-         border. Visible only when unlocked. Drag one to spin the cluster
-         around its centre to any angle, including inverted. -->
-    <div
-      v-if="!isFixed"
-      class="rotate-dot rotate-dot-top"
-      role="button"
-      aria-label="Rotate cluster"
-      title="Drag to rotate"
-      @pointerdown="(e) => onRotateDotPointerDown(e, 'top')"
-    ></div>
-    <div
-      v-if="!isFixed"
-      class="rotate-dot rotate-dot-bottom"
-      role="button"
-      aria-label="Rotate cluster"
-      title="Drag to rotate"
-      @pointerdown="(e) => onRotateDotPointerDown(e, 'bottom')"
-    ></div>
-    <!-- Group 1 — page actions (save, metadata, exit). These replace what
-         used to be the bottom footer of Write.vue. Save sits on top as the
-         primary action; metadata and exit follow. -->
+    <!-- Save / Publish / Update — the primary action, always first. -->
     <button
       type="button"
       class="tool-button is-primary"
@@ -53,34 +15,117 @@
       :disabled="saveBusy || saveDisabled"
       @click="$emit('save')"
     >
-      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M4 3h9l3 3v11a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" />
         <path d="M6 3v5h7V3" />
         <path d="M6 12h8" />
         <path d="M6 15h8" />
       </svg>
-      <span class="tool-label">{{ saveBusy ? 'Saving…' : (isEditing ? 'Update' : 'Publish') }}</span>
+      <span class="tool-caption">{{ saveBusy ? 'Saving' : (isEditing ? 'Update' : 'Publish') }}</span>
     </button>
 
-    <button
-      type="button"
-      class="tool-button"
-      :class="{ 'is-active': metadataOpen }"
-      aria-label="Metadata (cover, themes, visibility)"
-      title="Metadata (cover, themes, visibility)"
-      @click="$emit('metadata')"
-    >
-      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M4 5h12" />
-        <circle cx="7" cy="5" r="1.6" fill="currentColor" stroke="none" />
-        <path d="M4 10h12" />
-        <circle cx="13" cy="10" r="1.6" fill="currentColor" stroke="none" />
-        <path d="M4 15h12" />
-        <circle cx="9" cy="15" r="1.6" fill="currentColor" stroke="none" />
-      </svg>
-      <span class="tool-label">Metadata</span>
-    </button>
+    <!-- AI menu — single button consolidating every assist tool, the
+         Develop quadrant and the model picker into one sheet. -->
+    <div class="menu-anchor">
+      <button
+        type="button"
+        class="tool-button"
+        :class="{ 'is-active': aiMenuOpen || activeMode !== null }"
+        aria-label="AI writing tools"
+        :aria-haspopup="true"
+        :aria-expanded="aiMenuOpen"
+        title="AI writing tools"
+        @click="toggleAiMenu"
+      >
+        <!-- Sparkle — the conventional "AI" glyph. -->
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M10 3l1.6 3.9L15.5 8.5l-3.9 1.6L10 14l-1.6-3.9L4.5 8.5l3.9-1.6L10 3z" />
+          <path d="M15.5 13l0.8 1.9 1.9 0.8-1.9 0.8-0.8 1.9-0.8-1.9-1.9-0.8 1.9-0.8 0.8-1.9z" />
+        </svg>
+        <span class="tool-caption">AI</span>
+      </button>
 
+      <!-- AI sheet — bottom sheet on mobile, anchored popover on desktop. -->
+      <div
+        v-if="aiMenuOpen"
+        class="menu-sheet ai-sheet"
+        role="menu"
+        aria-label="AI tools"
+        @click.stop
+      >
+        <div class="sheet-scroll">
+          <p class="sheet-heading">Assist</p>
+          <button
+            v-for="tool in aiTools"
+            :key="tool.mode"
+            type="button"
+            class="sheet-option"
+            :class="{ 'is-selected': activeMode === tool.mode, 'is-disabled': tool.requiresSelection && !hasSelection }"
+            role="menuitem"
+            :disabled="tool.requiresSelection && !hasSelection"
+            :aria-label="`${tool.label}${tool.requiresSelection ? ' — needs a text selection' : ''}`"
+            @click="selectAiTool(tool.mode)"
+          >
+            <span class="sheet-option-label">{{ tool.label }}</span>
+            <span class="sheet-option-caption">{{ tool.caption }}</span>
+          </button>
+
+          <div class="sheet-divider" aria-hidden="true"></div>
+
+          <p class="sheet-heading">Develop — fiction</p>
+          <button
+            v-for="opt in DEVELOP_OPTIONS_FICTION"
+            :key="opt.mode"
+            type="button"
+            class="sheet-option"
+            :class="{ 'is-selected': activeMode === opt.mode }"
+            role="menuitem"
+            @click="selectAiTool(opt.mode)"
+          >
+            <span class="sheet-option-label">{{ opt.label }}</span>
+            <span class="sheet-option-caption">{{ opt.caption }}</span>
+          </button>
+
+          <p class="sheet-heading">Develop — non-fiction</p>
+          <button
+            v-for="opt in DEVELOP_OPTIONS_NONFICTION"
+            :key="opt.mode"
+            type="button"
+            class="sheet-option"
+            :class="{ 'is-selected': activeMode === opt.mode }"
+            role="menuitem"
+            @click="selectAiTool(opt.mode)"
+          >
+            <span class="sheet-option-label">{{ opt.label }}</span>
+            <span class="sheet-option-caption">{{ opt.caption }}</span>
+          </button>
+
+          <div class="sheet-divider" aria-hidden="true"></div>
+
+          <p class="sheet-heading">Model</p>
+          <button
+            v-for="opt in MODEL_OPTIONS"
+            :key="opt.id"
+            type="button"
+            class="sheet-option"
+            :class="{ 'is-selected': opt.id === model }"
+            role="menuitemradio"
+            :aria-checked="opt.id === model"
+            @click="selectModel(opt.id)"
+          >
+            <span class="sheet-option-label">
+              {{ opt.label }}
+              <svg v-if="opt.id === model" class="sheet-check" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M4 10.5l4 4 8-9" />
+              </svg>
+            </span>
+            <span class="sheet-option-caption">{{ opt.caption }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Find & replace -->
     <button
       type="button"
       class="tool-button"
@@ -89,13 +134,79 @@
       title="Find and replace (in essay or across the manuscript)"
       @click="$emit('find')"
     >
-      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <circle cx="8.5" cy="8.5" r="5" />
         <path d="M12.5 12.5l4.5 4.5" />
       </svg>
-      <span class="tool-label">Find</span>
+      <span class="tool-caption">Find</span>
     </button>
 
+    <!-- Metadata (cover, themes, visibility) -->
+    <button
+      type="button"
+      class="tool-button"
+      :class="{ 'is-active': metadataOpen }"
+      aria-label="Metadata (cover, themes, visibility)"
+      title="Metadata (cover, themes, visibility)"
+      @click="$emit('metadata')"
+    >
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M4 5h12" />
+        <circle cx="7" cy="5" r="1.6" fill="currentColor" stroke="none" />
+        <path d="M4 10h12" />
+        <circle cx="13" cy="10" r="1.6" fill="currentColor" stroke="none" />
+        <path d="M4 15h12" />
+        <circle cx="9" cy="15" r="1.6" fill="currentColor" stroke="none" />
+      </svg>
+      <span class="tool-caption">Details</span>
+    </button>
+
+    <!-- Text size — tiny popover with the two steppers so the bar itself
+         stays at one button. -->
+    <div class="menu-anchor">
+      <button
+        type="button"
+        class="tool-button"
+        :class="{ 'is-active': textMenuOpen }"
+        aria-label="Text size"
+        :aria-haspopup="true"
+        :aria-expanded="textMenuOpen"
+        title="Text size"
+        @click="toggleTextMenu"
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <text x="10" y="15" text-anchor="middle"
+                font-family="Courier Prime, monospace"
+                font-size="14" font-weight="700">Aa</text>
+        </svg>
+        <span class="tool-caption">Text</span>
+      </button>
+
+      <div
+        v-if="textMenuOpen"
+        class="menu-sheet text-sheet"
+        role="menu"
+        aria-label="Text size"
+        @click.stop
+      >
+        <button
+          type="button"
+          class="text-step-button"
+          aria-label="Decrease body font size"
+          title="Smaller text"
+          @click="$emit('font-down')"
+        >A−</button>
+        <button
+          type="button"
+          class="text-step-button"
+          aria-label="Increase body font size"
+          title="Larger text"
+          @click="$emit('font-up')"
+        >A+</button>
+      </div>
+    </div>
+
+    <!-- Exit -->
     <button
       type="button"
       class="tool-button"
@@ -103,307 +214,18 @@
       title="Exit to frags"
       @click="$emit('exit')"
     >
-      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M11 4h4a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1h-4" />
         <path d="M3 10h10" />
         <path d="M6 7l-3 3 3 3" />
       </svg>
-      <span class="tool-label">Exit</span>
-    </button>
-
-    <!-- Visual separator between page actions and font controls -->
-    <div class="cluster-divider" aria-hidden="true"></div>
-
-    <!-- Font size up — bigger 'A' on top of the icon -->
-    <button
-      type="button"
-      class="tool-button"
-      aria-label="Increase body font size"
-      title="Larger text"
-      @click="$emit('font-up')"
-    >
-      <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <text x="10" y="14" text-anchor="middle"
-              font-family="Courier Prime, monospace"
-              font-size="14" font-weight="700">A+</text>
-      </svg>
-      <span class="tool-label">Larger</span>
-    </button>
-
-    <!-- Font size down — smaller 'A' on top of the icon -->
-    <button
-      type="button"
-      class="tool-button"
-      aria-label="Decrease body font size"
-      title="Smaller text"
-      @click="$emit('font-down')"
-    >
-      <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <text x="10" y="14" text-anchor="middle"
-              font-family="Courier Prime, monospace"
-              font-size="11" font-weight="700">A−</text>
-      </svg>
-      <span class="tool-label">Smaller</span>
-    </button>
-
-    <!-- Visual separator between font controls and AI tools -->
-    <div class="cluster-divider" aria-hidden="true"></div>
-
-    <!-- Group 2 — AI assist tools -->
-    <button
-      v-for="tool in aiTools"
-      :key="tool.mode"
-      type="button"
-      class="tool-button"
-      :class="{ 'is-active': activeMode === tool.mode, 'is-disabled': tool.requiresSelection && !hasSelection }"
-      :aria-label="`${tool.label}${tool.requiresSelection ? ' — needs a text selection' : ''}`"
-      :title="tool.tooltip"
-      :disabled="tool.requiresSelection && !hasSelection"
-      @click="$emit('select', tool.mode)"
-    >
-      <!-- Icons are inline SVG with currentColor strokes so they pick up
-           text-color from CSS (theme-aware in light + dark). 18px icons. -->
-      <svg
-        v-if="tool.mode === 'coherence'"
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.4"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <path d="M3.5 5.5h11a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H8l-3.5 3v-3h-1a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1z" />
-        <path d="M7 9h7" />
-        <path d="M7 11.5h4.5" />
-      </svg>
-      <svg
-        v-else-if="tool.mode === 'define'"
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.4"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <path d="M4 3.5h9.5a1.5 1.5 0 0 1 1.5 1.5v11.5l-3-2-2.5 2-2.5-2-3 2V5a1.5 1.5 0 0 1 1.5-1.5z" />
-        <path d="M7 7.5h6" />
-        <path d="M7 10h4" />
-      </svg>
-      <svg
-        v-else-if="tool.mode === 'focus'"
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.4"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <circle cx="10" cy="10" r="6" />
-        <circle cx="10" cy="10" r="2" />
-        <path d="M10 1.5v2M10 16.5v2M1.5 10h2M16.5 10h2" />
-      </svg>
-      <svg
-        v-else-if="tool.mode === 'expand'"
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.4"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <path d="M3 7V3h4M17 7V3h-4M3 13v4h4M17 13v4h-4" />
-        <path d="M7 7l-3-3M13 7l3-3M7 13l-3 3M13 13l3 3" />
-      </svg>
-      <svg
-        v-else-if="tool.mode === 'proofread'"
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.4"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <path d="M3 4.5h11" />
-        <path d="M3 8.5h8" />
-        <path d="M3 12.5h6" />
-        <path d="M12 14l2 2 4-5" />
-      </svg>
-      <svg
-        v-else-if="tool.mode === 'factcheck'"
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.4"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <!-- magnifying glass with a checkmark inside the lens —
-             reads as "scrutinise + verify" -->
-        <circle cx="8.5" cy="8.5" r="5" />
-        <path d="M6 8.5l2 2 3.5-4" />
-        <path d="M12.5 12.5l4.5 4.5" />
-      </svg>
-
-      <!-- Label visible on hover/focus only — keeps the rest button-only -->
-      <span class="tool-label">{{ tool.label }}</span>
-    </button>
-
-    <!-- ============================================================
-         "Develop" sub-menu — single top-level button that opens a
-         popover with the four breadth/depth modes. Grouped by register
-         (fiction / non-fiction). Modelled on the model-picker popover
-         so the cluster's interaction surface stays consistent: one
-         click opens the layer, second click picks the action.
-
-         Why a sub-menu and not four flat buttons? Each Develop mode is
-         opinionated — fiction vs non-fiction, breadth vs depth — and
-         flattening them into the toolbar would quadruple the visible
-         icons. The sub-menu keeps the top layer at six AI buttons,
-         which preserves the zen feel.
-    ============================================================ -->
-    <div class="develop-picker-wrapper">
-      <button
-        type="button"
-        class="tool-button develop-picker-button"
-        :class="{
-          'is-active': developPickerOpen || isDevelopModeActive,
-          'is-disabled': false,
-        }"
-        :aria-label="`Develop — broaden or deepen the piece. Currently: ${currentDevelopLabel}`"
-        :aria-haspopup="true"
-        :aria-expanded="developPickerOpen"
-        title="Develop — broaden or deepen the piece"
-        @click="developPickerOpen = !developPickerOpen"
-      >
-        <!-- Sapling-with-fork icon: trunk forking into two branches.
-             Reads as "growing in two directions" — appropriate for
-             the breadth/depth split. Chevron pip in the corner hints
-             that this opens a sub-menu. -->
-        <svg
-          width="18" height="18" viewBox="0 0 20 20"
-          fill="none" stroke="currentColor" stroke-width="1.4"
-          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-        >
-          <!-- Trunk -->
-          <path d="M10 17V9" />
-          <!-- Left branch — broader/lower -->
-          <path d="M10 12L5.5 7.5" />
-          <path d="M5.5 7.5h2" />
-          <path d="M5.5 7.5v2" />
-          <!-- Right branch — deeper/higher -->
-          <path d="M10 9L14.5 4.5" />
-          <path d="M14.5 4.5h-2" />
-          <path d="M14.5 4.5v2" />
-          <!-- Tiny chevron pip bottom-right indicates 'opens a menu' -->
-          <path d="M14.5 15.5l1.25 1.25L17 15.5" stroke-width="1.2" />
-        </svg>
-        <span class="tool-label">Develop</span>
-      </button>
-
-      <div
-        v-if="developPickerOpen"
-        class="develop-picker-popover"
-        role="menu"
-        @click.stop
-      >
-        <div class="develop-group">
-          <p class="develop-group-heading">Fiction</p>
-          <button
-            v-for="opt in DEVELOP_OPTIONS_FICTION"
-            :key="opt.mode"
-            type="button"
-            class="develop-option"
-            :class="{ 'is-selected': activeMode === opt.mode }"
-            role="menuitem"
-            @click="selectDevelop(opt.mode)"
-          >
-            <span class="develop-option-label">{{ opt.label }}</span>
-            <span class="develop-option-caption">{{ opt.caption }}</span>
-          </button>
-        </div>
-        <div class="develop-group-divider" aria-hidden="true"></div>
-        <div class="develop-group">
-          <p class="develop-group-heading">Non-fiction</p>
-          <button
-            v-for="opt in DEVELOP_OPTIONS_NONFICTION"
-            :key="opt.mode"
-            type="button"
-            class="develop-option"
-            :class="{ 'is-selected': activeMode === opt.mode }"
-            role="menuitem"
-            @click="selectDevelop(opt.mode)"
-          >
-            <span class="develop-option-label">{{ opt.label }}</span>
-            <span class="develop-option-caption">{{ opt.caption }}</span>
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Divider before the model picker + fix/float toggle -->
-    <div class="cluster-divider" aria-hidden="true"></div>
-
-    <!-- Model picker — small button showing the current model number;
-         click opens a popover listing the four allow-listed models. -->
-    <div class="model-picker-wrapper">
-      <button
-        type="button"
-        class="tool-button model-picker-button"
-        :class="{ 'is-active': modelPickerOpen }"
-        :aria-label="`AI model: ${currentModelLabel}. Click to change.`"
-        :title="`Model: ${currentModelLabel}`"
-        @click="modelPickerOpen = !modelPickerOpen"
-      >
-        <span class="model-badge">{{ currentModelBadge }}</span>
-        <span class="tool-label">Model: {{ currentModelLabel }}</span>
-      </button>
-      <div
-        v-if="modelPickerOpen"
-        class="model-picker-popover"
-        role="menu"
-        @click.stop
-      >
-        <button
-          v-for="opt in MODEL_OPTIONS"
-          :key="opt.id"
-          type="button"
-          class="model-option"
-          :class="{ 'is-selected': opt.id === model }"
-          role="menuitemradio"
-          :aria-checked="opt.id === model"
-          @click="selectModel(opt.id)"
-        >
-          <span class="model-option-label">{{ opt.label }}</span>
-          <span class="model-option-caption">{{ opt.caption }}</span>
-        </button>
-      </div>
-    </div>
-
-    <!-- Divider before the fix/float toggle -->
-    <div class="cluster-divider" aria-hidden="true"></div>
-
-    <!-- Fix/float toggle — padlock icon at the bottom of the rack.
-         Closed shackle = locked in place (cluster stays bottom-right).
-         Open shackle   = floating (cluster tracks the cursor's Y). -->
-    <button
-      type="button"
-      class="tool-button"
-      :class="{ 'is-active': !isFixed }"
-      :aria-label="isFixed ? 'Unlock cluster (float with cursor)' : 'Lock cluster in place'"
-      :title="isFixed ? 'Unlock — float with cursor' : (userPosition !== null ? 'Lock here' : 'Lock — stay in place')"
-      @click="toggleLock"
-    >
-      <!-- Closed padlock — when isFixed -->
-      <svg
-        v-if="isFixed"
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.5"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <rect x="4" y="9" width="12" height="8" rx="1.5" />
-        <path d="M6.5 9V6.5a3.5 3.5 0 0 1 7 0V9" />
-        <circle cx="10" cy="13" r="1" fill="currentColor" stroke="none" />
-      </svg>
-      <!-- Open padlock — when !isFixed -->
-      <svg
-        v-else
-        width="18" height="18" viewBox="0 0 20 20"
-        fill="none" stroke="currentColor" stroke-width="1.5"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-      >
-        <rect x="4" y="9" width="12" height="8" rx="1.5" />
-        <path d="M6.5 9V6.5a3.5 3.5 0 0 1 6.5-1.8" />
-        <circle cx="10" cy="13" r="1" fill="currentColor" stroke="none" />
-      </svg>
-      <span class="tool-label">{{ isFixed ? 'Locked' : 'Floating' }}</span>
+      <span class="tool-caption">Exit</span>
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import type { WritingAssistMode } from '@shared/WritingAssist'
 
 interface Props {
@@ -419,402 +241,13 @@ interface Props {
   saveDisabled: boolean
   /** True when the metadata side-panel is open. Highlights the metadata icon. */
   metadataOpen: boolean
-  /**
-   * Cursor's Y position in the viewport, in pixels. Used in float mode to
-   * keep the cluster's bottom edge 10px above the cursor. Pass null when
-   * the cursor isn't in the textarea (the cluster falls back to its
-   * fixed position then).
-   */
-  cursorY: number | null
   /** Currently-selected OpenAI model id. v-model:model from the parent. */
   model: string
   /** True when the Find & Replace panel is open. Highlights the icon. */
   findOpen?: boolean
 }
 
-const props = defineProps<Props>()
-
-/** Internal — controls whether the cluster is locked to its corner (true)
- *  or follows the cursor in the viewport (false). The padlock icon at the
- *  bottom of the rack toggles this. State is local since the parent
- *  doesn't need to know — it just keeps providing cursor Y. */
-const isFixed = ref(true)
-
-/** Custom position the writer dragged the cluster to. Takes precedence
- *  over both the default corner placement and cursor-tracking when set.
- *  Cleared whenever the writer unlocks the cluster (so each unlock starts
- *  fresh — they can either let it track the cursor again or drag it
- *  somewhere new and lock it). */
-const userPosition = ref<{ left: number; top: number } | null>(null)
-
-/** Visual flag for the drag in progress — adds is-dragging class so the
- *  cluster's CSS transition can be disabled while the pointer is moving. */
-const isDragging = ref(false)
-
-/** Template ref to the cluster element — used for measurement during drag
- *  (we read its bounding rect to compute the start position). */
-const clusterRootRef = ref<HTMLElement | null>(null)
-
-/** Cluster layout orientation. Auto-flips to horizontal when the writer
- *  drags the cluster so its center sits over the writing block's horizontal
- *  range — keeps the icons from covering too much vertical prose. */
-const orientation = ref<'vertical' | 'horizontal'>('vertical')
-
-/** Manual rotation in degrees. Driven by the top/bottom dot handles.
- *  0 is upright; positive rotates clockwise; 180 is inverted; any value
- *  is allowed. Stacks on top of orientation — i.e. a horizontal cluster
- *  rotated 90° still has a rotated-horizontal feel. */
-const rotation = ref<number>(0)
-
-/** Computed style. Three cases, in priority order:
- *   1. userPosition is set → use it (locked OR floating, doesn't matter
- *      — once dragged, the cluster stays put).
- *   2. !isFixed and cursorY is available → track 10px above the cursor.
- *   3. Otherwise → empty style; the static CSS (bottom: 28px right: 18px)
- *      applies and the cluster sits in its default corner. */
-const clusterStyle = computed<Record<string, string>>(() => {
-  // Build the position style first…
-  let style: Record<string, string> = {}
-  if (userPosition.value !== null) {
-    style = {
-      top:    `${userPosition.value.top}px`,
-      left:   `${userPosition.value.left}px`,
-      bottom: 'auto',
-      right:  'auto',
-    }
-  } else if (!isFixed.value && props.cursorY !== null) {
-    style = {
-      bottom: `calc(100vh - ${props.cursorY}px + 10px)`,
-      top:    'auto',
-    }
-  }
-  // …then apply manual rotation on top of whatever positioning is active.
-  // transform-origin defaults to the cluster's centre, so the visual
-  // anchor stays put while the cluster spins around itself.
-  if (rotation.value !== 0) {
-    style.transform = `rotate(${rotation.value}deg)`
-  }
-  return style
-})
-
-/* ============================================================
- * Lock toggle. Clicking the padlock either locks the cluster in place
- * (preserving any custom userPosition) or unlocks it and CLEARS the
- * custom position so cursor-tracking resumes. This keeps the model
- * simple: each unlock starts a fresh float; drag if you want a custom
- * spot; lock to fix it.
- * ============================================================ */
-function toggleLock() {
-  if (isFixed.value) {
-    // Unlocking — clear any prior dragged position AND rotation so the
-    // cluster resumes following the cursor immediately, upright. If the
-    // writer wants to lock it back at a custom spot or angle, they drag
-    // / rotate and then lock.
-    isFixed.value = false
-    userPosition.value = null
-    orientation.value = 'vertical'
-    rotation.value = 0
-  } else {
-    // Locking — keep userPosition + rotation as-is (cluster stays at
-    // dragged location and angle). If both are null/0, the cluster
-    // reverts to its default corner upright.
-    isFixed.value = true
-  }
-  saveStateToStorage()
-}
-
-/* ============================================================
- * Rotation handles. Two dots on the top and bottom of the border —
- * grab one, drag, the cluster rotates around its centre to follow the
- * pointer. Inverted (180°) is reachable; any angle in between works.
- * ============================================================ */
-
-let rotateState: { dotSide: 'top' | 'bottom' } | null = null
-
-function onRotateDotPointerDown(e: PointerEvent, side: 'top' | 'bottom') {
-  if (e.button !== 0) return
-  // Stop propagation so the cluster's own pointerdown (drag) handler
-  // doesn't also trigger — this gesture is purely rotational.
-  e.stopPropagation()
-  e.preventDefault()
-  rotateState = { dotSide: side }
-  isDragging.value = true // suppress transitions during the rotation
-  window.addEventListener('pointermove', onWindowRotateMove)
-  window.addEventListener('pointerup',   onWindowRotateUp,   { once: false })
-  window.addEventListener('pointercancel', onWindowRotateUp, { once: false })
-}
-
-function onWindowRotateMove(e: PointerEvent) {
-  if (!rotateState) return
-  const root = clusterRootRef.value
-  if (!root) return
-  const rect = root.getBoundingClientRect()
-  const centerX = rect.left + rect.width / 2
-  const centerY = rect.top  + rect.height / 2
-  // Angle from cluster centre to pointer, in degrees. atan2 returns
-  // [-π, π]; right = 0°, down = +90°, up = −90°.
-  const dx = e.clientX - centerX
-  const dy = e.clientY - centerY
-  const pointerAngle = Math.atan2(dy, dx) * (180 / Math.PI)
-  // The dots sit on different cluster edges depending on orientation:
-  //   vertical:   top → above centre (−90°), bottom → below (+90°)
-  //   horizontal: top → left of centre (180°), bottom → right (0°)
-  // For the pointer to land on the dot, rotation = pointerAngle − natural.
-  let naturalAngle: number
-  if (orientation.value === 'horizontal') {
-    naturalAngle = rotateState.dotSide === 'top' ? 180 : 0
-  } else {
-    naturalAngle = rotateState.dotSide === 'top' ? -90 : 90
-  }
-  rotation.value = pointerAngle - naturalAngle
-}
-
-function onWindowRotateUp() {
-  if (!rotateState) return
-  rotateState = null
-  // Re-enable transitions BEFORE snapping so the snap animates the short
-  // way around instead of jumping. Vue batches the next reactive write
-  // (rotation.value below) into the same DOM update, so the transform
-  // transition picks it up.
-  isDragging.value = false
-  window.removeEventListener('pointermove', onWindowRotateMove)
-  window.removeEventListener('pointerup',   onWindowRotateUp)
-  window.removeEventListener('pointercancel', onWindowRotateUp)
-
-  // Snap to the nearest 45° increment. Math.round((angle / 45)) * 45 picks
-  // the closest multiple regardless of sign or magnitude — so 47° → 45°,
-  // 100° → 90°, 358° → 360° (effectively 0°). We deliberately don't
-  // normalize the absolute value here: keeping the raw rounded number
-  // preserves the visual short-path between the writer's release angle
-  // and the snapped target. Storage size is trivial either way.
-  rotation.value = Math.round(rotation.value / 45) * 45
-
-  saveStateToStorage()
-}
-
-/* ============================================================
- * Drag-to-reposition. Active only when unlocked. A 4px threshold
- * separates a click on a button from an actual drag, so the AI tools
- * + page actions still work normally with a single click.
- * ============================================================ */
-
-const DRAG_THRESHOLD_PX = 4
-
-interface DragState {
-  pointerId: number
-  startClientX: number
-  startClientY: number
-  startLeft: number
-  startTop: number
-  passedThreshold: boolean
-}
-let drag: DragState | null = null
-/** Set true on pointerup when a drag actually moved past threshold,
- *  so the next click event (synthesized from the pointer interaction)
- *  is suppressed — otherwise the dragged button would fire its action. */
-let suppressNextClick = false
-
-function onPointerDown(e: PointerEvent) {
-  if (isFixed.value) return // dragging only allowed when unlocked
-  if (e.button !== 0) return // primary button only
-  const root = clusterRootRef.value
-  if (!root) return
-
-  const rect = root.getBoundingClientRect()
-  drag = {
-    pointerId: e.pointerId,
-    startClientX: e.clientX,
-    startClientY: e.clientY,
-    startLeft: rect.left,
-    startTop: rect.top,
-    passedThreshold: false,
-  }
-
-  // Listen on window so the drag continues even if the pointer leaves
-  // the cluster's bounds. Removed in onWindowPointerUp.
-  window.addEventListener('pointermove', onWindowPointerMove)
-  window.addEventListener('pointerup',   onWindowPointerUp,   { once: false })
-  window.addEventListener('pointercancel', onWindowPointerUp, { once: false })
-}
-
-function onWindowPointerMove(e: PointerEvent) {
-  if (!drag || e.pointerId !== drag.pointerId) return
-
-  const dx = e.clientX - drag.startClientX
-  const dy = e.clientY - drag.startClientY
-
-  if (!drag.passedThreshold) {
-    if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return
-    drag.passedThreshold = true
-    isDragging.value = true
-  }
-
-  // Compute new position, clamped to viewport so the cluster never
-  // disappears off-screen.
-  const root = clusterRootRef.value
-  const w = root?.offsetWidth ?? 0
-  const h = root?.offsetHeight ?? 0
-  const left = Math.max(0, Math.min(window.innerWidth  - w, drag.startLeft + dx))
-  const top  = Math.max(0, Math.min(window.innerHeight - h, drag.startTop  + dy))
-  userPosition.value = { left, top }
-}
-
-function onWindowPointerUp(e: PointerEvent) {
-  if (!drag || e.pointerId !== drag.pointerId) return
-
-  const wasDragging = drag.passedThreshold
-  drag = null
-  isDragging.value = false
-  window.removeEventListener('pointermove', onWindowPointerMove)
-  window.removeEventListener('pointerup',   onWindowPointerUp)
-  window.removeEventListener('pointercancel', onWindowPointerUp)
-
-  if (wasDragging) {
-    // The synthesized click that follows pointerup must NOT fire on the
-    // button the writer happened to start the drag from — they meant to
-    // move the cluster, not run that tool. onClickCapture below will
-    // swallow the next click event and reset the flag.
-    suppressNextClick = true
-    // Re-detect orientation now that the cluster has settled at its
-    // new position; persist the whole state.
-    refreshOrientation()
-    saveStateToStorage()
-  }
-}
-
-function onClickCapture(e: MouseEvent) {
-  if (!suppressNextClick) return
-  suppressNextClick = false
-  e.stopPropagation()
-  e.preventDefault()
-}
-
-/* ============================================================
- * Auto-orientation. When the dragged cluster's centre sits inside the
- * writing block's horizontal range, flip to a horizontal layout so the
- * icons stack across instead of down — that way the cluster occupies
- * one row of prose rather than blocking many lines vertically.
- *
- * Detection uses a global selector to find the textarea#body. Cheap
- * and resilient; falls back to vertical if the textarea isn't present.
- * ============================================================ */
-function detectOrientation(): 'vertical' | 'horizontal' {
-  // No custom position → default corner → always vertical.
-  if (userPosition.value === null) return 'vertical'
-  const ta = document.querySelector('textarea#body') as HTMLTextAreaElement | null
-  if (!ta) return 'vertical'
-  const taRect = ta.getBoundingClientRect()
-  const root = clusterRootRef.value
-  // Use current cluster width (which depends on current orientation —
-  // that's fine: the centre-overlap test is robust to either width).
-  const clusterW = root?.offsetWidth ?? 48
-  const clusterCentre = userPosition.value.left + clusterW / 2
-  return (clusterCentre >= taRect.left && clusterCentre <= taRect.right)
-    ? 'horizontal'
-    : 'vertical'
-}
-
-function refreshOrientation() {
-  orientation.value = detectOrientation()
-}
-
-/* ============================================================
- * Persistence — isFixed + orientation + userPosition saved to
- * localStorage under one key. State survives page reload, app restart,
- * and route navigation. To reset to defaults: clear the storage entry
- * (DevTools → Application → Local Storage) or do a hard reload after
- * clearing site data.
- * ============================================================ */
-const STORAGE_KEY = 'rambulations-cluster-state'
-
-interface StoredClusterState {
-  isFixed?: boolean
-  orientation?: 'vertical' | 'horizontal'
-  userPosition?: { left: number; top: number } | null
-  rotation?: number
-}
-
-function loadStateFromStorage(): StoredClusterState | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw)
-    if (typeof parsed !== 'object' || parsed === null) return null
-    return parsed as StoredClusterState
-  } catch {
-    return null
-  }
-}
-
-function saveStateToStorage() {
-  try {
-    const state: StoredClusterState = {
-      isFixed: isFixed.value,
-      orientation: orientation.value,
-      userPosition: userPosition.value,
-      rotation: rotation.value,
-    }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-  } catch {
-    // Quota exceeded or storage unavailable — ignore. Cluster still works,
-    // just won't remember placement next session.
-  }
-}
-
-/** Re-clamp a remembered position so it can't be off-screen after a
- *  viewport change between sessions (window resize, different display, etc.) */
-function clampPositionToViewport(p: { left: number; top: number }): { left: number; top: number } {
-  const root = clusterRootRef.value
-  const w = root?.offsetWidth ?? 48
-  const h = root?.offsetHeight ?? 350
-  return {
-    left: Math.max(0, Math.min(window.innerWidth  - w, p.left)),
-    top:  Math.max(0, Math.min(window.innerHeight - h, p.top)),
-  }
-}
-
-/* ============================================================
- * Lifecycle: load saved state on mount, listen for resize so a
- * remembered position re-clamps and orientation re-detects.
- * ============================================================ */
-onMounted(async () => {
-  const state = loadStateFromStorage()
-  if (state) {
-    if (typeof state.isFixed === 'boolean') isFixed.value = state.isFixed
-    if (state.orientation === 'horizontal' || state.orientation === 'vertical') {
-      orientation.value = state.orientation
-    }
-    if (typeof state.rotation === 'number' && Number.isFinite(state.rotation)) {
-      rotation.value = state.rotation
-    }
-    if (state.userPosition
-        && typeof state.userPosition.left === 'number'
-        && typeof state.userPosition.top === 'number') {
-      // Set orientation first so the cluster reflows to the right size;
-      // wait for DOM to flush; then clamp position to current viewport.
-      await nextTick()
-      userPosition.value = clampPositionToViewport(state.userPosition)
-    }
-  }
-
-  window.addEventListener('resize', onWindowResize)
-  window.addEventListener('pointerdown', onWindowPointerDownForPicker)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', onWindowResize)
-  window.removeEventListener('pointerdown', onWindowPointerDownForPicker)
-})
-
-function onWindowResize() {
-  // Re-clamp the remembered position so the cluster stays on-screen,
-  // and re-detect orientation in case the writing block moved relative
-  // to the cluster.
-  if (userPosition.value !== null) {
-    userPosition.value = clampPositionToViewport(userPosition.value)
-  }
-  refreshOrientation()
-}
+defineProps<Props>()
 
 const emit = defineEmits<{
   /** AI tool clicked. Parent opens the assist panel in this mode. */
@@ -831,137 +264,122 @@ const emit = defineEmits<{
   'font-up': []
   /** Bump the body font size down by one step. */
   'font-down': []
-  /** Writer picked a different model from the popover. v-model:model. */
+  /** Writer picked a different model from the AI menu. v-model:model. */
   'update:model': [string]
 }>()
 
-const isHovering = ref(false)
+const toolbarRootRef = ref<HTMLElement | null>(null)
 
-/** Develop sub-menu open/closed. Declared up here so the `hasActiveMode`
- *  computed below can reference it without a forward reference — Vue's
- *  computed is lazy at runtime, but some bundler configurations evaluate
- *  the closure earlier than expected, so we keep declaration order
- *  strict to avoid surprises. The full Develop-quadrant config and
- *  helpers live further down (DEVELOP_OPTIONS, selectDevelop, etc). */
-const developPickerOpen = ref(false)
+/* ============================================================
+ * Menus — one open at a time. The AI sheet consolidates the assist
+ * tools, the Develop quadrant and the model picker; the text sheet
+ * holds the two font-size steppers.
+ * ============================================================ */
+const aiMenuOpen = ref(false)
+const textMenuOpen = ref(false)
 
-// Cluster is "active" (full opacity) whenever any panel/popover is open
-// or an AI mode is currently selected. Including the Develop popover
-// here means opening the sub-menu lights up the cluster the same way
-// hovering does — the writer's eye doesn't have to hunt for the picker.
-const hasActiveMode = computed(() =>
-  props.activeMode !== null
-  || props.metadataOpen
-  || developPickerOpen.value
-)
+function toggleAiMenu() {
+  aiMenuOpen.value = !aiMenuOpen.value
+  if (aiMenuOpen.value) textMenuOpen.value = false
+}
+
+function toggleTextMenu() {
+  textMenuOpen.value = !textMenuOpen.value
+  if (textMenuOpen.value) aiMenuOpen.value = false
+}
+
+function selectAiTool(mode: WritingAssistMode) {
+  emit('select', mode)
+  aiMenuOpen.value = false
+}
+
+function selectModel(id: string) {
+  emit('update:model', id)
+  // Keep the sheet open — picking a model is usually a prelude to picking
+  // a tool, and the checkmark gives immediate feedback.
+}
+
+// Close menus when the writer taps/clicks anywhere outside the toolbar,
+// or presses Escape. The sheets stop click propagation internally.
+function onWindowPointerDown(e: PointerEvent) {
+  if (!aiMenuOpen.value && !textMenuOpen.value) return
+  const root = toolbarRootRef.value
+  if (!root) return
+  if (root.contains(e.target as Node)) return
+  aiMenuOpen.value = false
+  textMenuOpen.value = false
+}
+
+function onWindowKeyDown(e: KeyboardEvent) {
+  if (e.key !== 'Escape') return
+  if (!aiMenuOpen.value && !textMenuOpen.value) return
+  aiMenuOpen.value = false
+  textMenuOpen.value = false
+}
+
+onMounted(() => {
+  window.addEventListener('pointerdown', onWindowPointerDown)
+  window.addEventListener('keydown', onWindowKeyDown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('pointerdown', onWindowPointerDown)
+  window.removeEventListener('keydown', onWindowKeyDown)
+})
 
 interface AiTool {
   mode: WritingAssistMode
   label: string
-  tooltip: string
+  caption: string
   /** True for tools that strictly need a selection (focus). Others fall back to whole-essay mode. */
   requiresSelection: boolean
-}
-
-/* ============================================================
- * Model selector — top 4 OpenAI models per platform.openai.com (2026
- * lineup). Keep this list in sync with ALLOWED_MODELS in
- * server/src/controllers/writing.controller.ts; if the two drift, the
- * server will silently ignore the client's choice and fall back to env.
- * ============================================================ */
-
-interface ModelOption {
-  id: string
-  /** Long label shown in the popover. */
-  label: string
-  /** Short trailing description shown beneath the label. */
-  caption: string
-  /** Tiny number/string shown on the cluster icon when selected. */
-  badge: string
-}
-
-const MODEL_OPTIONS: ModelOption[] = [
-  { id: 'gpt-5.5',      label: 'GPT-5.5',      caption: 'Flagship — best quality, slowest',  badge: '5.5'  },
-  { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', caption: 'Balanced speed and quality',         badge: '5.4'  },
-  { id: 'gpt-4.1',      label: 'GPT-4.1',      caption: 'Strong text + code, cheaper',        badge: '4.1'  },
-  { id: 'gpt-4o-mini',  label: 'GPT-4o mini',  caption: 'Fast and inexpensive (default)',     badge: '4o'   },
-]
-
-const modelPickerOpen = ref(false)
-
-const currentModelOption = computed<ModelOption>(() =>
-  MODEL_OPTIONS.find(m => m.id === props.model) ?? MODEL_OPTIONS[3] // default to gpt-4o-mini if unrecognised
-)
-const currentModelLabel = computed(() => currentModelOption.value.label)
-const currentModelBadge = computed(() => currentModelOption.value.badge)
-
-function selectModel(id: string) {
-  emit('update:model', id)
-  modelPickerOpen.value = false
-}
-
-// Close any open popover (model picker OR develop sub-menu) when the
-// writer clicks anywhere outside the cluster. Both popovers stop click
-// propagation internally with @click.stop, so a click on the popover
-// itself doesn't close it. Mounted/unmounted in the existing lifecycle
-// below.
-function onWindowPointerDownForPicker(e: PointerEvent) {
-  if (!modelPickerOpen.value && !developPickerOpen.value) return
-  const root = clusterRootRef.value
-  if (!root) return
-  if (root.contains(e.target as Node)) return
-  modelPickerOpen.value = false
-  developPickerOpen.value = false
 }
 
 const aiTools: AiTool[] = [
   {
     mode: 'coherence',
     label: 'Ask',
-    tooltip: 'Ask a coherence question (character, arc, motif)',
+    caption: 'Ask a coherence question (character, arc, motif)',
     requiresSelection: false,
   },
   {
     mode: 'define',
     label: 'Define',
-    tooltip: 'Define a word or phrase',
+    caption: 'Define a word or phrase',
     requiresSelection: false,
   },
   {
     mode: 'focus',
     label: 'Focus',
-    tooltip: 'Tighten the selection without losing voice',
+    caption: 'Tighten the selection without losing voice',
     requiresSelection: true,
   },
   {
     mode: 'expand',
     label: 'Expand',
-    tooltip: 'Add substance — never padding',
+    caption: 'Add substance — never padding',
     requiresSelection: false,
   },
   {
     mode: 'proofread',
     label: 'Proofread',
-    tooltip: 'Light spelling/grammar — preserves voice',
+    caption: 'Light spelling/grammar — preserves voice',
     requiresSelection: false,
   },
   {
     mode: 'factcheck',
     label: 'Fact-check',
-    tooltip: 'Check factual claims (selection or whole frag)',
+    caption: 'Check factual claims (selection or whole frag)',
     requiresSelection: false,
   },
 ]
 
 /* ============================================================
- * Develop sub-menu — four sister modes split across two registers
- * (fiction / non-fiction) and two axes (breadth / depth). Owned by
- * this component because the cluster is the only place they're
- * surfaced; the main aiTools array stays flat so the top toolbar
- * keeps its zen feel.
+ * Develop — four sister modes split across two registers
+ * (fiction / non-fiction) and two axes (breadth / depth).
  *
  * Each option's `caption` is the one-line phrasing the writer reads
- * inside the popover — kept short on purpose; the full prompt-side
+ * inside the sheet — kept short on purpose; the full prompt-side
  * brief is in server/src/services/llm/prompts.ts.
  * ============================================================ */
 
@@ -997,409 +415,82 @@ const DEVELOP_OPTIONS_NONFICTION: DevelopOption[] = [
   },
 ]
 
-/** Combined list — used for label lookup (popover-trigger aria text). */
-const DEVELOP_OPTIONS: DevelopOption[] = [
-  ...DEVELOP_OPTIONS_FICTION,
-  ...DEVELOP_OPTIONS_NONFICTION,
-]
+/* ============================================================
+ * Model selector — top 4 OpenAI models per platform.openai.com (2026
+ * lineup). Keep this list in sync with ALLOWED_MODELS in
+ * server/src/controllers/writing.controller.ts; if the two drift, the
+ * server will silently ignore the client's choice and fall back to env.
+ * ============================================================ */
 
-/** True when the current activeMode is one of the four develop modes. Used
- *  to keep the trigger button highlighted while the panel is showing a
- *  Develop result, even after the popover has closed. */
-const isDevelopModeActive = computed<boolean>(() =>
-  props.activeMode != null
-  && DEVELOP_OPTIONS.some(o => o.mode === props.activeMode)
-)
-
-/** Label shown in the Develop trigger's aria/title when a develop mode is
- *  currently the panel's active mode — gives the writer feedback on which
- *  Develop variant they last picked, without surfacing the full caption. */
-const currentDevelopLabel = computed<string>(() => {
-  const match = DEVELOP_OPTIONS.find(o => o.mode === props.activeMode)
-  return match ? match.label : 'none'
-})
-
-/** Selecting an option closes the popover and bubbles the choice up via
- *  the existing `select` event so the parent (Write.vue) can dispatch
- *  the assist request. The popover open/closed state lives further up
- *  in the script (declared above `hasActiveMode` so the latter can
- *  reference it without a forward-reference). */
-function selectDevelop(mode: WritingAssistMode) {
-  emit('select', mode)
-  developPickerOpen.value = false
+interface ModelOption {
+  id: string
+  label: string
+  caption: string
 }
+
+const MODEL_OPTIONS: ModelOption[] = [
+  { id: 'gpt-5.5',      label: 'GPT-5.5',      caption: 'Flagship — best quality, slowest' },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', caption: 'Balanced speed and quality' },
+  { id: 'gpt-4.1',      label: 'GPT-4.1',      caption: 'Strong text + code, cheaper' },
+  { id: 'gpt-4o-mini',  label: 'GPT-4o mini',  caption: 'Fast and inexpensive (default)' },
+]
 </script>
 
 <style scoped>
-/* Floating cluster — bottom-right corner of the viewport.
-   Positioned outside the prose so it never crosses what the writer is reading.
-   Idle ~30% opacity so it lives quietly in the periphery; full on hover/focus. */
-.writing-tools-cluster {
+/* ============================================================
+ * Bottom toolbar — mobile-first. Full-width bar pinned to the bottom
+ * edge (safe-area aware) on small screens; a centered floating pill
+ * on larger ones. Buttons are 44px+ touch targets with a tiny caption
+ * under each icon so nothing needs a hover to be understood.
+ * ============================================================ */
+.writing-toolbar {
   position: fixed;
-  right: 18px;
-  /* With the bottom footer gone in zen mode, the cluster can sit closer to
-     the corner — but we keep some breathing room so it doesn't kiss the edge. */
-  bottom: 28px;
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 40;
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 6px;
-  border-radius: 22px;
-  background-color: rgb(var(--color-paper) / 0.6);
-  /* Accent-color border at low opacity when idle so the cluster reads as
-     "burnt-orange-trimmed paper" rather than a generic pill. */
-  border: 1px solid rgb(var(--color-accent) / 0.4);
-  backdrop-filter: blur(6px);
-  opacity: 0.32;
-  transition: opacity 220ms ease-out, background-color 220ms ease-out, border-color 220ms ease-out;
+  align-items: stretch;
+  justify-content: space-around;
+  gap: 2px;
+  padding: 6px 8px calc(6px + env(safe-area-inset-bottom, 0px));
+  background-color: rgb(var(--color-paper) / 0.92);
+  border-top: 1px solid rgb(var(--color-line));
+  backdrop-filter: blur(8px);
 }
 
-.writing-tools-cluster.is-active,
-.writing-tools-cluster:focus-within {
-  opacity: 1;
-  background-color: rgb(var(--color-paper));
-  border-color: rgb(var(--color-accent));
-}
-
-/* Float mode — cluster glides with the cursor. The transition on
-   `bottom` smooths the per-keystroke jumps so the cluster reads as
-   "following" the cursor rather than teleporting. The transform
-   transition smooths the rotation snap-to-45° on dot-release.
-   Honors reduced-motion. */
-.writing-tools-cluster.is-floating {
-  transition:
-    bottom    220ms cubic-bezier(0.25, 0.1, 0.25, 1),
-    top       220ms cubic-bezier(0.25, 0.1, 0.25, 1),
-    left      220ms cubic-bezier(0.25, 0.1, 0.25, 1),
-    transform 220ms cubic-bezier(0.25, 0.1, 0.25, 1),
-    opacity   220ms ease-out,
-    background-color 220ms ease-out,
-    border-color    220ms ease-out;
-  cursor: grab;
-}
-
-/* Pinned — userPosition is set, cluster sits at a custom drag location. */
-.writing-tools-cluster.is-pinned {
-  cursor: grab;
-}
-
-/* Active drag — kill the smooth transition so the cluster sticks to the
-   pointer. Cursor flips to grabbing for grab-affordance feedback. */
-.writing-tools-cluster.is-dragging {
-  transition: none !important;
-  cursor: grabbing;
-  /* Slight scale + shadow to read as "lifted" while moving. Subtle. */
-  box-shadow: 0 8px 18px rgb(var(--color-ink) / 0.18);
-}
-.writing-tools-cluster.is-dragging .tool-button {
-  cursor: grabbing;
-  pointer-events: none; /* block hover/focus during drag */
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .writing-tools-cluster.is-floating {
-    transition: opacity 220ms ease-out;
+/* Desktop: float as a centered pill instead of a full-width bar. */
+@media (min-width: 768px) {
+  .writing-toolbar {
+    left: 50%;
+    right: auto;
+    bottom: 20px;
+    transform: translateX(-50%);
+    justify-content: center;
+    gap: 4px;
+    padding: 6px 10px;
+    border: 1px solid rgb(var(--color-accent) / 0.4);
+    border-radius: 999px;
+    box-shadow: 0 6px 20px rgb(var(--color-ink) / 0.14);
   }
 }
 
-.cluster-divider {
-  height: 1px;
-  margin: 4px 6px;
-  background-color: rgb(var(--color-line));
-  opacity: 0.7;
-}
-
-/* ============================================================
- * Model picker — small button shows the current model number; click
- * opens a popover anchored to the cluster's left edge listing all four
- * model options.
- * ============================================================ */
-.model-picker-wrapper {
-  position: relative;
-}
-.model-picker-button .model-badge {
-  font-family: 'Inter', sans-serif;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  line-height: 1;
-}
-.model-picker-popover {
-  position: absolute;
-  /* Anchor to the left of the button, with the same gap the tooltip uses. */
-  right: calc(100% + 8px);
-  top: 50%;
-  transform: translateY(-50%);
-  width: 220px;
-  max-width: 240px;
-  background-color: rgb(var(--color-paper));
-  border: 1px solid rgb(var(--color-accent));
-  border-radius: 8px;
-  padding: 4px;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  z-index: 50;
-  box-shadow: 0 8px 18px rgb(var(--color-ink) / 0.18);
-  pointer-events: auto;
-}
-.model-option {
-  appearance: none;
-  background: transparent;
-  border: none;
-  text-align: left;
-  padding: 8px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  transition: background-color 120ms ease-out;
-  font-family: 'Inter', sans-serif;
-}
-.model-option:hover,
-.model-option:focus-visible {
-  background-color: rgb(var(--color-accent-muted));
-  outline: none;
-}
-.model-option.is-selected {
-  background-color: rgb(var(--color-accent-muted));
-}
-.model-option-label {
-  font-size: 13px;
-  font-weight: 600;
-  color: rgb(var(--cluster-icon-color));
-}
-.model-option.is-selected .model-option-label {
-  color: rgb(var(--color-accent));
-}
-.model-option-caption {
-  font-size: 11px;
-  color: rgb(var(--color-ink-lighter));
-  line-height: 1.3;
-}
-
-/* In horizontal mode the popover should pop ABOVE the button, not to its
-   left, since the cluster sits horizontally and there's nothing to the
-   left of it. */
-.writing-tools-cluster.is-horizontal .model-picker-popover {
-  right: auto;
-  left: 50%;
-  top: auto;
-  bottom: calc(100% + 8px);
-  transform: translateX(-50%);
-}
-
-/* ============================================================
- * Develop sub-menu — single trigger button + popover with the four
- * fiction/non-fiction × breadth/depth options. Visual language matches
- * the model-picker popover (same paper colour, accent border, anchor
- * positioning) so the cluster's two popovers feel like one system.
- * ============================================================ */
-.develop-picker-wrapper {
-  position: relative;
-}
-.develop-picker-popover {
-  position: absolute;
-  /* Anchor to the LEFT of the trigger by default — the cluster lives
-     in the bottom-right corner so we open inward. The horizontal-mode
-     override below pops it ABOVE the trigger instead. */
-  right: calc(100% + 8px);
-  top: 50%;
-  transform: translateY(-50%);
-  /* Wider than the model picker because each option's caption needs a
-     comfortable line for the breadth/depth phrasing. Capped so the
-     popover never cuts the writing block in half on narrow screens. */
-  width: 260px;
-  max-width: min(280px, 90vw);
-  background-color: rgb(var(--color-paper));
-  border: 1px solid rgb(var(--color-accent));
-  border-radius: 8px;
-  padding: 6px;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  z-index: 50;
-  box-shadow: 0 8px 18px rgb(var(--color-ink) / 0.18);
-  pointer-events: auto;
-}
-.develop-group {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.develop-group-heading {
-  /* Same uppercase-tracker treatment used in the rest of the app for
-     "section heading" text. Kept tight because each group only has two
-     options. */
-  font-family: 'Inter', sans-serif;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgb(var(--color-ink-lighter));
-  padding: 6px 10px 2px;
-  margin: 0;
-}
-.develop-group-divider {
-  height: 1px;
-  margin: 4px 6px;
-  background-color: rgb(var(--color-line));
-  opacity: 0.6;
-}
-.develop-option {
-  appearance: none;
-  background: transparent;
-  border: none;
-  text-align: left;
-  padding: 8px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  transition: background-color 120ms ease-out;
-  font-family: 'Inter', sans-serif;
-}
-.develop-option:hover,
-.develop-option:focus-visible {
-  background-color: rgb(var(--color-accent-muted));
-  outline: none;
-}
-.develop-option.is-selected {
-  background-color: rgb(var(--color-accent-muted));
-}
-.develop-option-label {
-  font-size: 13px;
-  font-weight: 600;
-  color: rgb(var(--cluster-icon-color));
-}
-.develop-option.is-selected .develop-option-label {
-  color: rgb(var(--color-accent));
-}
-.develop-option-caption {
-  font-size: 11px;
-  color: rgb(var(--color-ink-lighter));
-  line-height: 1.3;
-}
-
-/* Horizontal-mode anchor: pop ABOVE the trigger (cluster is laid out
-   horizontally and there's no horizontal space for a side popover). */
-.writing-tools-cluster.is-horizontal .develop-picker-popover {
-  right: auto;
-  left: 50%;
-  top: auto;
-  bottom: calc(100% + 8px);
-  transform: translateX(-50%);
-}
-
-/* ============================================================
- * Rotation handle dots — only shown when unlocked. Drag a dot to spin
- * the cluster around its centre. Sit half-on-half-off the border so
- * they read as proper grip points.
- * ============================================================ */
-.rotate-dot {
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background-color: rgb(var(--color-accent));
-  border: 1.5px solid rgb(var(--color-paper));
-  cursor: grab;
-  z-index: 2;
-  pointer-events: auto;
-  transition: transform 120ms ease-out, background-color 120ms ease-out;
-  /* Inherit no rotation from the cluster's transform — they ARE inside the
-     rotated container, so they rotate with it. That's correct: each dot
-     stays attached to "its" border edge. */
-}
-.rotate-dot:hover,
-.rotate-dot:active {
-  background-color: rgb(var(--color-accent-hover));
-  cursor: grabbing;
-}
-.rotate-dot-top {
-  top: -5px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-.rotate-dot-bottom {
-  bottom: -5px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-.rotate-dot-top:hover,
-.rotate-dot-top:active {
-  transform: translateX(-50%) scale(1.25);
-}
-.rotate-dot-bottom:hover,
-.rotate-dot-bottom:active {
-  transform: translateX(-50%) scale(1.25);
-}
-
-/* In horizontal orientation the cluster's "top" and "bottom" become the
-   short edges. Move the dots to those edges so they remain grippable. */
-.writing-tools-cluster.is-horizontal .rotate-dot-top {
-  top: 50%;
-  left: -5px;
-  transform: translateY(-50%);
-}
-.writing-tools-cluster.is-horizontal .rotate-dot-bottom {
-  top: 50%;
-  left: auto;
-  right: -5px;
-  bottom: auto;
-  transform: translateY(-50%);
-}
-.writing-tools-cluster.is-horizontal .rotate-dot-top:hover,
-.writing-tools-cluster.is-horizontal .rotate-dot-top:active {
-  transform: translateY(-50%) scale(1.25);
-}
-.writing-tools-cluster.is-horizontal .rotate-dot-bottom:hover,
-.writing-tools-cluster.is-horizontal .rotate-dot-bottom:active {
-  transform: translateY(-50%) scale(1.25);
-}
-
-/* ============================================================
- * Horizontal orientation — kicks in when the writer drags the cluster
- * across the writing block. Icons stack across instead of down so the
- * cluster occupies one row of prose, not many.
- * ============================================================ */
-.writing-tools-cluster.is-horizontal {
-  flex-direction: row;
-  /* Pill stays pill — same border-radius works for the stretched shape. */
-}
-.writing-tools-cluster.is-horizontal .cluster-divider {
-  /* Vertical bar instead of horizontal line. */
-  width: 1px;
-  height: 24px;
-  margin: 6px 4px;
-}
-.writing-tools-cluster.is-horizontal .tool-label {
-  /* Tooltip pops above the button instead of to its left. */
-  right: auto;
-  left: 50%;
-  bottom: calc(100% + 8px);
-  top: auto;
-  transform: translateX(-50%) translateY(0);
-}
-
 .tool-button {
-  width: 36px;
-  height: 36px;
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 2px;
+  min-width: 52px;
+  min-height: 48px;
+  padding: 4px 8px;
   border: none;
-  border-radius: 999px;
+  border-radius: 12px;
   background: transparent;
-  /* --cluster-icon-color is theme-aware and interpolated by the
-     brightness slider: dark green in light mode, silver-white in dark. */
   color: rgb(var(--cluster-icon-color));
   cursor: pointer;
-  position: relative;
-  transition: color 160ms ease-out, background-color 160ms ease-out, transform 160ms ease-out;
+  transition: color 160ms ease-out, background-color 160ms ease-out;
+  -webkit-tap-highlight-color: transparent;
 }
 .tool-button:hover:not(.is-disabled),
 .tool-button:focus-visible {
@@ -1410,9 +501,6 @@ function selectDevelop(mode: WritingAssistMode) {
 .tool-button:focus-visible {
   box-shadow: 0 0 0 2px rgb(var(--color-accent));
 }
-.tool-button:hover:not(.is-disabled) {
-  transform: scale(1.06);
-}
 .tool-button.is-active {
   color: rgb(var(--color-accent));
   background-color: rgb(var(--color-accent-muted));
@@ -1422,8 +510,8 @@ function selectDevelop(mode: WritingAssistMode) {
   cursor: not-allowed;
 }
 
-/* Primary action (Save) gets a subtle accent ring at rest so the writer
-   can find it without scanning labels. Still discreet, still zen. */
+/* Primary action (Save) reads accented at rest so the writer can find it
+   without scanning captions. */
 .tool-button.is-primary {
   color: rgb(var(--color-accent));
 }
@@ -1433,53 +521,170 @@ function selectDevelop(mode: WritingAssistMode) {
   color: rgb(var(--color-paper));
 }
 
-/* Label — slides out to the LEFT on hover, only visible when cluster is active.
-   Positioned absolutely so the buttons themselves stay perfectly square. */
-.tool-label {
-  position: absolute;
-  right: calc(100% + 8px);
-  top: 50%;
-  transform: translateY(-50%);
+/* Caption under each icon — always visible, so the toolbar needs no
+   hover-tooltips (which don't exist on touch anyway). */
+.tool-caption {
   font-family: 'Inter', sans-serif;
-  font-size: 12px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.02em;
-  /* Same theme-aware color as the icons so labels read as silver-white
-     in dark mode too. */
-  color: rgb(var(--cluster-icon-color));
+  line-height: 1;
+}
+
+/* ============================================================
+ * Sheets/popovers — anchored to their trigger. On mobile the AI sheet
+ * spans the viewport width just above the bar; on desktop it becomes a
+ * compact popover above the trigger.
+ * ============================================================ */
+.menu-anchor {
+  position: relative;
+  display: flex;
+}
+
+.menu-sheet {
+  position: fixed;
+  left: 8px;
+  right: 8px;
+  bottom: calc(66px + env(safe-area-inset-bottom, 0px));
   background-color: rgb(var(--color-paper));
   border: 1px solid rgb(var(--color-accent) / 0.5);
-  border-radius: 4px;
-  padding: 3px 8px;
-  white-space: nowrap;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 140ms ease-out 250ms; /* small delay before tooltip appears */
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgb(var(--color-ink) / 0.2);
+  z-index: 50;
+  overflow: hidden;
 }
-.tool-button:hover:not(.is-disabled) .tool-label,
-.tool-button:focus-visible .tool-label {
-  opacity: 1;
+
+@media (min-width: 768px) {
+  .menu-sheet {
+    position: absolute;
+    left: 50%;
+    right: auto;
+    bottom: calc(100% + 12px);
+    transform: translateX(-50%);
+    width: 300px;
+  }
+}
+
+.sheet-scroll {
+  max-height: min(55vh, 480px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sheet-heading {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(var(--color-ink-lighter));
+  padding: 8px 10px 2px;
+  margin: 0;
+}
+
+.sheet-divider {
+  height: 1px;
+  margin: 6px 8px;
+  background-color: rgb(var(--color-line));
+  opacity: 0.7;
+}
+
+.sheet-option {
+  appearance: none;
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 10px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  transition: background-color 120ms ease-out;
+  font-family: 'Inter', sans-serif;
+  -webkit-tap-highlight-color: transparent;
+}
+.sheet-option:hover:not(:disabled),
+.sheet-option:focus-visible {
+  background-color: rgb(var(--color-accent-muted));
+  outline: none;
+}
+.sheet-option.is-selected {
+  background-color: rgb(var(--color-accent-muted));
+}
+.sheet-option.is-disabled,
+.sheet-option:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.sheet-option-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgb(var(--cluster-icon-color));
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.sheet-option.is-selected .sheet-option-label {
+  color: rgb(var(--color-accent));
+}
+.sheet-option-caption {
+  font-size: 11px;
+  color: rgb(var(--color-ink-lighter));
+  line-height: 1.3;
+}
+.sheet-check {
+  color: rgb(var(--color-accent));
+  flex-shrink: 0;
+}
+
+/* Text-size sheet — just the two steppers, side by side. */
+.text-sheet {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  padding: 6px;
+  left: auto;
+  right: 8px;
+  width: auto;
+}
+@media (min-width: 768px) {
+  .text-sheet {
+    right: auto;
+    width: auto;
+  }
+}
+.text-step-button {
+  appearance: none;
+  border: 1px solid rgb(var(--color-line));
+  background: transparent;
+  color: rgb(var(--cluster-icon-color));
+  border-radius: 10px;
+  min-width: 56px;
+  min-height: 44px;
+  font-family: 'Courier Prime', monospace;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 120ms ease-out, color 120ms ease-out;
+  -webkit-tap-highlight-color: transparent;
+}
+.text-step-button:hover,
+.text-step-button:focus-visible {
+  background-color: rgb(var(--color-accent-muted));
+  color: rgb(var(--color-accent));
+  outline: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .writing-tools-cluster,
   .tool-button,
-  .tool-label {
+  .sheet-option,
+  .text-step-button {
     transition: none;
-  }
-  .tool-button:hover:not(.is-disabled) {
-    transform: none;
-  }
-}
-
-/* On narrow screens (mobile), keep the cluster but pull it inward and shrink it slightly. */
-@media (max-width: 640px) {
-  .writing-tools-cluster {
-    right: 10px;
-    bottom: 16px;
-  }
-  .tool-button {
-    width: 32px;
-    height: 32px;
   }
 }
 </style>

--- a/client/src/pages/Write.vue
+++ b/client/src/pages/Write.vue
@@ -1,61 +1,11 @@
 <template>
-  <div class="zen-editor w-full" :class="{ 'panel-open': assistOpen || metadataPanelOpen }">
-    <!-- Typewriter chrome — purely decorative, evokes the machine without
-         crowding the surface. Top: cylindrical platen bar with end-knobs.
-         Bottom: ribbon strip with a thin accent stripe and ruler ticks.
-         Both sticky to the viewport edges so they always frame the page. -->
-    <div class="zen-platen" aria-hidden="true">
-      <div class="platen-knob platen-knob-left">
-        <div class="platen-knob-grooves"></div>
-      </div>
-      <div class="platen-cylinder"></div>
-      <div class="platen-knob platen-knob-right">
-        <div class="platen-knob-grooves"></div>
-      </div>
-    </div>
-    <div class="zen-ribbon" aria-hidden="true">
-      <div class="zen-ribbon-stripe"></div>
-      <div class="zen-ribbon-ruler"></div>
-    </div>
-
-    <!-- Zen editor surface: just the writing block. No header, no footer, no
-         banners. All controls live in the floating WritingToolsCluster. -->
+  <div class="write-page w-full" :class="{ 'panel-open': assistOpen || metadataPanelOpen }">
+    <!-- Simple authoring surface: title + body, nothing else. The page
+         scrolls naturally; all controls live in the bottom toolbar. -->
     <form @submit.prevent="handleSubmit" class="flex flex-col w-full">
-      <!-- Brightness slider — a near-invisible track in the top line of
-           the writing block. Sun icon thumb. Slides from full dark theme
-           (left) to full light theme (right). Drives JS interpolation of
-           every --color-* variable on documentElement. -->
-      <div class="zen-brightness w-full max-w-[100ch] mx-auto px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 pt-3">
-        <div class="zen-brightness-track">
-          <input
-            ref="brightnessInputRef"
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            v-model.number="brightnessValue"
-            aria-label="Page brightness — dark theme to light theme"
-            :title="`Brightness: ${brightnessValue}%`"
-            class="zen-brightness-slider"
-          />
-          <!-- Sun icon shown adjacent to the thumb. Stays at the right end as
-               a "destination = light" cue regardless of thumb position. -->
-          <span class="zen-brightness-icon" aria-hidden="true">
-            <svg width="14" height="14" viewBox="0 0 20 20" fill="none"
-                 stroke="currentColor" stroke-width="1.4"
-                 stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="10" cy="10" r="3.2" />
-              <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.6 4.6l1.4 1.4M14 14l1.4 1.4M4.6 15.4l1.4-1.4M14 6l1.4-1.4" />
-            </svg>
-          </span>
-        </div>
-      </div>
-
-      <!-- Title — typed onto the page, not a UI label. Same typewriter
-           font as the body, slightly larger, with a faint bottom rule
-           that suggests an underline-stamp from the typewriter itself.
-           Width matches the body so they read as one continuous sheet. -->
-      <div class="zen-title-area w-full max-w-[100ch] mx-auto px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 pt-6 sm:pt-8">
+      <!-- Title — same face as the body, slightly larger, faint rule
+           underneath so it reads as part of the sheet, not a UI label. -->
+      <div class="write-title-area w-full max-w-[72ch] mx-auto px-4 sm:px-6 md:px-8 pt-6 sm:pt-10">
         <input
           id="title"
           ref="titleInputRef"
@@ -63,7 +13,7 @@
           type="text"
           required
           class="block w-full border-0 bg-transparent font-typewriter text-2xl sm:text-3xl font-bold text-ink placeholder:text-ink-whisper focus:ring-0 focus:outline-none py-1"
-          placeholder="Place your title here"
+          placeholder="Title"
           aria-label="Title"
         />
       </div>
@@ -75,16 +25,16 @@
            textarea is hidden but the underlying value is unchanged. -->
       <div
         v-if="isSpaBody"
-        class="zen-spa-banner w-full max-w-[100ch] mx-auto px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 pt-3"
+        class="w-full max-w-[72ch] mx-auto px-4 sm:px-6 md:px-8 pt-3"
       >
-        <div class="zen-spa-banner-pill">
-          <span class="zen-spa-banner-dot" aria-hidden="true"></span>
-          <span class="zen-spa-banner-text">
+        <div class="spa-banner-pill">
+          <span class="spa-banner-dot" aria-hidden="true"></span>
+          <span class="spa-banner-text">
             Interactive HTML detected — this frag will render as a sandboxed SPA when published.
           </span>
           <button
             type="button"
-            class="zen-spa-banner-toggle"
+            class="spa-banner-toggle"
             @click="spaPreviewOpen = !spaPreviewOpen"
           >
             {{ spaPreviewOpen ? 'Edit source' : 'Preview' }}
@@ -92,28 +42,20 @@
         </div>
       </div>
 
-      <!-- Body — the typewriter "paper". This wrapper is the clip viewport
-           (sized in JS to end at the platen line); the textarea inside is
-           translateY-pinned so the caret's line always sits at the platen.
-           Above the caret = the display zone; the caret line = the single
-           input strip; below it is clipped to blank paper. Width matches the
-           title (100ch) so the page reads as one wide sheet. -->
-      <div ref="bodyAreaRef" class="zen-body-area relative w-full max-w-[100ch] mx-auto px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16">
+      <!-- Body — an auto-growing textarea; the page itself is the scroll
+           surface. Bottom padding keeps the last lines clear of the fixed
+           toolbar. Width matches the title so both read as one sheet. -->
+      <div class="relative w-full max-w-[72ch] mx-auto px-4 sm:px-6 md:px-8 pb-36 sm:pb-32">
         <textarea
           id="body"
           ref="bodyTextareaRef"
           v-show="!isSpaBody || !spaPreviewOpen"
           v-model="form.body"
           required
-          class="zen-body zen-body-roll block w-full min-h-[40vh] border-0 bg-transparent font-typewriter text-base sm:text-lg text-ink placeholder:text-ink-whisper focus:ring-0 focus:outline-none resize-none overflow-hidden py-2"
-          :style="[bodyFontStyle, paperTransformStyle]"
-          placeholder="Place your text here"
+          class="write-body block w-full min-h-[50vh] border-0 bg-transparent font-typewriter text-base sm:text-lg text-ink placeholder:text-ink-whisper focus:ring-0 focus:outline-none resize-none overflow-hidden py-2"
+          :style="bodyFontStyle"
+          placeholder="Start writing…"
           aria-label="Body"
-          @input="onBodyInput"
-          @focus="scheduleTypewriterScroll"
-          @click="scheduleTypewriterScroll"
-          @keyup="scheduleTypewriterScroll"
-          @blur="onBodyBlur"
         />
 
         <!-- Live SPA preview — sandboxed iframe of the current body value.
@@ -125,22 +67,20 @@
           :key="spaPreviewKey"
           :srcdoc="form.body"
           title="SPA preview"
-          class="zen-spa-preview"
+          class="spa-preview"
           sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
           referrerpolicy="no-referrer"
           loading="eager"
         />
         <!-- Mirror div: an invisible copy of the textarea content used to
-             measure caret pixel position for typewriter scrolling.
-             CRITICAL: must wrap text at the SAME column as the textarea or
-             the marker's Y won't match the cursor's actual Y. Width is set
-             via matching horizontal padding (parent has px-*; mirror copies
-             it). Font, size, vertical padding and line-height must also
-             match the textarea exactly. -->
+             measure content height for flash-free auto-resize.
+             CRITICAL: must wrap text at the SAME column as the textarea.
+             Width is set via matching horizontal padding (parent has px-*;
+             mirror copies it). Font, size, vertical padding and line-height
+             must also match the textarea exactly. -->
         <div
           ref="bodyMirrorRef"
-          class="zen-body absolute top-0 left-0 right-0 invisible font-typewriter text-base sm:text-lg px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 py-2 whitespace-pre-wrap break-words pointer-events-none"
-          :class="bodyMirrorClasses"
+          class="write-body absolute top-0 left-0 right-0 w-full invisible font-typewriter text-base sm:text-lg px-4 sm:px-6 md:px-8 py-2 whitespace-pre-wrap break-words pointer-events-none"
           :style="bodyFontStyle"
           aria-hidden="true"
         ></div>
@@ -149,7 +89,7 @@
 
     <!-- Metadata panel (cover, themes, visibility) — sits alongside the
          editor when open (no modal backdrop), thanks to the panel-open
-         class on .zen-editor that adds right-padding to the writing area. -->
+         class on .write-page that adds right-padding to the writing area. -->
     <MetadataPanel
       v-model="metadataPanelOpen"
       :form="form"
@@ -200,8 +140,8 @@
       >History</button>
     </div>
 
-    <!-- Floating zen cluster — page actions on top, AI tools below. This is
-         the ONLY persistent UI on the editor surface. Nothing else.  -->
+    <!-- Bottom toolbar — page actions plus a consolidated AI menu. This is
+         the ONLY persistent UI on the editor surface. -->
     <WritingToolsCluster
       :has-selection="hasLiveSelection"
       :active-mode="assistOpen ? assistMode : null"
@@ -209,7 +149,6 @@
       :save-busy="submitting"
       :save-disabled="loadingWriting || !canSave"
       :metadata-open="metadataPanelOpen"
-      :cursor-y="cursorViewportY"
       :model="selectedModel"
       :find-open="findOpen"
       @select="openAssist"
@@ -232,18 +171,17 @@
       @status="onFindStatus"
     />
 
-    <!-- Tiny bottom-left status pill — only visible briefly after save success
-         or while showing an error. Replaces the bulky footer's draft indicator
-         and error banner with something that doesn't permanently take screen real estate. -->
-    <Transition name="zen-status">
+    <!-- Tiny status pill — only visible briefly after save success or while
+         showing an error. Sits above the toolbar so neither covers the other. -->
+    <Transition name="status-pill">
       <div
-        v-if="zenStatus"
-        class="zen-status-pill"
-        :class="zenStatus.kind"
+        v-if="statusPill"
+        class="status-pill"
+        :class="statusPill.kind"
         role="status"
         aria-live="polite"
       >
-        {{ zenStatus.message }}
+        {{ statusPill.message }}
       </div>
     </Transition>
     <WritingAssistPanel
@@ -325,7 +263,6 @@ import FindReplacePanel from '../components/writing/FindReplacePanel.vue'
 import EditorsPanel from '../components/writing/EditorsPanel.vue'
 import RevisionHistoryPanel from '../components/writing/RevisionHistoryPanel.vue'
 import { ApiError } from '../api/client'
-import { useBreathingCaret } from '../composables/useBreathingCaret'
 import { useWritingAssist } from '../composables/useWritingAssist'
 import type { WritingAssistMode } from '@shared/WritingAssist'
 import { isStandaloneHtmlDoc } from '../utils/markdown'
@@ -384,45 +321,12 @@ const findOpen = ref(false)
 const { rules: typographyRules } = useTypographyRules()
 const titleInputRef = ref<HTMLInputElement | null>(null)
 const bodyTextareaRef = ref<HTMLTextAreaElement | null>(null)
+const bodyMirrorRef = ref<HTMLDivElement | null>(null)
 const typographySuggestions = ref<TypographySuggestion[]>([])
 const dismissedSuggestionKeys = ref(new Set<string>())
-// Breathing caret — P2-uix-06 / cni-06
-const { refresh: refreshCaret } = useBreathingCaret(titleInputRef, bodyTextareaRef)
-watch(() => form.value.body, () => nextTick(refreshCaret))
-watch(() => form.value.title, () => nextTick(refreshCaret))
 
 let scanTimer: ReturnType<typeof setTimeout> | null = null
 const SCAN_DEBOUNCE_MS = 1500
-
-// Word count on pause (P3-uix-07 / cni-07): visible only after typing pause, 2 lines below text
-const showWordCount = ref(false)
-const bodyMirrorRef = ref<HTMLDivElement | null>(null)
-const bodyAreaRef = ref<HTMLDivElement | null>(null)
-const wordCountStyle = ref<{ top: string }>({ top: '0.5rem' })
-
-const bodyMirrorClasses = 'w-full'
-
-function updateWordCountPosition() {
-  const mirror = bodyMirrorRef.value
-  if (!mirror) return
-  const computed = getComputedStyle(mirror)
-  const lineHeight = parseFloat(computed.lineHeight) || parseFloat(computed.fontSize) * 1.6
-  const textHeight = mirror.offsetHeight
-  const twoLines = 2 * lineHeight
-  wordCountStyle.value = { top: `${textHeight + twoLines}px` }
-}
-
-watch(showWordCount, (visible) => {
-  if (visible) {
-    nextTick(() => updateWordCountPosition())
-  }
-})
-
-watch(() => form.value.body, () => {
-  if (showWordCount.value) {
-    nextTick(() => updateWordCountPosition())
-  }
-})
 
 function suggestionKey(s: TypographySuggestion): string {
   return `${s.ruleId}:${s.original}`
@@ -469,19 +373,9 @@ function refreshSuggestions() {
 }
 
 watch(() => form.value.body, () => {
-  showWordCount.value = false
   if (scanTimer) clearTimeout(scanTimer)
-  scanTimer = setTimeout(() => {
-    refreshSuggestions()
-    showWordCount.value = true
-  }, SCAN_DEBOUNCE_MS)
+  scanTimer = setTimeout(refreshSuggestions, SCAN_DEBOUNCE_MS)
 })
-
-function onBodyBlur() {
-  if (scanTimer) clearTimeout(scanTimer)
-  refreshSuggestions()
-  showWordCount.value = true
-}
 
 // Draft management
 const draft = useWriteDraft(writingId.value, form)
@@ -497,19 +391,19 @@ const hasUnsavedChanges = computed(() => {
       form.value.coverImagePosition !== initialFormState.value.coverImagePosition) {
     return true
   }
-  
+
   // Check themeIds array efficiently
   const currentThemes = form.value.themeIds
   const initialThemes = initialFormState.value.themeIds
-  
+
   if (currentThemes.length !== initialThemes.length) {
     return true
   }
-  
+
   // Sort and compare element-by-element
   const sortedCurrent = [...currentThemes].sort()
   const sortedInitial = [...initialThemes].sort()
-  
+
   return sortedCurrent.some((id, index) => id !== sortedInitial[index])
 })
 
@@ -570,7 +464,7 @@ const setFormState = (writing: Partial<WritingBlock>) => {
     coverImageUrl: writing.coverImageUrl || '',
     coverImagePosition: writing.coverImagePosition || '50% 50%'
   }
-  
+
   form.value = { ...formState }
   initialFormState.value = { ...formState, themeIds: [...formState.themeIds] }
 }
@@ -684,7 +578,7 @@ const doSubmit = async () => {
 
     draft.clearDraft()
     setFormState(form.value)
-    flashZenStatus('success', isEditing.value ? 'Updated' : 'Published', 1200)
+    flashStatus('success', isEditing.value ? 'Updated' : 'Published', 1200)
     navigateBack()
   } catch (err) {
     if (err instanceof ApiError && err.status === 409) {
@@ -694,12 +588,12 @@ const doSubmit = async () => {
         'cancel to keep them and copy them out manually.)'
       )
       if (reload) await loadWriting()
-      flashZenStatus('error', 'Save blocked: frag was updated by another editor', 4000)
+      flashStatus('error', 'Save blocked: frag was updated by another editor', 4000)
       return
     }
     const msg = err instanceof Error ? err.message : (isEditing.value ? 'Failed to update writing' : 'Failed to publish writing')
     error.value = msg
-    flashZenStatus('error', msg, 4000)
+    flashStatus('error', msg, 4000)
   } finally {
     submitting.value = false
   }
@@ -709,7 +603,7 @@ const handleSubmit = async () => {
   if (!form.value.title.trim() || !form.value.body.trim()) {
     const msg = 'Title and body are required'
     error.value = msg
-    flashZenStatus('error', msg, 2400)
+    flashStatus('error', msg, 2400)
     return
   }
 
@@ -728,11 +622,10 @@ const handleSubmit = async () => {
 /* ============================================================
  * Writing assist — coherence Q&A, define, focus, expand, proofread.
  *
- * Floating bottom-right cluster opens a slide-out right panel. The cluster
- * picks the mode; the panel runs the AI request and emits insert/replace
- * back into the textarea. Selection tracking is the only intrusive bit —
- * it's read-only and runs on the same events the breathing-caret already
- * listens to, so it adds no new event surface.
+ * The toolbar's AI menu picks the mode; the slide-out panel runs the AI
+ * request and emits insert/replace back into the textarea. Selection
+ * tracking is the only intrusive bit — it's read-only and listens to
+ * document selectionchange, so it adds no new event surface.
  * ============================================================ */
 
 const assistOpen = ref(false)
@@ -744,7 +637,7 @@ const assistSelection = ref('')
 // Where the snapshotted selection lives in the textarea, so Replace can
 // substitute exactly the right range (Insert falls back to caret).
 const assistSelectionRange = ref<{ start: number; end: number } | null>(null)
-// Live "is there currently a selection" flag for the cluster's disabled
+// Live "is there currently a selection" flag for the toolbar's disabled
 // state. Updated on selectionchange — cheap, no debounce needed.
 const hasLiveSelection = ref(false)
 
@@ -754,10 +647,10 @@ const hasLiveSelection = ref(false)
 // causes "Expected Boolean, got Object" prop warnings on the panel. So we
 // destructure into top-level locals.
 /* ============================================================
- * Selected OpenAI model — the writer picks from a popover in the cluster.
- * Default 'gpt-4o-mini' (cheapest, matches the server's prior default).
- * Persisted to localStorage so the choice survives page reloads. The
- * server validates against an allow-list before honouring it.
+ * Selected OpenAI model — the writer picks from the AI menu's model
+ * section. Default 'gpt-4o-mini' (cheapest, matches the server's prior
+ * default). Persisted to localStorage so the choice survives page
+ * reloads. The server validates against an allow-list before honouring it.
  * ============================================================ */
 const SELECTED_MODEL_STORAGE_KEY = 'rambulations-selected-model'
 const DEFAULT_MODEL = 'gpt-4o-mini'
@@ -786,8 +679,8 @@ const {
   expand:               runExpand,
   proofread:            runProofread,
   factCheck:            runFactCheck,
-  // Develop quadrant — four sister wrappers, dispatched from the
-  // cluster's Develop sub-menu. Same arg shape as runExpand.
+  // Develop quadrant — four sister wrappers, dispatched from the AI
+  // menu's Develop section. Same arg shape as runExpand.
   fictionBreadth:       runFictionBreadth,
   fictionDepth:         runFictionDepth,
   nonfictionBreadth:    runNonfictionBreadth,
@@ -808,7 +701,7 @@ function captureCurrentSelection(): { text: string; start: number; end: number }
 }
 
 /* ============================================================
- * Zen page actions — Save / Metadata / Exit live in the cluster.
+ * Page actions — Save / Metadata / Exit live in the toolbar.
  * ============================================================ */
 
 /** Disable Save when there's no title or body — prevents empty submissions
@@ -818,17 +711,17 @@ const canSave = computed(() =>
   form.value.title.trim().length > 0 && form.value.body.trim().length > 0
 )
 
-/** Lightweight status pill replacing the old footer's draft / error banners.
- *  Stays minimal, fades after a short timeout, keeps the canvas zen. */
-const zenStatus = ref<{ kind: 'success' | 'error' | 'info'; message: string } | null>(null)
-let zenStatusTimer: ReturnType<typeof setTimeout> | null = null
+/** Lightweight status pill — save receipts, autosave notes, errors.
+ *  Stays minimal, fades after a short timeout. */
+const statusPill = ref<{ kind: 'success' | 'error' | 'info'; message: string } | null>(null)
+let statusPillTimer: ReturnType<typeof setTimeout> | null = null
 
 /* ============================================================
- * Body font size — controlled by the A+ / A- icons in the cluster.
+ * Body font size — controlled by the text-size control in the toolbar.
  * Default is null, meaning "use the CSS default" (text-base sm:text-lg).
  * Once the writer adjusts, we apply a pixel-explicit font-size on both
  * the textarea AND the mirror via :style binding. They MUST stay in
- * sync or line wrapping will diverge and typewriter scroll breaks.
+ * sync or line wrapping will diverge and auto-resize breaks.
  * ============================================================ */
 
 const FONT_SIZE_MIN = 12
@@ -857,14 +750,7 @@ function bumpFontSize(direction: number) {
   // Re-snap textarea height since line-height (unitless 1.85) scales with
   // font-size — the new content height is different. Wait one tick so the
   // style binding has flushed before we measure.
-  nextTick(() => {
-    autoResizeBody()
-    // Line height scales with font size, so the clip viewport and pin offset
-    // both need recomputing.
-    updatePaperClip()
-    scheduleTypewriterScroll()
-    refreshCursorViewportY()
-  })
+  nextTick(autoResizeBody)
 }
 
 /* ============================================================
@@ -916,13 +802,13 @@ async function runAutosaveIfNeeded() {
     // subsequent watcher won't trigger another autosave because each
     // watched getter returns the same primitive value as before.
     setFormState(form.value)
-    flashZenStatus('info', 'Autosaved', 1200)
+    flashStatus('info', 'Autosaved', 1200)
   } catch (err) {
     // Stay quiet on autosave failures — the writer didn't ask for this
     // to happen, so a brief notice is enough; they can manually Save
-    // (cluster Save icon) if they want a guaranteed write.
+    // (toolbar Save button) if they want a guaranteed write.
     const msg = err instanceof Error ? err.message : 'Autosave failed'
-    flashZenStatus('error', `Autosave failed: ${msg}`, 3000)
+    flashStatus('error', `Autosave failed: ${msg}`, 3000)
   } finally {
     submitting.value = false
   }
@@ -945,73 +831,10 @@ watch(
   { deep: true }
 )
 
-/* ============================================================
- * Brightness slider — interpolates between the dark and light theme
- * colors defined in index.css. The slider value (0–100) drives a JS
- * lerp of every --color-* variable, applied as inline styles on
- * document.documentElement (which override :root and .dark definitions).
- *
- * The .dark structural class is also stripped while the slider is in
- * use, so treatments that depend on it (the body gradient, the hidden
- * paper-grain overlay) don't fight the interpolation. They re-engage
- * if the writer drags the slider all the way to 0.
- * ============================================================ */
-
-const brightnessInputRef = ref<HTMLInputElement | null>(null)
-const brightnessValue = ref<number>(100) // 100 = light by default
-
-/** Snapshot of `.dark`-on-`<html>` taken at mount, BEFORE applyBrightness
- *  strips the class. The unmount cleanup uses this to restore the writer
- *  to the same theme state they arrived in. Module-scoped (not a ref)
- *  because no template needs it — it's plumbing for cleanup. */
-let wasDarkOnEntry = false
-
-/** Pairs of (light-mode RGB) and (dark-mode RGB) for every theme token.
- *  Keep these in sync with the values in index.css :root / .dark blocks.
- *  When you change a token's color in index.css, also update its entry
- *  here or the brightness slider will lerp to a stale value. */
-type Rgb = readonly [number, number, number]
-const THEME_PAIRS: { name: string; light: Rgb; dark: Rgb }[] = [
-  { name: '--color-paper',         light: [226, 204, 172], dark: [54,  52,  46] },
-  { name: '--color-surface',       light: [234, 215, 188], dark: [64,  70,  58] },
-  { name: '--color-ink',           light: [37,  37,  32 ], dark: [226, 204, 172] },
-  { name: '--color-ink-light',     light: [30,  46,  28 ], dark: [168, 180, 196] },
-  { name: '--color-ink-lighter',   light: [122, 142, 158], dark: [122, 142, 158] },
-  { name: '--color-ink-whisper',   light: [168, 180, 196], dark: [98,  95,  85 ] },
-  { name: '--color-line',          light: [207, 188, 156], dark: [78,  76,  68 ] },
-  { name: '--color-accent',        light: [255, 128, 24 ], dark: [255, 128, 24 ] },
-  { name: '--color-accent-hover',  light: [230, 100, 10 ], dark: [255, 208, 85 ] },
-  { name: '--color-accent-muted',  light: [248, 230, 200], dark: [70,  52,  36 ] },
-  { name: '--cluster-icon-color',  light: [30,  46,  28 ], dark: [255, 255, 255] },
-]
-
-function applyBrightness(value: number) {
-  const t = Math.max(0, Math.min(100, value)) / 100
-  const root = document.documentElement
-  for (const pair of THEME_PAIRS) {
-    const r = Math.round(pair.dark[0] + (pair.light[0] - pair.dark[0]) * t)
-    const g = Math.round(pair.dark[1] + (pair.light[1] - pair.dark[1]) * t)
-    const b = Math.round(pair.dark[2] + (pair.light[2] - pair.dark[2]) * t)
-    root.style.setProperty(pair.name, `${r} ${g} ${b}`)
-  }
-  // ALWAYS strip .dark — the slider drives all colors via inline vars,
-  // and the structural .dark CSS (body gradient, page-canvas gradient,
-  // hidden paper grain) was fighting those overrides. At slider=0 the
-  // shorthand `background: linear-gradient(...)` in .dark .page-canvas
-  // resets background-color to transparent and depends on the gradient
-  // vars, producing a blank surface. Solid colours via inline vars are
-  // predictable across the entire 0–100 range. The animated dusk-drift
-  // remains available outside slider mode — if the writer hasn't touched
-  // the slider, system-pref / .dark behaviour is unchanged.
-  root.classList.remove('dark')
-}
-
-watch(brightnessValue, (v) => applyBrightness(v))
-
-function flashZenStatus(kind: 'success' | 'error' | 'info', message: string, ms: number = 2400) {
-  zenStatus.value = { kind, message }
-  if (zenStatusTimer) clearTimeout(zenStatusTimer)
-  zenStatusTimer = setTimeout(() => { zenStatus.value = null }, ms)
+function flashStatus(kind: 'success' | 'error' | 'info', message: string, ms: number = 2400) {
+  statusPill.value = { kind, message }
+  if (statusPillTimer) clearTimeout(statusPillTimer)
+  statusPillTimer = setTimeout(() => { statusPill.value = null }, ms)
 }
 
 /** Exit icon — go back to wherever the writer came from, persisting any
@@ -1022,37 +845,26 @@ function handleExit() {
 }
 
 /** The Find & Replace panel emits `update:body` after an in-essay replace.
- *  We treat it like any other body edit so the autosave/draft and word-count
- *  pipelines pick it up. */
+ *  The body watcher picks it up like any other edit — autosave, draft and
+ *  auto-resize all run from there. */
 function onBodyReplaced(next: string) {
   form.value.body = next
-  // Re-run the same plumbing the textarea's @input handler triggers — body
- // mirror, draft autosave, typography scan, etc.
-  onBodyInput()
 }
 
 /** The Find & Replace panel emits status messages (match counts, errors,
- *  replace receipts). Surface them through the same zen status pill that
+ *  replace receipts). Surface them through the same status pill that
  *  save/error states use, so we don't introduce a second toast system. */
 function onFindStatus(status: { kind: 'info' | 'success' | 'error'; message: string }) {
-  flashZenStatus(status.kind, status.message, status.kind === 'error' ? 4000 : 2600)
+  flashStatus(status.kind, status.message, status.kind === 'error' ? 4000 : 2600)
 }
 
 /* ============================================================
  * Auto-resize the body textarea so its height always matches its content.
  *
  * Without this, the textarea's min-h-[Xvh] caps it at a fixed height and
- * any content past that scrolls INSIDE the textarea. That breaks two
- * things at once:
- *   1. The breathing-caret composable hides itself when the cursor's Y
- *      exceeds the textarea's clientHeight (it thinks the cursor has
- *      scrolled out of view).
- *   2. The typewriter window-scroll has nothing to scroll, because the
- *      textarea-internal scroll is what actually moved.
- *
- * Snapping height to scrollHeight every time the value changes makes the
- * textarea grow with content. The page itself becomes the scrollable
- * surface, and both effects work as intended.
+ * any content past that scrolls INSIDE the textarea — a miserable mobile
+ * experience. Snapping height to content height makes the textarea grow
+ * with the text so the page itself is the scrollable surface.
  * ============================================================ */
 
 function autoResizeBody() {
@@ -1068,11 +880,6 @@ function autoResizeBody() {
   // (matching font, padding, width). Reading its offsetHeight gives us the
   // target height in one pass without ever touching the live textarea's
   // dimensions during measurement.
-  //
-  // We sync the mirror's text to the current value here. The typewriter-
-  // scroll function will later overwrite it with a marker injected at the
-  // caret position; both writes are safe because the mirror is invisible
-  // and only used for measurement.
   const trailingNewline = ta.value.endsWith('\n')
   mirror.textContent = (ta.value || ' ') + (trailingNewline ? ' ' : '')
   const target = mirror.offsetHeight
@@ -1087,193 +894,14 @@ function autoResizeBody() {
 // Watch the body for ANY change — typing, load-from-server, draft-restore,
 // AI insert/replace — and snap the textarea height to fit. Runs on the
 // next tick so the textarea has had a chance to flush the new value
-// through the DOM before we read scrollHeight.
-watch(() => form.value.body, () => nextTick(() => {
-  autoResizeBody()
-  // Reposition the paper after programmatic changes (AI insert/replace,
-  // draft restore). No-ops visually when the textarea isn't focused.
-  scheduleTypewriterScroll()
-}))
-
-/* ============================================================
- * Typewriter scrolling — keep the active line at a fixed lower-middle
- * position in the viewport as the writer types or moves the caret. We use
- * the existing bodyMirrorRef to compute caret pixel position by inserting
- * a marker span at selectionStart. Throttled to one call per animation
- * frame. Honors prefers-reduced-motion.
- * ============================================================ */
-
-/**
- * Fraction of the viewport that should remain *below* the active typing
- * line once typewriter-centering has kicked in. 0.20 means the cursor
- * sits at 80% from the top with 20vh of breathing room beneath. Tweak
- * this single constant to move the typewriter line up or down.
- */
-const TYPEWRITER_BOTTOM_PCT = 0.20
-
-/**
- * Cursor's Y position in the viewport, in pixels. Updated whenever we
- * compute the marker's position (typewriter scroll, selection change,
- * window scroll/resize). Null when the textarea is not focused.
- *
- * The floating WritingToolsCluster reads this via :cursor-y prop and
- * tracks it 10px above when the writer toggles to float mode.
- */
-const cursorViewportY = ref<number | null>(null)
-
-/**
- * Vertical offset (px) applied to the body textarea so the caret's line is
- * pinned at the platen position. This is the typewriter mechanic: instead of
- * scrolling the window, we translate the paper. Negative pushes the paper up
- * (older lines roll out the top into the clipped display zone); positive
- * pushes it down (short docs / earlier lines sit at the platen). The body-area
- * is overflow-hidden and clipped at the active line's bottom, so anything
- * below the caret line reads as blank paper.
- */
-const paperOffset = ref(0)
-const paperTransformStyle = computed(() => ({
-  transform: `translateY(${paperOffset.value}px)`,
-}))
-
-let typewriterRaf: number | null = null
-
-function scheduleTypewriterScroll() {
-  if (typewriterRaf !== null) return
-  typewriterRaf = requestAnimationFrame(() => {
-    typewriterRaf = null
-    runTypewriterScroll()
-  })
-}
-
-/**
- * Measure the cursor's viewport Y by injecting a zero-width marker into
- * the mirror at the caret position and reading getBoundingClientRect().top.
- *
- * Returns null if the textarea isn't focused (cursor isn't really
- * "anywhere" in that case) or the refs aren't ready. Side-effect: the
- * mirror's content is replaced with [head, marker, tail]. autoResizeBody
- * also writes to the mirror, but the marker is zero-width so it doesn't
- * meaningfully change mirror.offsetHeight; auto-resize remains accurate.
- */
-function measureCursorViewportY(): number | null {
-  const ta = bodyTextareaRef.value
-  const mirror = bodyMirrorRef.value
-  if (!ta || !mirror) return null
-  if (document.activeElement !== ta) return null
-
-  const value = ta.value
-  const caret = ta.selectionStart ?? value.length
-
-  mirror.textContent = ''
-  mirror.appendChild(document.createTextNode(value.slice(0, caret)))
-  const marker = document.createElement('span')
-  marker.textContent = '​' // zero-width space — keeps line height correct
-  mirror.appendChild(marker)
-  mirror.appendChild(document.createTextNode(value.slice(caret) || ' '))
-
-  return marker.getBoundingClientRect().top
-}
-
-function runTypewriterScroll() {
-  const cursorY = measureCursorViewportY()
-  if (cursorY === null) return
-
-  // Pin the caret's line at the platen by translating the paper, not the
-  // window. measureCursorViewportY reads the marker from the UNtranslated
-  // mirror, so cursorY is the caret's natural viewport Y; the offset needed
-  // to move it onto the platen line is simply (targetY - cursorY). Unlike
-  // the old window-scroll this runs in BOTH directions: typing forward rolls
-  // the paper up, clicking back into an earlier line rolls it down so that
-  // line returns to the platen.
-  const targetY = window.innerHeight * (1 - TYPEWRITER_BOTTOM_PCT)
-  paperOffset.value = targetY - cursorY
-
-  // The caret now visually sits at the platen; tell the floating cluster.
-  cursorViewportY.value = targetY
-}
-
-/**
- * Resolve the body's line height in px (unitless 1.85 × font-size). Falls
- * back to a sane multiple of the font size if the textarea isn't measurable
- * yet. Used to size the clip viewport so its bottom edge lands at the bottom
- * of the active (platen) line.
- */
-function currentBodyLineHeight(): number {
-  const ta = bodyTextareaRef.value
-  if (!ta) return 30
-  const cs = getComputedStyle(ta)
-  const lh = parseFloat(cs.lineHeight)
-  if (!Number.isNaN(lh) && lh > 0) return lh
-  const fs = parseFloat(cs.fontSize) || 16
-  return fs * 1.85
-}
-
-/**
- * Size the body-area so it becomes the "paper viewport": its top stays where
- * the body begins (just under the title), and its bottom is clipped at the
- * bottom of the active line — the platen position (80vh) plus one line. With
- * overflow:hidden, this clips everything below the caret line to blank paper
- * and everything that rolls above the title, leaving only the display zone
- * (above) and the single active line (the input strip) visible.
- */
-function updatePaperClip() {
-  const area = bodyAreaRef.value
-  if (!area) return
-  // SPA preview replaces the textarea with a full-height iframe — the
-  // typewriter clip would crop it. Let the area size to its content instead.
-  if (isSpaBody.value && spaPreviewOpen.value) {
-    area.style.height = ''
-    return
-  }
-  const top = area.getBoundingClientRect().top
-  const activeLineBottom =
-    window.innerHeight * (1 - TYPEWRITER_BOTTOM_PCT) + currentBodyLineHeight()
-  area.style.height = `${Math.max(0, activeLineBottom - top)}px`
-}
-
-// Layout-affecting state: opening a side panel re-pads the editor (changing
-// the body's top and wrap width) and the SPA banner shifts the body down.
-// Recompute the clip and re-pin both immediately and after the 240ms panel
-// transition settles.
-watch(
-  [() => assistOpen.value, () => metadataPanelOpen.value, () => isSpaBody.value, () => spaPreviewOpen.value],
-  () => {
-    nextTick(() => {
-      updatePaperClip()
-      scheduleTypewriterScroll()
-    })
-    window.setTimeout(() => {
-      updatePaperClip()
-      scheduleTypewriterScroll()
-    }, 260)
-  },
-)
-
-/**
- * Lightweight cursor-Y updater that does NOT scroll the page. Called on
- * selection change, window scroll, and window resize so the floating
- * cluster keeps tracking even when the writer isn't typing.
- */
-function refreshCursorViewportY() {
-  const y = measureCursorViewportY()
-  // null is meaningful — it means the cursor isn't in the textarea.
-  // Pass it through so the cluster falls back to its fixed corner.
-  cursorViewportY.value = y
-}
-
-/** Combined input handler — schedule the typewriter window-scroll. The
- *  watcher on form.value.body handles auto-resize; the typography-scan
- *  watch handles typography suggestions. So this only needs to drive the
- *  per-keystroke window-scroll. */
-function onBodyInput() {
-  scheduleTypewriterScroll()
-}
+// through the DOM before we measure.
+watch(() => form.value.body, () => nextTick(autoResizeBody))
 
 function onSelectionMaybeChanged() {
   const ta = bodyTextareaRef.value
   if (!ta || document.activeElement !== ta) {
     // Don't flip on/off when the user moves focus to the panel — keep the
-    // last known selection state instead, so the cluster doesn't disable
+    // last known selection state instead, so the toolbar doesn't disable
     // mid-flow.
     return
   }
@@ -1429,28 +1057,8 @@ function handleReplaceSelection(text: string) {
 
 // selectionchange is the cleanest signal for "the selection in any input
 // has changed". Fires for both keyboard (shift+arrow) and mouse drag.
-// Also refreshes the cursor's viewport Y so the floating cluster tracks
-// arrow-key navigation, not just typing.
 function onDocumentSelectionChange() {
   onSelectionMaybeChanged()
-  refreshCursorViewportY()
-}
-
-/** Window scroll / resize — the cursor's viewport Y changes even when the
- *  writer isn't doing anything (page scrolling, window resize). The
- *  floating cluster needs to follow. Throttled to one rAF to avoid spam. */
-let cursorYRaf: number | null = null
-function onWindowScrollOrResize() {
-  if (cursorYRaf !== null) return
-  cursorYRaf = requestAnimationFrame(() => {
-    cursorYRaf = null
-    // Viewport size feeds both the clip height and the platen target, so
-    // recompute the clip and re-pin the active line before refreshing the
-    // cluster's tracked cursor Y.
-    updatePaperClip()
-    runTypewriterScroll()
-    refreshCursorViewportY()
-  })
 }
 
 // Persist draft to localStorage before leaving (no confirmation dialog)
@@ -1501,472 +1109,65 @@ onMounted(async () => {
   // was set before the textarea was in the DOM).
   await nextTick()
   autoResizeBody()
-  // Establish the paper viewport's clip height now that the body is laid out.
-  updatePaperClip()
-
-  // Initialize brightness from the current document state. If the writer
-  // arrived in dark mode (.dark class set by useTheme), the slider starts
-  // at 0 (full dark). Otherwise 100 (full light). This is purely visual
-  // initialization — the slider takes over from here.
-  //
-  // We snapshot the original .dark state BEFORE applyBrightness strips
-  // it, so onBeforeUnmount can restore it. Without this, navigating
-  // away leaves the inline CSS vars on <html> and the .dark class
-  // stripped, which breaks the rest of the app: any later toggle of
-  // dark mode pairs the structural .dark gradient with light-valued
-  // inline CSS vars, producing dark text on a dark gradient → blank
-  // pages site-wide. See also: cleanup block in onBeforeUnmount.
-  wasDarkOnEntry = document.documentElement.classList.contains('dark')
-  brightnessValue.value = wasDarkOnEntry ? 0 : 100
 
   // Add beforeunload event listener
   window.addEventListener('beforeunload', handleBeforeUnload)
-  // selectionchange tells the writing-tools cluster whether to enable
-  // selection-only tools like Focus. It fires from both keyboard and mouse.
+  // selectionchange tells the toolbar whether to enable selection-only
+  // tools like Focus. It fires from both keyboard and mouse.
   document.addEventListener('selectionchange', onDocumentSelectionChange)
-  // Page scroll + viewport resize change the cursor's viewport Y even
-  // without typing — the floating cluster must follow.
-  window.addEventListener('scroll', onWindowScrollOrResize, { passive: true })
-  window.addEventListener('resize', onWindowScrollOrResize)
 })
 
 onBeforeUnmount(() => {
   if (scanTimer) clearTimeout(scanTimer)
-  if (zenStatusTimer) clearTimeout(zenStatusTimer)
+  if (statusPillTimer) clearTimeout(statusPillTimer)
   if (autosaveTimer) clearTimeout(autosaveTimer)
-  if (typewriterRaf !== null) cancelAnimationFrame(typewriterRaf)
-  if (cursorYRaf !== null) cancelAnimationFrame(cursorYRaf)
   draft.disableAutosave()
   window.removeEventListener('beforeunload', handleBeforeUnload)
   document.removeEventListener('selectionchange', onDocumentSelectionChange)
-  window.removeEventListener('scroll', onWindowScrollOrResize)
-  window.removeEventListener('resize', onWindowScrollOrResize)
-
-  /* ---- Brightness cleanup ----
-   *
-   * The slider sets inline CSS vars on document.documentElement and
-   * strips the .dark class. Both effects must be undone when the
-   * writer leaves /write — otherwise the rest of the app inherits the
-   * inline overrides. The classic symptom: user visits /write, hits
-   * dark mode somewhere else later, and content becomes invisible
-   * because dark-mode structural CSS (the .page-canvas gradient)
-   * pairs with light-valued inline vars (--color-ink stuck at 37 37
-   * 32) producing dark text on a dark gradient.
-   *
-   * Strategy: remove every theme-pair var we set, then restore the
-   * .dark class to whatever it was on entry so useTheme stays in
-   * sync.
-   */
-  const rootStyle = document.documentElement.style
-  for (const pair of THEME_PAIRS) {
-    rootStyle.removeProperty(pair.name)
-  }
-  document.documentElement.classList.toggle('dark', wasDarkOnEntry)
 })
 
 </script>
 
 <style scoped>
-/* Paper viewport — the body-area is the clipping window for the typewriter.
-   Its height is set in JS (updatePaperClip) so the bottom edge lands at the
-   active line (the platen, 80vh). overflow:hidden then clips everything below
-   the caret line to blank "paper" and everything that rolls above the title,
-   leaving the display zone (above) and the single active input line visible.
-   The body itself is translateY-pinned (zen-body-roll) rather than scrolled. */
-.zen-body-area {
-  overflow: hidden;
-}
-
 /* Side-by-side panel layout — when AssistPanel or MetadataPanel is open,
    the editor reserves a right-side gutter the width of the panel. The
    title + body have max-width + mx-auto, so this gutter shifts the
-   centered content leftward without breaking line-length. The platen
-   and ribbon stay viewport-wide; the panel sits opaque on top of them
-   on the right. */
-.zen-editor.panel-open {
+   centered content leftward without breaking line-length. */
+.write-page.panel-open {
   padding-right: 420px;
   transition: padding-right 240ms cubic-bezier(0.25, 0.1, 0.25, 1);
 }
-.zen-editor {
+.write-page {
   transition: padding-right 240ms cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 @media (prefers-reduced-motion: reduce) {
-  .zen-editor,
-  .zen-editor.panel-open {
+  .write-page,
+  .write-page.panel-open {
     transition: none;
   }
 }
 @media (max-width: 768px) {
   /* On narrow viewports, panel takes full width; no point shifting the
      editor — it'd just be hidden anyway. */
-  .zen-editor.panel-open {
+  .write-page.panel-open {
     padding-right: 0;
   }
 }
 
-/* ============================================================
- * Brightness slider — sits in the top line of the writing block.
- * Track is a near-invisible 1px line in the line color; thumb is a
- * 20px sun icon in the accent color. The native range input is
- * styled to be effectively invisible aside from the thumb area.
- * ============================================================ */
-.zen-brightness {
-  pointer-events: none; /* container — events only on the track */
-}
-.zen-brightness-track {
-  position: relative;
-  height: 22px;
-  display: flex;
-  align-items: center;
-  pointer-events: auto;
-}
-.zen-brightness-slider {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 100%;
-  height: 22px;
-  background: transparent;
-  cursor: pointer;
-  outline: none;
-  /* Track styled via ::-webkit-slider-runnable-track and ::-moz-range-track
-     below. The wrapper element is just for layout. */
-}
-.zen-brightness-slider::-webkit-slider-runnable-track {
-  height: 1px;
-  background: rgb(var(--color-line) / 0.5);
-  border-radius: 1px;
-}
-.zen-brightness-slider::-moz-range-track {
-  height: 1px;
-  background: rgb(var(--color-line) / 0.5);
-  border-radius: 1px;
-}
-.zen-brightness-slider::-webkit-slider-thumb {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: rgb(var(--color-paper));
-  border: 1.5px solid rgb(var(--color-accent));
-  margin-top: -9px; /* center on 1px track */
-  cursor: grab;
-  transition: transform 120ms ease-out, background-color 120ms ease-out;
-}
-.zen-brightness-slider::-webkit-slider-thumb:hover,
-.zen-brightness-slider:focus::-webkit-slider-thumb {
-  transform: scale(1.12);
-  background: rgb(var(--color-accent-muted));
-}
-.zen-brightness-slider:active::-webkit-slider-thumb {
-  cursor: grabbing;
-}
-.zen-brightness-slider::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: rgb(var(--color-paper));
-  border: 1.5px solid rgb(var(--color-accent));
-  cursor: grab;
-}
-.zen-brightness-slider:focus-visible {
-  outline: none;
-}
-.zen-brightness-icon {
-  position: absolute;
-  right: -2px; /* float just past the right edge of the track */
-  top: 50%;
-  transform: translateY(-50%);
-  color: rgb(var(--color-accent));
-  pointer-events: none;
-  display: inline-flex;
-}
-
-/* Title — typed onto the page. Subtle underline-rule directly beneath the
-   text mimics the underscore-stamp many typewriter pages have under their
-   heading. Letter-spacing nudged up slightly to read as machine-typed. */
-.zen-title-area input {
+/* Title — faint rule beneath so it reads as a heading on the sheet,
+   not a form field. */
+.write-title-area input {
   letter-spacing: 0.01em;
   border-bottom: 1px solid rgb(var(--color-line));
   padding-bottom: 6px;
   margin-bottom: 8px;
 }
 
-/* Body — typewriter cadence. Slightly looser line-height than default
-   monospace gives the lines air to breathe (real typewriter copy lives at
-   ~1.8). Letter-spacing kept neutral — Courier Prime's metrics already
-   read as machine-spaced; pushing further makes it look stretched. The
-   class is applied to BOTH the textarea and the mirror so wrap behavior
-   stays identical. */
-.zen-body {
+/* Body — comfortable long-form line-height. The class is applied to BOTH
+   the textarea and the mirror so wrap behavior stays identical. */
+.write-body {
   line-height: 1.85;
   letter-spacing: 0.005em;
-}
-
-/* Typewriter roll — the body is translateY-pinned so the active line stays at
-   the platen. Within a line the offset is constant (caret moves horizontally,
-   no vertical jump); on Enter or a margin wrap the offset steps by one line,
-   and this transition animates the paper rolling up by exactly that line. */
-.zen-body-roll {
-  transition: transform 130ms cubic-bezier(0.22, 0.61, 0.36, 1);
-  will-change: transform;
-}
-@media (prefers-reduced-motion: reduce) {
-  .zen-body-roll {
-    transition: none;
-  }
-}
-
-/* ============================================================
- * Paper feel — bumped up.
- *
- * Two layered effects on .zen-editor::before give the writing surface
- * tactile depth without touching the writing area itself:
- *
- *   1. A fine SVG noise layer simulating paper fiber. Inline data-uri
- *      so no asset request, ~1.5KB. At ~6% opacity it's barely
- *      perceptible up close but reads instantly as "paper, not screen".
- *
- *   2. A stronger radial vignette than before — corners darkened to
- *      ~9% ink so the page feels like an actual sheet with edges,
- *      not an infinite plain.
- *
- * Both skipped in dark mode where .page-canvas's moving charcoal
- * gradient handles atmosphere.
- * ============================================================ */
-.zen-editor::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background-color: transparent;
-  background-image:
-    /* Vignette */
-    radial-gradient(
-      ellipse at center,
-      transparent 0%,
-      transparent 45%,
-      rgb(var(--color-ink) / 0.09) 100%
-    ),
-    /* Paper grain */
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.06 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-  background-size: cover, 240px 240px;
-  background-repeat: no-repeat, repeat;
-}
-:global(.dark) .zen-editor::before {
-  display: none;
-}
-
-/* ============================================================
- * Typewriter chrome — platen at top, ribbon at bottom.
- *
- * Pure CSS, no images. Subtle dark fixtures that read as a real
- * machine framing the page without dominating the writing area.
- * Both sit BEHIND the floating cluster (z-index 40) but above the
- * paper background.
- * ============================================================ */
-
-/* ----- PLATEN — sits just above the strike line ------
- *
- * The platen and the ribbon together form a compact mechanism around the
- * line being typed. The platen's BOTTOM edge sits ~4px above the cursor
- * position (80vh from top), and the ribbon's TOP edge sits ~36px below
- * the cursor — the gap is one line of body text, so only the active
- * line is framed inside the mechanism. Above the platen: previously-
- * typed paper. Below the ribbon: breathing-room paper.
- *
- * Both pieces are keyed to TYPEWRITER_BOTTOM_PCT = 0.20 in the script.
- * If you change that constant, update the `top` values in both .zen-platen
- * and .zen-ribbon to keep the chrome aligned with the cursor.
- * ---------------------------------------------------------- */
-.zen-platen {
-  position: fixed;
-  /* 80vh − (platen height) − 4px gap above the cursor */
-  top: calc(80vh - 48px);
-  left: 0;
-  right: 0;
-  height: 44px;
-  z-index: 5;
-  pointer-events: none;
-  display: flex;
-  align-items: stretch;
-}
-
-.platen-cylinder {
-  flex: 1;
-  position: relative;
-  background:
-    /* Highlight strip near the top — a wet sheen along the platen. */
-    linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.05) 0%,
-      transparent 30%
-    ),
-    /* Body of the cylinder — dark with a subtle highlight at upper third
-       to fake the cylindrical curve. */
-    linear-gradient(
-      to bottom,
-      rgb(38, 36, 32) 0%,
-      rgb(28, 26, 22) 35%,
-      rgb(20, 18, 16) 65%,
-      rgb(40, 38, 33) 100%
-    );
-  border-bottom-left-radius: 28px;
-  border-bottom-right-radius: 28px;
-  box-shadow:
-    inset 0 -2px 4px rgba(255, 255, 255, 0.05),
-    inset 0 2px 6px rgba(0, 0, 0, 0.4),
-    0 6px 14px rgba(0, 0, 0, 0.18);
-}
-
-/* The paper edge peeking out from under the cylinder — a thin cream
-   line right at the bottom curve, suggesting the sheet emerges here. */
-.platen-cylinder::after {
-  content: '';
-  position: absolute;
-  left: 18%;
-  right: 18%;
-  bottom: -3px;
-  height: 6px;
-  background-color: rgb(var(--color-paper));
-  border-bottom-left-radius: 6px;
-  border-bottom-right-radius: 6px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
-  z-index: -1;
-}
-
-/* End knobs on either side of the cylinder — circular, slightly larger
-   than the cylinder's height, with grooves suggesting a turning grip.
-   Sized to match the compacted 44px platen. */
-.platen-knob {
-  position: relative;
-  width: 52px;
-  flex-shrink: 0;
-  background:
-    radial-gradient(
-      circle at 35% 30%,
-      rgb(80, 76, 68) 0%,
-      rgb(45, 42, 36) 45%,
-      rgb(20, 18, 16) 100%
-    );
-  border-radius: 50%;
-  align-self: center;
-  height: 52px;
-  /* Stick up slightly above the cylinder so the knob crowns are visible. */
-  margin-top: -4px;
-  box-shadow:
-    inset -2px -2px 4px rgba(0, 0, 0, 0.5),
-    inset 2px 2px 4px rgba(255, 255, 255, 0.05),
-    0 4px 10px rgba(0, 0, 0, 0.25);
-}
-.platen-knob-left  { margin-left: -12px; }
-.platen-knob-right { margin-right: -12px; }
-
-/* Grooves — concentric ring suggesting the textured grip on a real
-   typewriter platen knob. */
-.platen-knob-grooves {
-  position: absolute;
-  inset: 12px;
-  border-radius: 50%;
-  border: 1px solid rgba(0, 0, 0, 0.4);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
-    inset 0 0 0 8px rgba(0, 0, 0, 0.0),
-    inset 0 0 0 9px rgba(0, 0, 0, 0.25);
-}
-
-/* ----- RIBBON / RULER — sits just below the strike line ------
- * Pairs with .zen-platen above. The gap between platen-bottom and
- * ribbon-top equals one line of body text, so only the active line
- * being typed is visible inside the mechanism. Below the ribbon: paper
- * extends to viewport bottom as breathing room and as "the page being
- * fed into the machine".
- * ---------------------------------------------------------- */
-.zen-ribbon {
-  position: fixed;
-  left: 0;
-  right: 0;
-  /* 80vh + line-height gap. ~36px clears one line of text-base/text-lg
-     at line-height 1.85 plus a touch of margin on either side. */
-  top: calc(80vh + 36px);
-  height: 26px;
-  z-index: 5;
-  pointer-events: none;
-  display: flex;
-  flex-direction: column;
-}
-
-/* The ribbon stripe — a thin band in the accent color along the top
-   edge, like an inked typewriter ribbon. Subtle so it doesn't shout. */
-.zen-ribbon-stripe {
-  height: 4px;
-  background:
-    linear-gradient(
-      to bottom,
-      rgb(var(--color-accent) / 0.55) 0%,
-      rgb(var(--color-accent) / 0.85) 50%,
-      rgb(var(--color-accent) / 0.4) 100%
-    );
-  box-shadow: 0 0 6px rgb(var(--color-accent) / 0.25);
-}
-
-/* The ruler bar — dark strip with evenly-spaced tick marks rendered as a
-   repeating linear gradient. The ticks are at every ~20px to suggest the
-   measurement scale visible in the reference image. */
-.zen-ribbon-ruler {
-  flex: 1;
-  background:
-    /* Tick marks — repeating darker stripe every 20px */
-    repeating-linear-gradient(
-      to right,
-      rgba(0, 0, 0, 0.0) 0px,
-      rgba(0, 0, 0, 0.0) 18px,
-      rgba(255, 255, 255, 0.12) 18px,
-      rgba(255, 255, 255, 0.12) 19px,
-      rgba(0, 0, 0, 0.0) 19px,
-      rgba(0, 0, 0, 0.0) 20px
-    ),
-    /* Body */
-    linear-gradient(
-      to bottom,
-      rgb(28, 26, 22) 0%,
-      rgb(20, 18, 16) 100%
-    );
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
-}
-
-/* ----- Smooth height transitions to mask the auto-resize ----- */
-/* The textarea snaps to its new height on auto-resize. A short transition
-   reads it as smooth growth instead of a hard step. Honors reduced-motion. */
-.zen-body {
-  transition: height 80ms ease-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .zen-body {
-    transition: none;
-  }
-}
-
-/* ----- Responsive: shrink mechanism on narrow viewports ----- */
-@media (max-width: 640px) {
-  .zen-platen {
-    /* Same strike-line offset, just shorter platen. */
-    height: 36px;
-    top: calc(80vh - 40px);
-  }
-  .platen-knob {
-    width: 42px;
-    height: 42px;
-    margin-top: -3px;
-  }
-  .platen-knob-left  { margin-left: -10px; }
-  .platen-knob-right { margin-right: -10px; }
-  .zen-ribbon {
-    height: 20px;
-    /* Slightly tighter line-height at smaller text size. */
-    top: calc(80vh + 30px);
-  }
 }
 
 /* ============================================================
@@ -1977,11 +1178,7 @@ onBeforeUnmount(() => {
  * iframe replaces the textarea visually but the textarea remains in the
  * DOM (just v-show'd off) so all the keyboard / draft state is intact.
  * ============================================================ */
-.zen-spa-banner {
-  pointer-events: none;
-}
-.zen-spa-banner-pill {
-  pointer-events: auto;
+.spa-banner-pill {
   display: inline-flex;
   align-items: center;
   gap: 10px;
@@ -1995,19 +1192,19 @@ onBeforeUnmount(() => {
   color: rgb(var(--color-ink-light));
   max-width: 100%;
 }
-.zen-spa-banner-dot {
+.spa-banner-dot {
   width: 7px;
   height: 7px;
   border-radius: 50%;
   background: rgb(var(--color-accent));
   flex-shrink: 0;
 }
-.zen-spa-banner-text {
+.spa-banner-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.zen-spa-banner-toggle {
+.spa-banner-toggle {
   flex-shrink: 0;
   margin-left: 4px;
   padding: 2px 8px;
@@ -2021,18 +1218,18 @@ onBeforeUnmount(() => {
   cursor: pointer;
   transition: background-color 120ms ease-out, color 120ms ease-out;
 }
-.zen-spa-banner-toggle:hover {
+.spa-banner-toggle:hover {
   background: rgb(var(--color-accent));
   color: rgb(var(--color-paper));
   border-color: rgb(var(--color-accent));
 }
 @media (max-width: 640px) {
-  .zen-spa-banner-text {
+  .spa-banner-text {
     white-space: normal;
   }
 }
 
-.zen-spa-preview {
+.spa-preview {
   display: block;
   width: 100%;
   height: 80vh;
@@ -2044,12 +1241,13 @@ onBeforeUnmount(() => {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
-/* Tiny status pill — bottom-left, fades in/out, stays out of the way. */
-.zen-status-pill {
+/* Tiny status pill — bottom-left, above the toolbar, fades in/out. */
+.status-pill {
   position: fixed;
-  left: 18px;
-  bottom: 28px;
-  z-index: 30;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+  z-index: 45;
   font-family: 'Inter', sans-serif;
   font-size: 12px;
   letter-spacing: 0.02em;
@@ -2059,41 +1257,35 @@ onBeforeUnmount(() => {
   border: 1px solid rgb(var(--color-line));
   color: rgb(var(--color-ink-light));
   pointer-events: none;
+  box-shadow: 0 2px 8px rgb(var(--color-ink) / 0.08);
 }
-.zen-status-pill.success {
+.status-pill.success {
   border-color: rgb(var(--color-accent));
   color: rgb(var(--color-accent));
 }
-.zen-status-pill.error {
+.status-pill.error {
   border-color: rgb(var(--color-highlight));
   color: rgb(var(--color-highlight));
 }
 
-.zen-status-enter-active,
-.zen-status-leave-active {
+.status-pill-enter-active,
+.status-pill-leave-active {
   transition: opacity 220ms ease-out, transform 220ms ease-out;
 }
-.zen-status-enter-from,
-.zen-status-leave-to {
+.status-pill-enter-from,
+.status-pill-leave-to {
   opacity: 0;
-  transform: translateY(6px);
+  transform: translateX(-50%) translateY(6px);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .zen-status-enter-active,
-  .zen-status-leave-active {
+  .status-pill-enter-active,
+  .status-pill-leave-active {
     transition: none;
   }
-  .zen-status-enter-from,
-  .zen-status-leave-to {
-    transform: none;
-  }
-}
-
-@media (max-width: 640px) {
-  .zen-status-pill {
-    left: 10px;
-    bottom: 16px;
+  .status-pill-enter-from,
+  .status-pill-leave-to {
+    transform: translateX(-50%);
   }
 }
 </style>


### PR DESCRIPTION
## What changed

**`client/src/pages/Write.vue`** — the classic typewriter UI is completely removed:
- Platen/ribbon chrome, the paper-roll transform scrolling (caret pinned to a strike line via a clipped viewport), the paper-grain/vignette overlay, the brightness slider (and its dark-class strip/restore logic), the breathing caret, and dead word-count plumbing are all gone.
- The editor is now a plain, low-cognitive-load surface: title input + auto-growing textarea at a 72ch measure, natural page scrolling, bottom padding to clear the fixed toolbar.

**`client/src/components/writing/WritingToolsCluster.vue`** — rebuilt as a mobile-first toolbar:
- Full-width bottom bar on mobile (safe-area aware, 48px+ touch targets, always-visible captions); centered floating pill on desktop.
- Six top-level actions: Publish/Update, AI, Find, Details, Text size, Exit.
- All AI options are consolidated into a single **AI submenu** — the six assist tools (Focus disabled without a selection), the four Develop modes grouped fiction/non-fiction, and the model picker — in one scrollable sheet (bottom sheet on mobile, anchored popover on desktop).
- The drag/rotate/float/lock machinery and the `cursor-y` tracking prop are removed.

## Why

The typewriter experience carried heavy per-keystroke measurement work and high novelty/cognitive load, and never worked well on mobile. This replaces it with a simple authoring flow that works on both form factors, per product direction.

## Preserved behaviour

Drafts + recovery modal, idle server autosave, optimistic-lock 409 merge prompt, standalone-HTML SPA detection/preview, find & replace, metadata/editors/history panels, font-size stepping, and the mirror-based flash-free textarea auto-resize. Component props/events are unchanged apart from dropping `cursor-y`, so no other callers needed changes.

## Notes for review

- `vue-tsc --noEmit` passes clean.
- Verified in the browser (desktop 1280px and 375px mobile viewports): typing/auto-grow, AI sheet on both form factors, font bump with height re-snap, assist panel opening, no new console errors.
- Follow-up (separate task): delete the now-unused `useBreathingCaret.ts` composable and update help pages that still describe the old typewriter UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)